### PR TITLE
Added possibility to print what is in the state vector (true by default)

### DIFF
--- a/include/tudat/simulation/propagation_setup/dynamicsSimulator.h
+++ b/include/tudat/simulation/propagation_setup/dynamicsSimulator.h
@@ -225,6 +225,46 @@ Eigen::Matrix< StateScalarType, Eigen::Dynamic, 1 > getInitialArcWiseStateOfBody
     return initialStates;
 }
 
+
+//! Function to print what is inside the propagated state vector
+template< typename StateScalarType = double >
+void printPropagatedStateVectorContent (const std::map< IntegratedStateType, std::vector< std::pair< std::string, std::string > > > integratedTypeAndBodyList)
+{
+    std::cout << "State vector contains: " << std::endl
+              << "Vector entries, Vector contents" << std::endl;
+
+    unsigned int stateVectorIndex = 0;
+    std::vector<std::string> stateTypeStrings {"hybrid", "translational", "rotational", "body mass", "custom"};
+    
+    // Loop trough propagated state types and body names
+    for (std::pair<IntegratedStateType, std::vector< std::pair< std::string, std::string > >> integratedTypeAndBody : integratedTypeAndBodyList)
+    {
+        // Extract state type and list of body names
+        IntegratedStateType stateType = integratedTypeAndBody.first;
+        std::vector< std::pair< std::string, std::string > > bodyList = integratedTypeAndBody.second;
+
+        int stateSize = getSingleIntegrationSize(stateType);
+
+        // Loop trough list of body names
+        for(unsigned int i = 0; i < bodyList.size (); i++)
+        {
+            // Print index at which given state type of body can be accessed
+            if (stateSize == 1) {
+                std::cout << "[" << stateVectorIndex << "], ";
+            }
+            else {
+                std::cout << "[" << stateVectorIndex << ":" << stateVectorIndex+stateSize << "], ";
+            }
+
+            // Print state type and body name (note: hybrid state type should never be printed, taken care of by `getIntegratedTypeAndBodyList()` function)
+            std::cout << stateTypeStrings[stateType] << " state of body " << bodyList[i].first << std::endl; 
+            
+            // Remember where we are at trough the state vector
+            stateVectorIndex += stateSize;
+        }
+    }
+}
+
 //! Base class for performing full numerical integration of a dynamical system.
 /*!
  *  Base class for performing full numerical integration of a dynamical system. Governing equations are set once,
@@ -465,40 +505,7 @@ public:
 
         if( printStateData_ )
         {
-            std::cout << "State vector contains: " << std::endl
-                      << "Vector entries, Vector contents" << std::endl;
-
-            unsigned int stateVectorIndex = 0;
-            std::map< IntegratedStateType, std::vector< std::pair< std::string, std::string > > > integratedTypeAndBodyList = getIntegratedTypeAndBodyList(propagatorSettings_);
-            std::vector<std::string> stateTypeStrings {"hybrid", "translational", "rotational", "body mass", "custom"};
-            
-            // Loop trough propagated state types and body names
-            for (std::pair<IntegratedStateType, std::vector< std::pair< std::string, std::string > >> integratedTypeAndBody : integratedTypeAndBodyList)
-            {
-                // Extract state type and list of body names
-                IntegratedStateType stateType = integratedTypeAndBody.first;
-                std::vector< std::pair< std::string, std::string > > bodyList = integratedTypeAndBody.second;
-
-                int stateSize = getSingleIntegrationSize(stateType);
-
-                // Loop trough list of body names
-                for(unsigned int i = 0; i < bodyList.size (); i++)
-                {
-                    // Print index at which given state type of body can be accessed
-                    if (stateSize == 1) {
-                        std::cout << "[" << stateVectorIndex << "], ";
-                    }
-                    else {
-                        std::cout << "[" << stateVectorIndex << ":" << stateVectorIndex+stateSize << "], ";
-                    }
-
-                    // Print state type and body name (note: hybrid state type should never be printed, taken care of by `getIntegratedTypeAndBodyList()` function)
-                    std::cout << stateTypeStrings[stateType] << " state of body " << bodyList[i].first << std::endl; 
-                    
-                    // Remember where we are at trough the state vector
-                    stateVectorIndex += stateSize;
-                }
-            }
+            printPropagatedStateVectorContent(getIntegratedTypeAndBodyList(propagatorSettings_));
         }
 
         if( propagatorSettings_->getDependentVariablesToSave( ) != nullptr )

--- a/include/tudat/simulation/propagation_setup/dynamicsSimulator.h
+++ b/include/tudat/simulation/propagation_setup/dynamicsSimulator.h
@@ -398,8 +398,8 @@ public:
             const bool setIntegratedResult = false,
             const bool printNumberOfFunctionEvaluations = false,
             const std::chrono::steady_clock::time_point initialClockTime = std::chrono::steady_clock::now( ),
-            const bool printStateData = true,
-            const bool printDependentVariableData = true ):
+            const bool printDependentVariableData = true,
+            const bool printStateData = true ):
         DynamicsSimulator< StateScalarType, TimeType >(
             bodies, clearNumericalSolutions, setIntegratedResult ),
         integratorSettings_( integratorSettings ),
@@ -544,8 +544,8 @@ public:
             const bool clearNumericalSolutions = false,
             const bool setIntegratedResult = false,
             const bool printNumberOfFunctionEvaluations = false,
-            const bool printStateData = true,
-            const bool printDependentVariableData = true ):
+            const bool printDependentVariableData = true,
+            const bool printStateData = true ):
         SingleArcDynamicsSimulator(  bodies, integratorSettings,  propagatorSettings,
                                      std::vector< std::shared_ptr< SingleStateTypeDerivative< StateScalarType, TimeType > > >( ),
                                      areEquationsOfMotionToBeIntegrated,
@@ -553,8 +553,8 @@ public:
                                      setIntegratedResult,
                                      printNumberOfFunctionEvaluations,
                                      std::chrono::steady_clock::now( ),
-                                     printStateData,
-                                     printDependentVariableData ){ }
+                                     printDependentVariableData,
+                                     printStateData ){ }
 
     //! Destructor
     ~SingleArcDynamicsSimulator( ) { }


### PR DESCRIPTION
A new argument is added to the `SingleArcSimulator`, named `printStateData`. By default set to True, this argument control whether to prints or not the propagated state data.

This print takes the form of the following:
````
State vector contains:
Vector entries, Vector contents
[0:6], translational state of body Lunar CubeSat A
[6:12], translational state of body Lunar CubeSat B
[12], body mass state of body Lunar CubeSat A
[13], body mass state of body Lunar CubeSat B
````