### PR TITLE
Improved dependent variable access

### DIFF
--- a/include/tudat/simulation/estimation_setup/orbitDeterminationManager.h
+++ b/include/tudat/simulation/estimation_setup/orbitDeterminationManager.h
@@ -1101,7 +1101,7 @@ protected:
             integrateAndEstimateOrbit_ = false;
         }
 
-        propagatorSettings->getOutputSettingsBase( )->setCreateDependentVariablesInterface( true );
+        propagatorSettings->getOutputSettingsBase( )->setUpdateDependentVariableInterpolator( true );
         if( integrateAndEstimateOrbit_ )
         {
             variationalEquationsSolver_ = simulation_setup::createVariationalEquationsSolver< ObservationScalarType, TimeType >(

--- a/include/tudat/simulation/estimation_setup/variationalEquationsSolver.h
+++ b/include/tudat/simulation/estimation_setup/variationalEquationsSolver.h
@@ -795,7 +795,8 @@ public:
 
         // Create object that will contain and process the propagation results
         variationalPropagationResults_ = std::make_shared< SingleArcVariationalSimulationResults< StateScalarType, TimeType>>(
-                dynamicsSimulator_->getSingleArcPropagationResults( ), this->stateTransitionMatrixSize_, this->parameterVectorSize_ - this->stateTransitionMatrixSize_ );
+                dynamicsSimulator_->getSingleArcPropagationResults( ),
+                this->stateTransitionMatrixSize_, this->parameterVectorSize_ - this->stateTransitionMatrixSize_ );
 
         // Integrate variational equations from initial state estimate.
         if( integrateEquationsOnCreation )
@@ -1219,7 +1220,8 @@ public:
                     arcWiseStateTransitionMatrixSize_.at( i ), arcWiseParameterVectorSize_.at( i ) - arcWiseStateTransitionMatrixSize_.at( i ) ) );
         }
         variationalPropagationResults_ = std::make_shared< MultiArcSimulationResults< SingleArcVariationalSimulationResults, StateScalarType, TimeType > >(
-                singleArcVariationalResults );
+                singleArcVariationalResults,
+                dynamicsSimulator_->getMultiArcPropagationResults( )->getMultiArcDependentVariablesInterface( ) );
 
 
         for( unsigned int i = 0; i < singleArcDynamicsSimulators.size( ); i++ )

--- a/include/tudat/simulation/propagation_setup/dependentVariablesInterface.h
+++ b/include/tudat/simulation/propagation_setup/dependentVariablesInterface.h
@@ -128,7 +128,7 @@ public:
      * Function to retrieve the dependent variables settings object.
      * \return dependent variables settings
      */
-    std::vector< std::shared_ptr< SingleDependentVariableSaveSettings > > getDependentVariablesSettings( )
+    std::vector< std::shared_ptr< SingleDependentVariableSaveSettings > > getDependentVariablesSettings( ) const
     {
         return dependentVariablesSettings_;
     }
@@ -173,9 +173,13 @@ public:
      */
     SingleArcDependentVariablesInterface(
             const std::shared_ptr< interpolators::OneDimensionalInterpolator< TimeType, Eigen::VectorXd > > dependentVariablesInterpolator,
-            const std::vector< std::shared_ptr< SingleDependentVariableSaveSettings > > dependentVariablesSettings ):
+            const std::vector< std::shared_ptr< SingleDependentVariableSaveSettings > > dependentVariablesSettings,
+            const std::map< std::pair< int, int >, std::string > dependentVariableIds,
+            const std::map< std::pair< int, int >, std::shared_ptr< SingleDependentVariableSaveSettings > > orderedDependentVariableSettings ):
             DependentVariablesInterface< TimeType >( dependentVariablesSettings ),
-            dependentVariablesInterpolator_( dependentVariablesInterpolator )
+            dependentVariablesInterpolator_( dependentVariablesInterpolator ),
+            dependentVariableIds_( dependentVariableIds ),
+            orderedDependentVariableSettings_( orderedDependentVariableSettings )
     {
         dependentVariables_ = Eigen::VectorXd::Zero( dependentVariablesSize_ );
     }
