### PR TITLE
Fix segfault thrown when creating SGP4 ephemeris

### DIFF
--- a/include/tudat/simulation/environment_setup/createEphemeris.h
+++ b/include/tudat/simulation/environment_setup/createEphemeris.h
@@ -751,7 +751,7 @@ public:
     DirectTleEphemerisSettings( std::shared_ptr< ephemerides::Tle > tle,
                                 const std::string frameOrigin = "Earth",
                                 const std::string frameOrientation = "J2000" ):
-        EphemerisSettings( direct_tle_ephemeris, frameOrigin, frameOrientation )
+        EphemerisSettings( direct_tle_ephemeris, frameOrigin, frameOrientation ), tle_( tle )
     { }
 
     const std::shared_ptr< ephemerides::Tle > getTle( ) const


### PR DESCRIPTION
When trying to create an Ephemeris object from the new sgp4 ephemeris settings using the code below, a segfault is thrown:

```python
delfi_tle = environment_setup.ephemeris.sgp4(
    "1 32789U 07021G   08119.60740078 -.00000054  00000-0  00000+0 0  9999",
    "2 32789 098.0082 179.6267 0015321 307.2977 051.0656 14.81417433    68",
    frame_origin = "Earth", frame_orientation = "J2000"
)
delfi_ephemeris = environment_setup.create_body_ephemeris(delfi_tle, "Earth")
``` 
When compiling the proposed fix without the tests, the build finishes without any errors and the code above runs as expected.
However, when compiling it with tests, I get the following (seemingly?) unrelated error message:

<details><summary>Error when compiling with tests</summary>
<p>

