### PR TITLE
Replace deprecated set-output Command with Environment Files in Nightly Bump Workflow

### DIFF
--- a/.github/workflows/bump_dev_version_nightly.yml
+++ b/.github/workflows/bump_dev_version_nightly.yml
@@ -1,4 +1,4 @@
-# This workflow is triggered at 3:00 AM CET everyday and checks if there has
+# This workflow is triggered at 01:00 AM CET everyday and checks if there has
 # been a commit in the last 24 hours on the develop branch of tudat repository.
 
 # If there has been a commit, it bumps the version in the develop branch of
@@ -32,7 +32,7 @@ jobs:
         runs-on: ubuntu-latest
         name: Check latest commit
         outputs:
-          should_run: ${{ steps.should_run.outputs.should_run }}
+          should_run: ${{ steps.should_bump_version.outputs.should_run }}
         steps:
           - uses: actions/checkout@v4
             with:
@@ -41,21 +41,24 @@ jobs:
             run: git log -n 1 --pretty=format:"%H"
 
 
-          - id: should_run
+          - id: should_bump_version
             continue-on-error: true
             name: check latest commit is less than a day
-            if: ${{ github.event_name == 'schedule' }}
-            run: test -z $(git rev-list  --after="24 hours" $(git log -n 1 --pretty=format:"%H")) && echo "::set-output name=should_run::false"
+            run: |
+              STR=$(git rev-list --after="24 hours" $(git log -n 1 --pretty=format:"%H"))
+              if test -z $STR; then
+                echo "should_run=false" >> $GITHUB_OUTPUT
+              else
+                echo "should_run=true" >> $GITHUB_OUTPUT
+              fi
             # If the latest commit is less than 24 hours old, the command git rev-list --after="24 hours" $(git log -n 1 --pretty=format:"%H") will return a non-empty string (list of commit ids in the last 24 hours), which will cause the test -z command to return false and the output should_run will not be set to false.
             # test -z $STR checks if $STR is empty or not. If it is empty, it returns true, else false.
 
   bump-version_tudat:
     needs: check_recent_24h_commit
-    if: ${{ needs.check_recent_24h_commit.outputs.should_run != 'false' }}
+    if: ${{ needs.check_recent_24h_commit.outputs.should_run != 'false' && github.event_name == 'schedule' }}
     runs-on: ubuntu-latest
     name: Bump version in tudat repository
-    outputs:
-      new_version: ${{ steps.bump_version.outputs.new_version }}
 
     steps:
       - name: Checkout
@@ -80,7 +83,7 @@ jobs:
 
   bump_version_tudat_feedstock:
     needs: check_recent_24h_commit
-    if: ${{ needs.check_recent_24h_commit.outputs.should_run != 'false' }}
+    if: ${{ needs.check_recent_24h_commit.outputs.should_run != 'false' && github.event_name == 'schedule' }}
     runs-on: ubuntu-latest
     name: bump version and create tag in tudat-feedstock
     steps:


### PR DESCRIPTION
Closes #266 

set-output command will be deprecated soon as seen in the latest github actions log for the bump version workflow https://github.com/tudat-team/tudat/actions/runs/12001146833.  


### Summary of changes
- Replace set-output with using Environment files because set-output will be deprecated soon. Rename step `should_run` to `should_bump_version` to avoid conflicting names for the step and the output variable. 
- Break down the command test -z $(git rev-list  --after="24 hours" $(git log -n 1 --pretty=format:"%H")) && echo "::set-output name=should_run::false" into multiple steps to improve readability.
- Remove obsolete output variable `new_version`. This was part of the old design and not in use now. 