### PR TITLE
Upgrade to latest version of the setup-miniconda action in CI workflow 

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -71,7 +71,7 @@ jobs:
     - name: Setup conda environment using mamba
       # This step sets up a conda environment using mamba, a faster alternative to conda. It creates an empty conda environment with the name 'tudat' and activates it. The environment is created using the latest version of Mambaforge, a conda distribution that includes mamba.
       # setup minoconda version 3.0.4 has fix for
-      uses: conda-incubator/setup-miniconda@v3.0.4
+      uses: conda-incubator/setup-miniconda@v3
       with:
          miniforge-variant: Mambaforge
          miniforge-version: latest

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -70,7 +70,6 @@ jobs:
 
     - name: Setup conda environment using mamba
       # This step sets up a conda environment using mamba, a faster alternative to conda. It creates an empty conda environment with the name 'tudat' and activates it. The environment is created using the latest version of Mambaforge, a conda distribution that includes mamba.
-      # setup minoconda version 3.0.4 has fix for
       uses: conda-incubator/setup-miniconda@v3
       with:
          miniforge-variant: Mambaforge

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -70,7 +70,8 @@ jobs:
 
     - name: Setup conda environment using mamba
       # This step sets up a conda environment using mamba, a faster alternative to conda. It creates an empty conda environment with the name 'tudat' and activates it. The environment is created using the latest version of Mambaforge, a conda distribution that includes mamba.
-      uses: conda-incubator/setup-miniconda@v2
+      # setup minoconda version 3.0.4 has fix for
+      uses: conda-incubator/setup-miniconda@v3.0.4
       with:
          miniforge-variant: Mambaforge
          miniforge-version: latest


### PR DESCRIPTION
- Fixes #212 
- Current CI workflow uses version 2 of the setup-miniconda GitHub action. Latest version is 3.0.4. [It includes a bug fix for MacOS](https://github.com/conda-incubator/setup-miniconda/issues/312)

 