```
~/repos/tudat-bundle main !2 ❯ python build.py -j 4                                                                                                                                                                                                                                  32m 56s  tudat-bundle
-- CMAKE_PREFIX_PATH: /home/lars/anaconda3/envs/tudat-bundle
-- CMAKE_BINARY_DIR: /home/lars/repos/tudat-bundle/build
-- Using UNDOCUMENTED tudat
-- System name: Linux
-- ******************** BUILD CONFIGURATION ********************
-- TUDAT_BUILD_TESTS                                     True
-- TUDAT_BUILD_WITH_PROPAGATION_TESTS                    OFF
-- TUDAT_BUILD_WITH_ESTIMATION_TOOLS                     ON
-- TUDAT_BUILD_TUDAT_TUTORIALS                           ON
-- TUDAT_BUILD_STATIC_LIBRARY                            ON
-- TUDAT_BUILD_WITH_FILTERS                              OFF
-- TUDAT_BUILD_WITH_SOFA_INTERFACE                       ON
-- TUDAT_BUILD_WITH_FFTW3                                OFF
-- TUDAT_BUILD_WITH_JSON_INTERFACE                       OFF
-- TUDAT_BUILD_WITH_EXTENDED_PRECISION_PROPAGATION_TOOLS OFF
-- TUDAT_DOWNLOAD_AND_BUILD_BOOST                        OFF

-- INSTALLATION PREFIX: /home/lars/anaconda3/envs/tudat-bundle

-- << Tudat (Release - ) >>

*** COMPILER CONFIGURATION ***

-- CMAKE_C_COMPILER:   /usr/bin/cc
-- CMAKE_CXX_COMPILER: /usr/bin/c++
-- CMAKE_CXX_COMPILER_ID: GNU
-- CMAKE_CXX_SIMULATE_ID: 
-- CMAKE_CXX_COMPILER_VERSION: 11.4.0
-- CMAKE_CXX_COMPILER_VERSION 11.4.0
-- Using gnucxx compiler.
-- Building with flags: -Wall -std=c++1z -Wextra -Wno-unused-parameter -Wno-unused-variable -Wno-array-bounds -Woverloaded-virtual -Wold-style-cast -Wnon-virtual-dtor -Wunused-but-set-variable -Wsign-compare -O3 -O2 -DNDEBUG.
-- Required Boost libraries: filesystem;system;regex;date_time;thread;chrono;atomic;unit_test_framework
CMake Warning at /usr/share/cmake-3.22/Modules/FindBoost.cmake:1369 (message):
  New Boost version may have incorrect or missing dependencies and imported
  targets
Call Stack (most recent call first):
  /usr/share/cmake-3.22/Modules/FindBoost.cmake:1492 (_Boost_COMPONENT_DEPENDENCIES)
  /usr/share/cmake-3.22/Modules/FindBoost.cmake:2102 (_Boost_MISSING_DEPENDENCIES)
  tudat/cmake_modules/TudatFindBoost.cmake:21 (find_package)
  tudat/CMakeLists.txt:232 (include)


CMake Warning at /usr/share/cmake-3.22/Modules/FindBoost.cmake:1369 (message):
  New Boost version may have incorrect or missing dependencies and imported
  targets
Call Stack (most recent call first):
  /usr/share/cmake-3.22/Modules/FindBoost.cmake:1492 (_Boost_COMPONENT_DEPENDENCIES)
  /usr/share/cmake-3.22/Modules/FindBoost.cmake:2102 (_Boost_MISSING_DEPENDENCIES)
  tudat/cmake_modules/TudatFindBoost.cmake:21 (find_package)
  tudat/CMakeLists.txt:232 (include)


CMake Warning at /usr/share/cmake-3.22/Modules/FindBoost.cmake:1369 (message):
  New Boost version may have incorrect or missing dependencies and imported
  targets
Call Stack (most recent call first):
  /usr/share/cmake-3.22/Modules/FindBoost.cmake:1492 (_Boost_COMPONENT_DEPENDENCIES)
  /usr/share/cmake-3.22/Modules/FindBoost.cmake:2102 (_Boost_MISSING_DEPENDENCIES)
  tudat/cmake_modules/TudatFindBoost.cmake:21 (find_package)
  tudat/CMakeLists.txt:232 (include)


CMake Warning at /usr/share/cmake-3.22/Modules/FindBoost.cmake:1369 (message):
  New Boost version may have incorrect or missing dependencies and imported
  targets
Call Stack (most recent call first):
  /usr/share/cmake-3.22/Modules/FindBoost.cmake:1492 (_Boost_COMPONENT_DEPENDENCIES)
  /usr/share/cmake-3.22/Modules/FindBoost.cmake:2102 (_Boost_MISSING_DEPENDENCIES)
  tudat/cmake_modules/TudatFindBoost.cmake:21 (find_package)
  tudat/CMakeLists.txt:232 (include)


CMake Warning at /usr/share/cmake-3.22/Modules/FindBoost.cmake:1369 (message):
  New Boost version may have incorrect or missing dependencies and imported
  targets
Call Stack (most recent call first):
  /usr/share/cmake-3.22/Modules/FindBoost.cmake:1492 (_Boost_COMPONENT_DEPENDENCIES)
  /usr/share/cmake-3.22/Modules/FindBoost.cmake:2102 (_Boost_MISSING_DEPENDENCIES)
  tudat/cmake_modules/TudatFindBoost.cmake:21 (find_package)
  tudat/CMakeLists.txt:232 (include)


CMake Warning at /usr/share/cmake-3.22/Modules/FindBoost.cmake:1369 (message):
  New Boost version may have incorrect or missing dependencies and imported
  targets
Call Stack (most recent call first):
  /usr/share/cmake-3.22/Modules/FindBoost.cmake:1492 (_Boost_COMPONENT_DEPENDENCIES)
  /usr/share/cmake-3.22/Modules/FindBoost.cmake:2102 (_Boost_MISSING_DEPENDENCIES)
  tudat/cmake_modules/TudatFindBoost.cmake:21 (find_package)
  tudat/CMakeLists.txt:232 (include)


CMake Warning at /usr/share/cmake-3.22/Modules/FindBoost.cmake:1369 (message):
  New Boost version may have incorrect or missing dependencies and imported
  targets
Call Stack (most recent call first):
  /usr/share/cmake-3.22/Modules/FindBoost.cmake:1492 (_Boost_COMPONENT_DEPENDENCIES)
  /usr/share/cmake-3.22/Modules/FindBoost.cmake:2102 (_Boost_MISSING_DEPENDENCIES)
  tudat/cmake_modules/TudatFindBoost.cmake:21 (find_package)
  tudat/CMakeLists.txt:232 (include)


CMake Warning at /usr/share/cmake-3.22/Modules/FindBoost.cmake:1369 (message):
  New Boost version may have incorrect or missing dependencies and imported
  targets
Call Stack (most recent call first):
  /usr/share/cmake-3.22/Modules/FindBoost.cmake:1492 (_Boost_COMPONENT_DEPENDENCIES)
  /usr/share/cmake-3.22/Modules/FindBoost.cmake:2102 (_Boost_MISSING_DEPENDENCIES)
  tudat/cmake_modules/TudatFindBoost.cmake:21 (find_package)
  tudat/CMakeLists.txt:232 (include)


-- Found Boost: /home/lars/anaconda3/envs/tudat-bundle-docstrings/include (found suitable version "1.78.0", minimum required is "1.72.0") found components: filesystem system regex date_time thread chrono atomic unit_test_framework 
-- Detected Boost version: 107800
-- Boost include dirs: /home/lars/anaconda3/envs/tudat-bundle-docstrings/include
-- Checking for _GLIBCXX_USE_CXX11_ABI definition...
-- _GLIBCXX_USE_CXX11_ABI was not found.
/home/lars/anaconda3/envs/tudat-bundle-docstrings/lib/cmake/tudatresources/../../../include
-- NRLMSISE00::nrlmsise00
-- Extended precision propagation disabled!
-- TUDAT_DATA_DIR_RELATIVE_TO_INSTALL_PREFIX: data/tudat
-- Using UNDOCUMENTED tudatpy
CMake Deprecation Warning at tudatpy/CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 2.8.12 will be removed from a future version of
  CMake.

  Update the VERSION argument <min> value or use a ...<max> suffix to tell
  CMake that the project does not need compatibility with older versions.


-- System name: Linux
-- tudatpy version: 0.9.0
-- << tudatpy (Release - ) >>
CMake Warning at /usr/share/cmake-3.22/Modules/FindBoost.cmake:1369 (message):
  New Boost version may have incorrect or missing dependencies and imported
  targets
Call Stack (most recent call first):
  /usr/share/cmake-3.22/Modules/FindBoost.cmake:1492 (_Boost_COMPONENT_DEPENDENCIES)
  /usr/share/cmake-3.22/Modules/FindBoost.cmake:2102 (_Boost_MISSING_DEPENDENCIES)
  tudatpy/CMakeLists.txt:72 (find_package)


CMake Warning at /usr/share/cmake-3.22/Modules/FindBoost.cmake:1369 (message):
  New Boost version may have incorrect or missing dependencies and imported
  targets
Call Stack (most recent call first):
  /usr/share/cmake-3.22/Modules/FindBoost.cmake:1492 (_Boost_COMPONENT_DEPENDENCIES)
  /usr/share/cmake-3.22/Modules/FindBoost.cmake:2102 (_Boost_MISSING_DEPENDENCIES)
  tudatpy/CMakeLists.txt:72 (find_package)


CMake Warning at /usr/share/cmake-3.22/Modules/FindBoost.cmake:1369 (message):
  New Boost version may have incorrect or missing dependencies and imported
  targets
Call Stack (most recent call first):
  /usr/share/cmake-3.22/Modules/FindBoost.cmake:1492 (_Boost_COMPONENT_DEPENDENCIES)
  /usr/share/cmake-3.22/Modules/FindBoost.cmake:2102 (_Boost_MISSING_DEPENDENCIES)
  tudatpy/CMakeLists.txt:72 (find_package)


CMake Warning at /usr/share/cmake-3.22/Modules/FindBoost.cmake:1369 (message):
  New Boost version may have incorrect or missing dependencies and imported
  targets
Call Stack (most recent call first):
  /usr/share/cmake-3.22/Modules/FindBoost.cmake:1492 (_Boost_COMPONENT_DEPENDENCIES)
  /usr/share/cmake-3.22/Modules/FindBoost.cmake:2102 (_Boost_MISSING_DEPENDENCIES)
  tudatpy/CMakeLists.txt:72 (find_package)


CMake Warning at /usr/share/cmake-3.22/Modules/FindBoost.cmake:1369 (message):
  New Boost version may have incorrect or missing dependencies and imported
  targets
Call Stack (most recent call first):
  /usr/share/cmake-3.22/Modules/FindBoost.cmake:1492 (_Boost_COMPONENT_DEPENDENCIES)
  /usr/share/cmake-3.22/Modules/FindBoost.cmake:2102 (_Boost_MISSING_DEPENDENCIES)
  tudatpy/CMakeLists.txt:72 (find_package)


CMake Warning at /usr/share/cmake-3.22/Modules/FindBoost.cmake:1369 (message):
  New Boost version may have incorrect or missing dependencies and imported
  targets
Call Stack (most recent call first):
  /usr/share/cmake-3.22/Modules/FindBoost.cmake:1492 (_Boost_COMPONENT_DEPENDENCIES)
  /usr/share/cmake-3.22/Modules/FindBoost.cmake:2102 (_Boost_MISSING_DEPENDENCIES)
  tudatpy/CMakeLists.txt:72 (find_package)


CMake Warning at /usr/share/cmake-3.22/Modules/FindBoost.cmake:1369 (message):
  New Boost version may have incorrect or missing dependencies and imported
  targets
Call Stack (most recent call first):
  /usr/share/cmake-3.22/Modules/FindBoost.cmake:1492 (_Boost_COMPONENT_DEPENDENCIES)
  /usr/share/cmake-3.22/Modules/FindBoost.cmake:2102 (_Boost_MISSING_DEPENDENCIES)
  tudatpy/CMakeLists.txt:72 (find_package)


CMake Warning at /usr/share/cmake-3.22/Modules/FindBoost.cmake:1369 (message):
  New Boost version may have incorrect or missing dependencies and imported
  targets
Call Stack (most recent call first):
  /usr/share/cmake-3.22/Modules/FindBoost.cmake:1492 (_Boost_COMPONENT_DEPENDENCIES)
  /usr/share/cmake-3.22/Modules/FindBoost.cmake:2102 (_Boost_MISSING_DEPENDENCIES)
  tudatpy/CMakeLists.txt:72 (find_package)


-- Found Boost: /home/lars/anaconda3/envs/tudat-bundle-docstrings/include (found suitable version "1.78.0", minimum required is "1.72.0") found components: thread date_time system unit_test_framework filesystem regex chrono atomic 
-- Tudat:[Tudat_PROPAGATION_LIBRARIES]Tudat::tudat_propagation_setupTudat::tudat_shape_based_methodsTudat::tudat_low_thrust_trajectoriesTudat::tudat_environment_setupTudat::tudat_ground_stationsTudat::tudat_aerodynamicsTudat::tudat_system_modelsTudat::tudat_geometric_shapesTudat::tudat_relativityTudat::tudat_gravitationTudat::tudat_mission_segmentsTudat::tudat_electromagnetismTudat::tudat_propulsionTudat::tudat_ephemeridesTudat::tudat_earth_orientationTudat::tudat_numerical_integratorsTudat::tudat_reference_framesTudat::tudat_statisticsTudat::tudat_propagatorsTudat::tudat_spice_interfaceTudat::tudat_sofa_interfaceNRLMSISE00::nrlmsise00Tudat::tudat_basic_astrodynamicsTudat::tudat_numerical_quadratureTudat::tudat_interpolatorsTudat::tudat_root_findersTudat::tudat_basic_mathematicsTudat::tudat_input_outputTudat::tudat_basicsTudat::tudat_data
-- Tudat:[Tudat_INCLUDE_DIRS]
-- Python modules do NOT require linking to the Python library.
-- Python interpreter: /home/lars/anaconda3/envs/tudat-bundle/bin/python
-- Python interpreter version: 3.11.11
-- Python include dir: /home/lars/anaconda3/envs/tudat-bundle/include/python3.11
-- Generic UNIX platform detected.
-- Python modules install path: lib/python3.11/site-packages
-- Setting up the compilation of the Python module 'kernel'.
-- Setting up extra compiler flag '-fwrapv' for the Python module 'kernel'.
-- Configuring done
-- Generating done
-- Build files have been written to: /home/lars/repos/tudat-bundle/build
Consolidate compiler generated dependencies of target tudat_electromagnetism
Consolidate compiler generated dependencies of target tudat_earth_orientation
Consolidate compiler generated dependencies of target tudat_aerodynamics
Consolidate compiler generated dependencies of target tudat_basic_astrodynamics
[  1%] Built target tudat_electromagnetism
[  3%] Built target tudat_basic_astrodynamics
[  3%] Built target tudat_earth_orientation
[  5%] Built target tudat_aerodynamics
Consolidate compiler generated dependencies of target tudat_low_thrust_trajectories
Consolidate compiler generated dependencies of target tudat_ground_stations
[  5%] Built target tudat_low_thrust_trajectories
Consolidate compiler generated dependencies of target tudat_ephemerides
Consolidate compiler generated dependencies of target tudat_gravitation
Consolidate compiler generated dependencies of target tudat_shape_based_methods
[  6%] Built target tudat_shape_based_methods
[  7%] Built target tudat_ground_stations
Consolidate compiler generated dependencies of target tudat_mission_segments
Consolidate compiler generated dependencies of target tudat_observation_models
[ 10%] Built target tudat_gravitation
[ 11%] Built target tudat_ephemerides
Consolidate compiler generated dependencies of target tudat_orbit_determination
Consolidate compiler generated dependencies of target tudat_acceleration_partials
[ 12%] Built target tudat_mission_segments
[ 13%] Built target tudat_orbit_determination
Consolidate compiler generated dependencies of target tudat_torque_partials
Consolidate compiler generated dependencies of target tudat_estimatable_parameters
[ 14%] Built target tudat_observation_models
[ 15%] Built target tudat_torque_partials
[ 16%] Built target tudat_estimatable_parameters
Consolidate compiler generated dependencies of target tudat_propulsion
Consolidate compiler generated dependencies of target tudat_observation_partials
Consolidate compiler generated dependencies of target tudat_propagators
[ 18%] Built target tudat_acceleration_partials
Consolidate compiler generated dependencies of target tudat_reference_frames
[ 19%] Built target tudat_propulsion
Consolidate compiler generated dependencies of target tudat_relativity
[ 19%] Built target tudat_reference_frames
Consolidate compiler generated dependencies of target tudat_system_models
[ 20%] Built target tudat_relativity
Consolidate compiler generated dependencies of target tudat_basics
[ 20%] Built target tudat_basics
[ 21%] Built target tudat_system_models
Consolidate compiler generated dependencies of target tudat_spice_interface
Consolidate compiler generated dependencies of target tudat_sofa_interface
[ 21%] Built target tudat_sofa_interface
[ 22%] Built target tudat_observation_partials
[ 24%] Built target tudat_propagators
[ 24%] Built target tudat_spice_interface
Consolidate compiler generated dependencies of target tudat_geometric_shapes
Consolidate compiler generated dependencies of target tudat_basic_mathematics
Consolidate compiler generated dependencies of target tudat_interpolators
Consolidate compiler generated dependencies of target tudat_numerical_integrators
[ 25%] Built target tudat_geometric_shapes
Consolidate compiler generated dependencies of target tudat_root_finders
[ 25%] Built target tudat_root_finders
[ 26%] Built target tudat_interpolators
[ 27%] Built target tudat_basic_mathematics
[ 28%] Built target tudat_numerical_integrators
Consolidate compiler generated dependencies of target tudat_numerical_quadrature
Consolidate compiler generated dependencies of target tudat_statistics
Consolidate compiler generated dependencies of target tudat_propagation_setup
[ 29%] Built target tudat_numerical_quadrature
Consolidate compiler generated dependencies of target tudat_environment_setup
[ 30%] Built target tudat_statistics
Consolidate compiler generated dependencies of target tudat_input_output
Consolidate compiler generated dependencies of target tudat_estimation_setup
[ 31%] Built target tudat_propagation_setup
Consolidate compiler generated dependencies of target tudat_data
[ 32%] Built target tudat_data
Unpacking data.zip
[ 35%] Built target tudat_environment_setup
Consolidate compiler generated dependencies of target test_aerodynamics_AerodynamicsNamespace
[ 37%] Built target tudat_input_output
[ 38%] Built target test_aerodynamics_AerodynamicsNamespace
Consolidate compiler generated dependencies of target test_aerodynamics_ExponentialAtmosphere
Consolidate compiler generated dependencies of target test_aerodynamics_CoefficientGenerator
[ 38%] Built target test_aerodynamics_ExponentialAtmosphere
[ 38%] Built target test_aerodynamics_CoefficientGenerator
[ 40%] Built target tudat_estimation_setup
Consolidate compiler generated dependencies of target test_aerodynamics_CustomConstantTemperatureAtmosphere
Consolidate compiler generated dependencies of target test_aerodynamics_TabulatedAtmosphere
Consolidate compiler generated dependencies of target test_aerodynamics_HeatTransfer
[ 40%] Built target test_aerodynamics_CustomConstantTemperatureAtmosphere
[ 41%] Built target test_aerodynamics_HeatTransfer
[ 41%] Built target test_aerodynamics_TabulatedAtmosphere
Consolidate compiler generated dependencies of target test_aerodynamics_AerodynamicCoefficientsFromFile
Consolidate compiler generated dependencies of target test_aerodynamics_ControlSurfaceIncrements
Consolidate compiler generated dependencies of target test_aerodynamics_WindModel
[ 41%] Built target test_aerodynamics_AerodynamicCoefficientsFromFile
[ 41%] Built target test_aerodynamics_WindModel
[ 41%] Built target test_aerodynamics_ControlSurfaceIncrements
Consolidate compiler generated dependencies of target test_aerodynamics_NRLMSISE00Atmosphere
Consolidate compiler generated dependencies of target test_basic_astro_AstrodynamicsFunctions
Consolidate compiler generated dependencies of target test_basic_astro_OrbitalElementConversions
[ 41%] Built target test_basic_astro_AstrodynamicsFunctions
[ 41%] Built target test_basic_astro_OrbitalElementConversions
Consolidate compiler generated dependencies of target test_basic_astro_UnitConversions
Consolidate compiler generated dependencies of target test_basic_astro_PhysicalConstants
[ 41%] Built target test_aerodynamics_NRLMSISE00Atmosphere
[ 41%] Built target test_basic_astro_UnitConversions
Consolidate compiler generated dependencies of target test_basic_astro_ConvertMeanAnomalyToEccentricAnomaly
[ 41%] Built target test_basic_astro_PhysicalConstants
Consolidate compiler generated dependencies of target test_basic_astro_ConvertMeanAnomalyToHyperbolicEccentricAnomaly
Consolidate compiler generated dependencies of target test_basic_astro_KeplerPropagator
[ 41%] Built target test_basic_astro_ConvertMeanAnomalyToEccentricAnomaly
Consolidate compiler generated dependencies of target test_basic_astro_AccelerationModel
[ 41%] Built target test_basic_astro_ConvertMeanAnomalyToHyperbolicEccentricAnomaly
[ 41%] Built target test_basic_astro_KeplerPropagator
Consolidate compiler generated dependencies of target test_basic_astro_ClohessyWiltshirePropagator
Consolidate compiler generated dependencies of target test_basic_astro_CustomAccelerationAndTorqueModel
[ 41%] Built target test_basic_astro_AccelerationModel
[ 41%] Built target test_basic_astro_ClohessyWiltshirePropagator
Consolidate compiler generated dependencies of target test_basic_astro_MissionGeometry
Consolidate compiler generated dependencies of target test_basic_astro_TimeConversions
[ 41%] Built target test_basic_astro_CustomAccelerationAndTorqueModel
[ 41%] Built target test_basic_astro_TimeConversions
[ 41%] Built target test_basic_astro_MissionGeometry
Consolidate compiler generated dependencies of target test_basic_astro_CelestialBodyConstants
Consolidate compiler generated dependencies of target test_basic_astro_ModifiedEquinoctialElementConversions
Consolidate compiler generated dependencies of target test_basic_astro_GeodeticCoordinateConversions
[ 42%] Built target test_basic_astro_CelestialBodyConstants
Consolidate compiler generated dependencies of target test_basic_astro_StateConversions
[ 42%] Built target test_basic_astro_GeodeticCoordinateConversions
[ 43%] Built target test_basic_astro_ModifiedEquinoctialElementConversions
Consolidate compiler generated dependencies of target test_basic_astro_SphericalOrbitStateConversions
Consolidate compiler generated dependencies of target test_basic_astro_BodyShapeModels
[ 44%] Built target test_basic_astro_StateConversions
[ 44%] Built target test_basic_astro_SphericalOrbitStateConversions
[ 44%] Built target test_basic_astro_BodyShapeModels
Consolidate compiler generated dependencies of target test_basic_astro_UnifiedStateModelQuaternionElementConversions
Consolidate compiler generated dependencies of target test_basic_astro_UnifiedStateModelMRPElementConversions
Consolidate compiler generated dependencies of target test_basic_astro_UnifiedStateModelEMElementConversions
[ 44%] Built target test_basic_astro_UnifiedStateModelQuaternionElementConversions
[ 44%] Built target test_basic_astro_UnifiedStateModelMRPElementConversions
[ 44%] Built target test_basic_astro_UnifiedStateModelEMElementConversions
Consolidate compiler generated dependencies of target test_basic_astro_EmpiricalAcceleration
Consolidate compiler generated dependencies of target test_basic_astro_DateTime
Consolidate compiler generated dependencies of target test_basic_astro_PolyhedronFunctions
[ 44%] Built target test_basic_astro_PolyhedronFunctions
[ 45%] Built target test_basic_astro_DateTime
Consolidate compiler generated dependencies of target test_earth_orientation_EarthOrientationCalculator
Consolidate compiler generated dependencies of target test_earth_orientation_EopReader
[ 45%] Built target test_basic_astro_EmpiricalAcceleration
Consolidate compiler generated dependencies of target test_earth_orientation_PolarMotionCalculator
[ 45%] Built target test_earth_orientation_EarthOrientationCalculator
[ 45%] Built target test_earth_orientation_EopReader
Consolidate compiler generated dependencies of target test_earth_orientation_TimeScaleConverter
Consolidate compiler generated dependencies of target test_earth_orientation_ShortPeriodEopCorrections
[ 45%] Built target test_earth_orientation_PolarMotionCalculator
Consolidate compiler generated dependencies of target test_electromagnetism_LorentzStaticMagneticAccelerationAndForce
[ 45%] Built target test_earth_orientation_TimeScaleConverter
[ 46%] Built target test_earth_orientation_ShortPeriodEopCorrections
Consolidate compiler generated dependencies of target test_electromagnetism_RadiationSourceModel
Consolidate compiler generated dependencies of target test_electromagnetism_LuminosityModel
[ 46%] Built target test_electromagnetism_LorentzStaticMagneticAccelerationAndForce
Consolidate compiler generated dependencies of target test_electromagnetism_SourcePanelRadiosityModel
[ 46%] Built target test_electromagnetism_LuminosityModel
[ 46%] Built target unpack_test_data
[ 46%] Built target test_electromagnetism_RadiationSourceModel
Consolidate compiler generated dependencies of target test_electromagnetism_RadiationPressureAcceleration
Consolidate compiler generated dependencies of target test_electromagnetism_RadiationPressureTargetModel
Consolidate compiler generated dependencies of target test_electromagnetism_ReflectionLaw
[ 46%] Built target test_electromagnetism_SourcePanelRadiosityModel
Consolidate compiler generated dependencies of target test_electromagnetism_OccultationModel
[ 46%] Built target test_electromagnetism_ReflectionLaw
[ 46%] Built target test_electromagnetism_RadiationPressureTargetModel
[ 46%] Built target test_electromagnetism_OccultationModel
Consolidate compiler generated dependencies of target test_electromagnetism_SurfacePropertyDistribution
[ 47%] Built target test_electromagnetism_RadiationPressureAcceleration
Consolidate compiler generated dependencies of target test_electromagnetism_YarkovskyAcceleration
Consolidate compiler generated dependencies of target test_ephemerides_ApproximatePlanetPositions
Consolidate compiler generated dependencies of target test_ephemerides_TabulatedEphemeris
[ 48%] Built target test_electromagnetism_SurfacePropertyDistribution
[ 48%] Built target test_ephemerides_ApproximatePlanetPositions
Consolidate compiler generated dependencies of target test_ephemerides_CartesianStateExtractor
[ 48%] Built target test_ephemerides_TabulatedEphemeris
Consolidate compiler generated dependencies of target test_ephemerides_KeplerStateExtractor
[ 48%] Built target test_electromagnetism_YarkovskyAcceleration
Consolidate compiler generated dependencies of target test_ephemerides_RotationalEphemeris
Consolidate compiler generated dependencies of target test_ephemerides_SimpleRotationalEphemeris
[ 48%] Built target test_ephemerides_CartesianStateExtractor
[ 48%] Built target test_ephemerides_KeplerStateExtractor
Consolidate compiler generated dependencies of target test_ephemerides_KeplerEphemeris
Consolidate compiler generated dependencies of target test_ephemerides_PlanetaryRotationModel
[ 49%] Built target test_ephemerides_RotationalEphemeris
[ 49%] Built target test_ephemerides_SimpleRotationalEphemeris
Consolidate compiler generated dependencies of target test_ephemerides_TabulatedRotationalEphemeris
Consolidate compiler generated dependencies of target test_ephemerides_CompositeEphemeris
[ 49%] Built target test_ephemerides_KeplerEphemeris
Consolidate compiler generated dependencies of target test_ephemerides_FrameManager
[ 49%] Built target test_ephemerides_PlanetaryRotationModel
[ 49%] Built target test_ephemerides_TabulatedRotationalEphemeris
Consolidate compiler generated dependencies of target test_ephemerides_SynchronousRotationalEphemeris
Consolidate compiler generated dependencies of target test_ephemerides_CustomRotationalEphemeris
[ 49%] Built target test_ephemerides_CompositeEphemeris
[ 49%] Built target test_ephemerides_FrameManager
Consolidate compiler generated dependencies of target test_ephemerides_TwoLineElementsEphemeris
Consolidate compiler generated dependencies of target test_ephemerides_ItrsToGcrsRotationModel
[ 49%] Built target test_ephemerides_SynchronousRotationalEphemeris
[ 50%] Built target test_ephemerides_TwoLineElementsEphemeris
Consolidate compiler generated dependencies of target test_gravitation_SphericalHarmonicsGravityField
[ 51%] Built target test_ephemerides_CustomRotationalEphemeris
Consolidate compiler generated dependencies of target test_gravitation_JacobiEnergy
[ 51%] Built target test_ephemerides_ItrsToGcrsRotationModel
Consolidate compiler generated dependencies of target test_gravitation_CentralGravityModel
Consolidate compiler generated dependencies of target test_gravitation_UnitConversionsCircularRestrictedThreeBodyProblem
[ 51%] Built target test_gravitation_SphericalHarmonicsGravityField
Consolidate compiler generated dependencies of target test_gravitation_LibrationPoints
[ 51%] Built target test_gravitation_JacobiEnergy
[ 51%] Built target test_gravitation_CentralGravityModel
Consolidate compiler generated dependencies of target test_gravitation_SphericalHarmonicsGravityModel
Consolidate compiler generated dependencies of target test_gravitation_ThirdBodyPerturbation
[ 51%] Built target test_gravitation_UnitConversionsCircularRestrictedThreeBodyProblem
[ 51%] Built target test_gravitation_LibrationPoints
Consolidate compiler generated dependencies of target test_gravitation_TriAxialEllipsoidGravity
Consolidate compiler generated dependencies of target test_gravitation_DirectTidalDissipationAcceleration
[ 51%] Built target test_gravitation_SphericalHarmonicsGravityModel
[ 52%] Built target test_gravitation_ThirdBodyPerturbation
Consolidate compiler generated dependencies of target test_gravitation_GravityFieldVariations
[ 52%] Built target test_gravitation_TriAxialEllipsoidGravity
Consolidate compiler generated dependencies of target test_gravitation_MutualSphericalHarmonicAcceleration
Consolidate compiler generated dependencies of target test_gravitation_GravitationalTorques
[ 52%] Built target test_gravitation_DirectTidalDissipationAcceleration
[ 53%] Built target test_gravitation_GravityFieldVariations
Consolidate compiler generated dependencies of target test_gravitation_PolyhedronGravityField
Consolidate compiler generated dependencies of target test_gravitation_PolyhedronGravityModel
[ 53%] Built target test_gravitation_MutualSphericalHarmonicAcceleration
Consolidate compiler generated dependencies of target test_gravitation_RingGravityField
[ 53%] Built target test_gravitation_GravitationalTorques
[ 53%] Built target test_gravitation_PolyhedronGravityField
[ 54%] Built target test_gravitation_PolyhedronGravityModel
Consolidate compiler generated dependencies of target test_gravitation_RingGravityModel
Consolidate compiler generated dependencies of target test_ground_stations_GroundStationState
Consolidate compiler generated dependencies of target test_ground_stations_PointingAnglesCalculator
[ 54%] Built target test_gravitation_RingGravityField
Consolidate compiler generated dependencies of target test_ground_stations_Iers2010DeformationModel
[ 54%] Built target test_gravitation_RingGravityModel
[ 54%] Built target test_ground_stations_GroundStationState
[ 55%] Built target test_ground_stations_PointingAnglesCalculator
Consolidate compiler generated dependencies of target test_ground_stations_PoleTideDisplacement
Consolidate compiler generated dependencies of target test_ground_stations_OceanTideDisplacement
[ 55%] Built target test_ground_stations_Iers2010DeformationModel
Consolidate compiler generated dependencies of target test_ground_stations_TransmittingFrequencies
Consolidate compiler generated dependencies of target test_shape_based_HodographicShaping
[ 55%] Built target test_ground_stations_OceanTideDisplacement
[ 55%] Built target test_ground_stations_PoleTideDisplacement
[ 55%] Built target test_ground_stations_TransmittingFrequencies
Consolidate compiler generated dependencies of target test_shape_based_SphericalShaping
Consolidate compiler generated dependencies of target test_mission_segments_EscapeAndCaptureRoutines
Consolidate compiler generated dependencies of target test_mission_segments_GravityAssistRoutines
[ 55%] Built target test_shape_based_HodographicShaping
Consolidate compiler generated dependencies of target test_mission_segments_LambertTargeterIzzo
[ 55%] Built target test_mission_segments_EscapeAndCaptureRoutines
[ 55%] Built target test_mission_segments_GravityAssistRoutines
Consolidate compiler generated dependencies of target test_mission_segments_LambertTargeterGooding
Consolidate compiler generated dependencies of target test_mission_segments_LambertTargeter
[ 55%] Built target test_shape_based_SphericalShaping
[ 56%] Built target test_mission_segments_LambertTargeterIzzo
Consolidate compiler generated dependencies of target test_mission_segments_LambertRoutines
[ 56%] Built target test_mission_segments_LambertTargeterGooding
Consolidate compiler generated dependencies of target test_mission_segments_ZeroRevolutionLambertTargeterIzzo
[ 56%] Built target test_mission_segments_LambertTargeter
Consolidate compiler generated dependencies of target test_mission_segments_MultiRevolutionLambertTargeterIzzo
Consolidate compiler generated dependencies of target test_mission_segments_MathematicalShapeFunctions
[ 56%] Built target test_mission_segments_LambertRoutines
[ 56%] Built target test_mission_segments_ZeroRevolutionLambertTargeterIzzo
[ 57%] Built target test_mission_segments_MultiRevolutionLambertTargeterIzzo
[ 57%] Built target test_mission_segments_MathematicalShapeFunctions
Consolidate compiler generated dependencies of target test_mission_segments_CaptureLeg
Consolidate compiler generated dependencies of target test_mission_segments_DepartureLegMga
Consolidate compiler generated dependencies of target test_mission_segments_MgaDsmPosition
Consolidate compiler generated dependencies of target test_mission_segments_MgaDsmVelocity
[ 57%] Built target test_mission_segments_CaptureLeg
[ 58%] Built target test_mission_segments_DepartureLegMga
[ 58%] Built target test_mission_segments_MgaDsmVelocity
[ 58%] Built target test_mission_segments_MgaDsmPosition
Consolidate compiler generated dependencies of target test_mission_segments_SwingbyLegMga
Consolidate compiler generated dependencies of target test_mission_segments_MgaTrajectory
Consolidate compiler generated dependencies of target test_observation_models_AngularPositionModel
Consolidate compiler generated dependencies of target test_observation_models_LightTimeSolution
[ 58%] Built target test_mission_segments_SwingbyLegMga
Consolidate compiler generated dependencies of target test_observation_models_OneWayRangeModel
[ 58%] Built target test_mission_segments_MgaTrajectory
[ 58%] Built target test_observation_models_LightTimeSolution
[ 58%] Built target test_observation_models_AngularPositionModel
Consolidate compiler generated dependencies of target test_observation_models_OneWayDifferencedRangeModel
Consolidate compiler generated dependencies of target test_observation_models_DopplerModels
Consolidate compiler generated dependencies of target test_observation_models_PositionObservationModel
[ 58%] Built target test_observation_models_OneWayRangeModel
Consolidate compiler generated dependencies of target test_observation_models_EulerAngleObservationModel
[ 58%] Built target test_observation_models_DopplerModels
[ 58%] Built target test_observation_models_PositionObservationModel
[ 58%] Built target test_observation_models_OneWayDifferencedRangeModel
Consolidate compiler generated dependencies of target test_observation_models_VelocityObservationModel
Consolidate compiler generated dependencies of target test_observation_models_SimulatedObservationNoise
Consolidate compiler generated dependencies of target test_observation_models_NWayRangeObservationModel
[ 59%] Built target test_observation_models_EulerAngleObservationModel
Consolidate compiler generated dependencies of target test_observation_models_NWayRangeRateObservationModel
[ 59%] Built target test_observation_models_SimulatedObservationNoise
[ 59%] Built target test_observation_models_NWayRangeObservationModel
[ 59%] Built target test_observation_models_VelocityObservationModel
Consolidate compiler generated dependencies of target test_observation_models_DopplerMeasuredFrequencyObservationModel
Consolidate compiler generated dependencies of target test_observation_models_RelativeAngularPositionModel
Consolidate compiler generated dependencies of target test_observation_models_RelativePositionModel
[ 59%] Built target test_observation_models_NWayRangeRateObservationModel
Consolidate compiler generated dependencies of target test_observation_models_ObservationViabilityCalculators
[ 59%] Built target test_observation_models_RelativePositionModel
[ 59%] Built target test_observation_models_RelativeAngularPositionModel
[ 59%] Built target test_observation_models_DopplerMeasuredFrequencyObservationModel
Consolidate compiler generated dependencies of target test_observation_models_PerArcObservationSimulation
Consolidate compiler generated dependencies of target test_observation_models_TimeBias
Consolidate compiler generated dependencies of target test_observation_models_ClockModels
[ 59%] Built target test_observation_models_ObservationViabilityCalculators
Consolidate compiler generated dependencies of target test_observation_models_AtmosphereCorrection
[ 60%] Built target test_observation_models_PerArcObservationSimulation
[ 60%] Built target test_observation_models_TimeBias
[ 61%] Built target test_observation_models_ClockModels
Consolidate compiler generated dependencies of target test_observation_models_SolarPlasmaCorrection
Consolidate compiler generated dependencies of target test_observation_models_ObservationRoundingErrors
Consolidate compiler generated dependencies of target test_observation_models_IfmsMex
[ 61%] Built target test_observation_models_AtmosphereCorrection
[ 62%] Built target test_observation_models_SolarPlasmaCorrection
Consolidate compiler generated dependencies of target test_observation_models_ObservationDependentVariables
[ 62%] Built target test_observation_models_IfmsMex
[ 62%] Built target test_observation_models_ObservationRoundingErrors
Consolidate compiler generated dependencies of target test_observation_models_ProcessOdfData
Consolidate compiler generated dependencies of target test_observation_models_DsnNWayDopplerObservationModel
Consolidate compiler generated dependencies of target test_observation_models_DsnNWayRangeObservationModel
[ 62%] Built target test_observation_models_ProcessOdfData
[ 63%] Built target test_observation_models_ObservationDependentVariables
[ 63%] Built target test_observation_models_DsnNWayDopplerObservationModel
Consolidate compiler generated dependencies of target test_orbit_determination_EstimationInput
Consolidate compiler generated dependencies of target test_orbit_determination_EstimationFromIdealDataDoubleDouble
[ 63%] Built target test_observation_models_DsnNWayRangeObservationModel
Consolidate compiler generated dependencies of target test_orbit_determination_TidalPropertyEstimation
Consolidate compiler generated dependencies of target test_orbit_determination_HybridArcStateEstimation
[ 63%] Built target test_orbit_determination_EstimationInput
[ 63%] Building CXX object tudat/tests/src/astro/orbit_determination/CMakeFiles/test_orbit_determination_EstimationFromIdealDataDoubleDouble.dir/unitTestEstimationFromIdealDataDoubleDouble.cpp.o
[ 63%] Built target test_orbit_determination_TidalPropertyEstimation
Consolidate compiler generated dependencies of target test_orbit_determination_MultiArcStateEstimation
[ 63%] Built target test_orbit_determination_HybridArcStateEstimation
Consolidate compiler generated dependencies of target test_orbit_determination_ParameterInfluenceDetermination
Consolidate compiler generated dependencies of target test_orbit_determination_BiasEstimation
[ 63%] Building CXX object tudat/tests/src/astro/orbit_determination/CMakeFiles/test_orbit_determination_MultiArcStateEstimation.dir/unitTestMultiArcStateEstimation.cpp.o
[ 63%] Building CXX object tudat/tests/src/astro/orbit_determination/CMakeFiles/test_orbit_determination_ParameterInfluenceDetermination.dir/unitTestParameterInfluenceDetermination.cpp.o
[ 63%] Building CXX object tudat/tests/src/astro/orbit_determination/CMakeFiles/test_orbit_determination_BiasEstimation.dir/unitTestBiasEstimation.cpp.o
c++: fatal error: Killed signal terminated program cc1plus
compilation terminated.
gmake[2]: *** [tudat/tests/src/astro/orbit_determination/CMakeFiles/test_orbit_determination_EstimationFromIdealDataDoubleDouble.dir/build.make:76: tudat/tests/src/astro/orbit_determination/CMakeFiles/test_orbit_determination_EstimationFromIdealDataDoubleDouble.dir/unitTestEstimationFromIdealDataDoubleDouble.cpp.o] Error 1
gmake[1]: *** [CMakeFiles/Makefile2:8287: tudat/tests/src/astro/orbit_determination/CMakeFiles/test_orbit_determination_EstimationFromIdealDataDoubleDouble.dir/all] Error 2
gmake[1]: *** Waiting for unfinished jobs....
[ 63%] Linking CXX executable ../../../test_orbit_determination_MultiArcStateEstimation
[ 63%] Linking CXX executable ../../../test_orbit_determination_ParameterInfluenceDetermination
[ 63%] Built target test_orbit_determination_MultiArcStateEstimation
[ 63%] Built target test_orbit_determination_ParameterInfluenceDetermination
[ 63%] Linking CXX executable ../../../test_orbit_determination_BiasEstimation
[ 63%] Built target test_orbit_determination_BiasEstimation
gmake: *** [Makefile:136: all] Error 2
```

</p>
</details> 

I'm not sure if the error might somehow be related to the changes or if there are other side effects to this bug, hence the draft PR :)