### PR TITLE
Fix #252: Fix bug in bumpversion workflow

### DIFF
--- a/.github/workflows/bump_dev_version_nightly.yml
+++ b/.github/workflows/bump_dev_version_nightly.yml
@@ -63,17 +63,14 @@ jobs:
         with:
           ref: develop
 
-      - name: Install bump2version
-        run: pip install bump2version
-
-      - name: Bump version
-        id: bump_version
+      - name: Install bump2version and run bumpversion
         run: |
-          git config --global user.email "actions@github.com"
-          git config --global user.name "GitHub Actions"
-          bump2version dev --config-file .bumpversion.cfg --verbose
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+            python3 -m venv venv
+            source venv/bin/activate
+            pip install bump2version
+            git config --global user.email "actions@github.com"
+            git config --global user.name "GitHub Actions"
+            bump2version dev --config-file .bumpversion.cfg --verbose
 
       - name: Push tag to tudat repository
         run: git push origin --follow-tags
@@ -94,14 +91,14 @@ jobs:
             token: ${{ secrets.BUMP_VERSION_NIGHTLY }}
             ref: develop
 
-        - name: Install bump2version
-          run: pip install bump2version
-
-        - name: Bump version on feedstock
+        - name: Install bump2version and run bumpversion
           run: |
-              git config --global user.email "actions@github.com"
-              git config --global user.name "GitHub Actions"
-              bump2version dev --config-file .bumpversion.cfg --verbose
+               python3 -m venv venv
+               source venv/bin/activate
+               pip install bump2version
+               git config --global user.email "actions@github.com"
+               git config --global user.name "GitHub Actions"
+               bump2version dev --config-file .bumpversion.cfg --verbose
 
         - name: Reset build number in meta.yml to 0
           shell: bash


### PR DESCRIPTION
Closes #252  

### Summary of changes

- Fix for the bug described in #252 : Install python dependency (nump2version) inside a python virtual environment instead of system-wide installation
- GITHUB_TOKEN is not needed for running the bumpversion command. This was mistakenly added previously, and now removed.



### Testing
Changes are tested here:  https://github.com/niketagrawal/tudat/actions/workflows/bump_dev_version_tudat_and_tudat_feedstock.yml 