@@ -219,6 +223,15 @@ public:
         return dependentVariables_;
     }
 
+    std::map< std::pair< int, int >, std::string > getDependentVariableIds( ) const
+    {
+        return dependentVariableIds_;
+    }
+
+    std::map< std::pair< int, int >, std::shared_ptr< SingleDependentVariableSaveSettings > > getOrderedDependentVariableSettings( ) const
+    {
+        return orderedDependentVariableSettings_;
+    }
 
 private:
 
@@ -227,6 +240,10 @@ private:
 
     //! Interpolator returning the dependent variables as a function of time.
     std::shared_ptr< interpolators::OneDimensionalInterpolator< TimeType, Eigen::VectorXd > > dependentVariablesInterpolator_;
+
+    std::map< std::pair< int, int >, std::string > dependentVariableIds_;
+
+    std::map< std::pair< int, int >, std::shared_ptr< SingleDependentVariableSaveSettings > > orderedDependentVariableSettings_;
 
 };
 

--- a/include/tudat/simulation/propagation_setup/propagationOutput.h
+++ b/include/tudat/simulation/propagation_setup/propagationOutput.h
@@ -122,8 +122,14 @@ int getDependentVariableSaveSize(
 int getDependentVariableSize(
         const std::shared_ptr< SingleDependentVariableSaveSettings > dependentVariableSettings );
 
+std::pair< int, int > getDependentVariableShape(
+    const std::shared_ptr< SingleDependentVariableSaveSettings > dependentVariableSettings );
+
 bool isScalarDependentVariable(
         const std::shared_ptr< SingleDependentVariableSaveSettings > dependentVariableSettings );
+
+bool isMatrixDependentVariable(
+    const std::shared_ptr< SingleDependentVariableSaveSettings > dependentVariableSettings );
 
 //! Get the vector representation of a rotation matrix.
 /*!
@@ -2444,10 +2450,9 @@ template< typename TimeType = double, typename StateScalarType = double >
 std::pair< std::function< Eigen::VectorXd( ) >, std::map< std::pair< int, int >, std::string > > createDependentVariableListFunction(
         const std::vector< std::shared_ptr< SingleDependentVariableSaveSettings > > dependentVariables,
         const simulation_setup::SystemOfBodies& bodies,
+        std::map< std::pair< int, int >, std::shared_ptr< SingleDependentVariableSaveSettings > >& orderedDependentVariables,
         const std::unordered_map< IntegratedStateType,
-        std::vector< std::shared_ptr< SingleStateTypeDerivative< StateScalarType, TimeType > > > >& stateDerivativeModels =
-        std::unordered_map< IntegratedStateType,
-        std::vector< std::shared_ptr< SingleStateTypeDerivative< StateScalarType, TimeType > > > >( ),
+        std::vector< std::shared_ptr< SingleStateTypeDerivative< StateScalarType, TimeType > > > >& stateDerivativeModels,
         const std::map< propagators::IntegratedStateType, orbit_determination::StateDerivativePartialsMap >& stateDerivativePartials =
         std::map< propagators::IntegratedStateType, orbit_determination::StateDerivativePartialsMap >( ) )
 {
@@ -2488,9 +2493,13 @@ std::pair< std::function< Eigen::VectorXd( ) >, std::map< std::pair< int, int >,
     // Set list of variable ids/indices in correc otder.
     int totalVariableSize = 0;
     std::map< std::pair< int, int >, std::string > dependentVariableIds;
+
+    int variableCounter = 0;
     for( std::pair< std::string, int > vectorVariable: vectorVariableList )
     {
         dependentVariableIds[ { totalVariableSize, vectorVariable.second } ] = vectorVariable.first;
+        orderedDependentVariables[ { totalVariableSize, vectorVariable.second } ] = dependentVariables.at( variableCounter );
+        variableCounter++;
         totalVariableSize += vectorVariable.second;
     }
 

--- a/include/tudat/simulation/propagation_setup/propagationProcessingSettings.h
+++ b/include/tudat/simulation/propagation_setup/propagationProcessingSettings.h
@@ -38,10 +38,10 @@ public:
     PropagatorProcessingSettings(
             const bool clearNumericalSolutions = false,
             const bool setIntegratedResult = false,
-            const bool createDependentVariablesInterface = false ):
+            const bool updateDependentVariableInterpolator = false ):
         clearNumericalSolutions_( clearNumericalSolutions ),
         setIntegratedResult_( setIntegratedResult ),
-        createDependentVariablesInterface_( createDependentVariablesInterface )
+        updateDependentVariableInterpolator_( updateDependentVariableInterpolator )
     { }
 
     virtual ~PropagatorProcessingSettings( ){ }
@@ -56,9 +56,9 @@ public:
         return setIntegratedResult_;
     }
 
-    bool getCreateDependentVariablesInterface( )
+    bool getUpdateDependentVariableInterpolator( )
     {
-        return createDependentVariablesInterface_;
+        return updateDependentVariableInterpolator_;
     }
 
     virtual void setClearNumericalSolutions( const bool clearNumericalSolutions )
@@ -71,9 +71,9 @@ public:
         setIntegratedResult_ = setIntegratedResult;
     }
 
-    virtual void setCreateDependentVariablesInterface( const bool createDependentVariablesInterface )
+    virtual void setUpdateDependentVariableInterpolator( const bool updateDependentVariableInterpolator )
     {
-         createDependentVariablesInterface_ = createDependentVariablesInterface;
+         updateDependentVariableInterpolator_ = updateDependentVariableInterpolator;
     }
 
     virtual bool printAnyOutput( ) = 0;
@@ -86,7 +86,7 @@ protected:
 
     bool clearNumericalSolutions_;
     bool setIntegratedResult_;
-    bool createDependentVariablesInterface_;
+    bool updateDependentVariableInterpolator_;
 };
 
 //! Base class for defining output and processing settings for single-arc propagation.
@@ -103,8 +103,8 @@ public:
             const double resultsSaveFrequencyInSeconds = TUDAT_NAN,
             const std::shared_ptr< PropagationPrintSettings > printSettings =
             std::make_shared< PropagationPrintSettings >( ),
-            const bool createDependentVariablesInterface = false ):
-            PropagatorProcessingSettings( clearNumericalSolutions, setIntegratedResult, createDependentVariablesInterface ),
+            const bool updateDependentVariableInterpolator = false ):
+            PropagatorProcessingSettings( clearNumericalSolutions, setIntegratedResult, updateDependentVariableInterpolator ),
             resultsSaveFrequencyInSteps_( resultsSaveFrequencyInSteps ),
             resultsSaveFrequencyInSeconds_( resultsSaveFrequencyInSeconds ),
             printSettings_( printSettings ),
@@ -217,8 +217,8 @@ public:
             const bool setIntegratedResult = false,
             const bool printFirstArcOnly = false,
             const bool printCurrentArcIndex = false,
-            const bool createDependentVariablesInterface = false ):
-        PropagatorProcessingSettings( clearNumericalSolutions, setIntegratedResult, createDependentVariablesInterface ),
+            const bool updateDependentVariableInterpolator = false ):
+        PropagatorProcessingSettings( clearNumericalSolutions, setIntegratedResult, updateDependentVariableInterpolator ),
         consistentSingleArcPrintSettings_( consistentSingleArcPrintSettings ),
         useIdenticalSettings_( true ),
         printFirstArcOnly_( printFirstArcOnly ),
@@ -233,8 +233,8 @@ public:
             const bool setIntegratedResult = false,
             const bool printFirstArcOnly = false,
             const bool printCurrentArcIndex = false,
-            const bool createDependentVariablesInterface = false ):
-        PropagatorProcessingSettings( clearNumericalSolutions, setIntegratedResult, createDependentVariablesInterface ),
+            const bool updateDependentVariableInterpolator = false ):
+        PropagatorProcessingSettings( clearNumericalSolutions, setIntegratedResult, updateDependentVariableInterpolator ),
         consistentSingleArcPrintSettings_( nullptr ),
         useIdenticalSettings_( false ),
         printFirstArcOnly_( printFirstArcOnly ),
@@ -427,8 +427,8 @@ public:
             const bool clearNumericalSolutions = false,
             const bool setIntegratedResult = false,
             const bool printStateTypeStart = false,
-            const bool createDependentVariablesInterface = false ):
-        PropagatorProcessingSettings( clearNumericalSolutions, setIntegratedResult, createDependentVariablesInterface ),
+            const bool updateDependentVariableInterpolator = false ):
+        PropagatorProcessingSettings( clearNumericalSolutions, setIntegratedResult, updateDependentVariableInterpolator ),
         consistentArcPrintSettings_( consistentArcPrintSettings ),
         useIdenticalSettings_( true ),
         printStateTypeStart_( printStateTypeStart ){ }
@@ -437,8 +437,8 @@ public:
             const bool clearNumericalSolutions = false,
             const bool setIntegratedResult = false,
             const bool printStateTypeStart = false,
-            const bool createDependentVariablesInterface = false ):
-        PropagatorProcessingSettings( clearNumericalSolutions, setIntegratedResult, createDependentVariablesInterface ),
+            const bool updateDependentVariableInterpolator = false ):
+        PropagatorProcessingSettings( clearNumericalSolutions, setIntegratedResult, updateDependentVariableInterpolator ),
         useIdenticalSettings_( false ),
         printStateTypeStart_( printStateTypeStart ){ }
 

--- a/src/simulation/propagation_setup/propagationOutput.cpp
+++ b/src/simulation/propagation_setup/propagationOutput.cpp
@@ -482,6 +482,54 @@ int getDependentVariableSize(
     return variableSize;
 }
 
+std::pair< int, int > getDependentVariableShape(
+    const std::shared_ptr< SingleDependentVariableSaveSettings > dependentVariableSettings )
+{
+    int dependentVariableSize = getDependentVariableSaveSize( dependentVariableSettings );
+    std::pair< int, int > dependentVariableShape;
+    switch ( dependentVariableSettings->dependentVariableType_ )
+    {
+    case inertial_to_body_fixed_rotation_matrix_variable:
+        dependentVariableShape = { 3, 3 };
+        break;
+    case intermediate_aerodynamic_rotation_matrix_variable:
+        dependentVariableShape = { 3, 3 };
+        break;
+    case tnw_to_inertial_frame_rotation_dependent_variable:
+        dependentVariableShape = { 3, 3 };
+        break;
+    case rsw_to_inertial_frame_rotation_dependent_variable:
+        dependentVariableShape = { 3, 3 };
+        break;
+    case acceleration_partial_wrt_body_translational_state:
+        dependentVariableShape = { 3, 3 };
+        break;
+    case body_inertia_tensor:
+        dependentVariableShape = { 3, 3 };
+        break;
+    default:
+        dependentVariableShape = { dependentVariableSize, 1 };
+        break;
+    }
+
+    if( isMatrixDependentVariable( dependentVariableSettings ) && dependentVariableShape.second == 1 )
+    {
+        throw std::runtime_error( "Error when finding shape of dependent variable: (" + getDependentVariableName( dependentVariableSettings ) +
+            "), dependent variable should be a matrix, but number of columns is equal to 1 " );
+    }
+
+    if( dependentVariableShape.first * dependentVariableShape.second != dependentVariableSize )
+    {
+        throw std::runtime_error( "Error when finding shape of dependent variable: (" + getDependentVariableName( dependentVariableSettings ) +
+                                  "), vector size (" + std::to_string( dependentVariableSize ) + ") and matrix size (" +
+                                  std::to_string( dependentVariableShape.first ) + ", " + std::to_string( dependentVariableShape.second ) + ") are incompatible" );
+    }
+    return dependentVariableShape;
+
+
+    return dependentVariableShape;
+}
+
 bool isScalarDependentVariable(
         const std::shared_ptr< SingleDependentVariableSaveSettings > dependentVariableSettings )
 {
@@ -502,6 +550,37 @@ bool isScalarDependentVariable(
                                   ", cannot be parsed" );
     }
 
+}
+
+
+bool isMatrixDependentVariable(
+    const std::shared_ptr< SingleDependentVariableSaveSettings > dependentVariableSettings )
+{
+    bool isMatrixVariable = false;
+    switch ( dependentVariableSettings->dependentVariableType_ )
+    {
+    case inertial_to_body_fixed_rotation_matrix_variable:
+        isMatrixVariable = true;
+        break;
+    case intermediate_aerodynamic_rotation_matrix_variable:
+        isMatrixVariable = true;
+        break;
+    case tnw_to_inertial_frame_rotation_dependent_variable:
+        isMatrixVariable = true;
+        break;
+    case rsw_to_inertial_frame_rotation_dependent_variable:
+        isMatrixVariable = true;
+        break;
+    case acceleration_partial_wrt_body_translational_state:
+        isMatrixVariable = true;
+        break;
+    case body_inertia_tensor:
+        isMatrixVariable = true;
+        break;
+    default:
+        break;
+    }
+    return isMatrixVariable;
 }
 
 Eigen::VectorXd getConstellationMinimumDistance(

--- a/tests/src/astro/orbit_determination/unitTestEstimationInput.cpp
+++ b/tests/src/astro/orbit_determination/unitTestEstimationInput.cpp
@@ -378,7 +378,7 @@ BOOST_AUTO_TEST_CASE( test_WeightDefinitions )
 
         for( auto it : weightPerObservable )
         {
-            for( unsigned int i = 0; i < observationTypeStartAndSize.at( it.first ).second; i++ )
+            for( int i = 0; i < observationTypeStartAndSize.at( it.first ).second; i++ )
             {
                 BOOST_CHECK_CLOSE_FRACTION( totalWeights( observationTypeStartAndSize.at( it.first ).first + i ), it.second, std::numeric_limits< double >::epsilon( ) );
             }
@@ -396,12 +396,12 @@ BOOST_AUTO_TEST_CASE( test_WeightDefinitions )
 
         std::pair< int, int > startEndIndex = observationTypeStartAndSize.at( angular_position );
 
-        for( unsigned int i = 0; i < startEndIndex.first; i++ )
+        for( int i = 0; i < startEndIndex.first; i++ )
         {
             BOOST_CHECK_CLOSE_FRACTION( totalWeights( i ), 2.0, std::numeric_limits< double >::epsilon( ) );
         }
 
-        for( unsigned int i = 0; i < startEndIndex.second; i++ )
+        for( int i = 0; i < startEndIndex.second; i++ )
         {
             if( i % 2 == 0 )
             {

--- a/tests/src/astro/propagators/unitTestDependentVariablesInterface.cpp
+++ b/tests/src/astro/propagators/unitTestDependentVariablesInterface.cpp
@@ -140,7 +140,7 @@ BOOST_AUTO_TEST_CASE( testSingleArcDependentVariablesInterface )
             std::make_shared< TranslationalStatePropagatorSettings< double > >(
             centralBodies, accelerationModelMap, bodiesToPropagate, initialState, simulationStartEpoch,
             integratorSettings, terminationSettings, cowell, dependentVariables );
-    propagatorSettings->getOutputSettings()->setCreateDependentVariablesInterface( true );
+    propagatorSettings->getOutputSettings()->setUpdateDependentVariableInterpolator( true );
 
     // Define single-arc dynamics simulator
     SingleArcDynamicsSimulator< > simulator = SingleArcDynamicsSimulator< >(
@@ -314,7 +314,7 @@ BOOST_AUTO_TEST_CASE( testMultiArcDependentVariablesInterface )
 
     std::shared_ptr< MultiArcPropagatorSettings< > > multiArcPropagatorSettings =
             std::make_shared<MultiArcPropagatorSettings<> >( propagatorSettingsList );
-    multiArcPropagatorSettings->getOutputSettings( )->setCreateDependentVariablesInterface( true );
+    multiArcPropagatorSettings->getOutputSettings( )->setUpdateDependentVariableInterpolator( true );
 
     // Define single-arc dynamics simulator
     MultiArcDynamicsSimulator< > simulator = MultiArcDynamicsSimulator< >(


### PR DESCRIPTION
This pull request addresses issue #179, with improved access to dependent variable properties after the propagation. To support this, the functionality of the DependentVariableInterface has been modified. It is now always created, and a boolean (default false) can be set to create an interpolator for the dependent variables if desired.