### PR TITLE
Remove deprecated mambaforge installer in CI

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -75,7 +75,8 @@ jobs:
            activate-environment: tudat
            auto-activate-base: false
 
-
+    - name: Print conda environment information
+      run: conda info --envs
 
     - name: Get date
       # Get the current date and time in UTC format. This step is used to create a unique cache key for the conda environment cache by appending the date to the cache key.
@@ -84,6 +85,8 @@ jobs:
       run: echo "today=$(/bin/date -u '+%Y%m%d')" >> $GITHUB_OUTPUT
       shell: bash
 
+    - name: Debug conda environment path
+      run: ls -la ${{ matrix.path_conda_env }}
 
     - name: Cache conda environment
       # Cache the conda environment to avoid re-installing the same packages every time the workflow runs. The cache key is based on the environment.yml file, the operating system, and the date. The cache is restored if the cache key matches the cache key of the previous run.

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -75,8 +75,6 @@ jobs:
            activate-environment: tudat
            auto-activate-base: false
 
-    - name: Print conda environment information
-      run: conda info --envs
 
     - name: Get date
       # Get the current date and time in UTC format. This step is used to create a unique cache key for the conda environment cache by appending the date to the cache key.

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -96,7 +96,7 @@ jobs:
 
     - name: Create conda environment from environment.yml
       # Update the tudat conda environment created using the environment.yml file if the cache is not restored
-      run: mamba env update -n tudat -f environment.yml
+      run: conda env update -n tudat -f environment.yml
       if: steps.cache.outputs.cache-hit != 'true'
 
 

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -74,7 +74,7 @@ jobs:
       with:
            activate-environment: tudat
            auto-activate-base: false
-           conda-version: 'latest'
+
 
 
     - name: Get date

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -73,8 +73,8 @@ jobs:
       uses: conda-incubator/setup-miniconda@v3
       with:
            activate-environment: tudat
+           auto-activate-base: false
            conda-version: 'latest'
-
 
 
     - name: Get date

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -39,12 +39,12 @@ jobs:
             c_compiler: cl
             cpp_compiler: cl
             label: win-64
-            path_conda_env: C:\Miniconda3\envs\tudat
+            path_conda_env: C:\Miniconda\envs\tudat
           - os: ubuntu-latest
             c_compiler: gcc
             cpp_compiler: g++
             label: linux-64
-            path_conda_env: /usr/share/miniconda3/envs/tudat
+            path_conda_env: /usr/share/miniconda/envs/tudat
           - os: macos-latest
             c_compiler: clang
             cpp_compiler: clang++
@@ -85,8 +85,6 @@ jobs:
       run: echo "today=$(/bin/date -u '+%Y%m%d')" >> $GITHUB_OUTPUT
       shell: bash
 
-    - name: Debug conda environment path
-      run: ls -la ${{ matrix.path_conda_env }}
 
     - name: Cache conda environment
       # Cache the conda environment to avoid re-installing the same packages every time the workflow runs. The cache key is based on the environment.yml file, the operating system, and the date. The cache is restored if the cache key matches the cache key of the previous run.

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -68,14 +68,13 @@ jobs:
     - uses: actions/checkout@v4
 
 
-    - name: Setup conda environment using mamba
-      # This step sets up a conda environment using mamba, a faster alternative to conda. It creates an empty conda environment with the name 'tudat' and activates it. The environment is created using the latest version of Mambaforge, a conda distribution that includes mamba.
+    - name: Setup conda environment
+      # This step creates an empty conda environment with the name 'tudat' and activates it. Use latest conda version.
       uses: conda-incubator/setup-miniconda@v3
       with:
-         miniforge-variant: Mambaforge
-         miniforge-version: latest
-         activate-environment: tudat
-         use-mamba: true
+           activate-environment: tudat
+           conda-version: 'latest'
+
 
 
     - name: Get date


### PR DESCRIPTION
Closes #243 

Rollback to using conda instead of mamba in the setup conda environment step in CI. 

[The documentation of the GitHub action setup-miniconda mentions that mamba support is experimental and that latest conda provides comparable performance](https://github.com/marketplace/actions/setup-miniconda#example-6-mamba). 