### PR TITLE
Add support for geomagnetic activity flag in NRLMSISE00 settings

### DIFF
--- a/include/tudat/astro/aerodynamics/nrlmsise00Atmosphere.h
+++ b/include/tudat/astro/aerodynamics/nrlmsise00Atmosphere.h
@@ -138,7 +138,7 @@
      }
  
      NRLMSISE00Atmosphere( const tudat::input_output::solar_activity::SolarActivityDataMap solarActivityData, 
-                           const bool useIdealGasLaw = true, const int geomagneticActivity = -1 ): solarActivityContainer_( solarActivityData )
+                           const bool useIdealGasLaw = true, const int geomagneticActivity = 1 ): solarActivityContainer_( solarActivityData )
      {
          nrlmsise00InputFunction_ = std::bind( &tudat::aerodynamics::nrlmsiseInputFunction,
                                                std::placeholders::_1,
@@ -170,7 +170,7 @@
      NRLMSISE00Atmosphere( const tudat::input_output::solar_activity::SolarActivityDataMap solarActivityData,
                            const double specificHeatRatio,
                            const GasComponentProperties gasProperties,
-                           const bool useIdealGasLaw = true, const int geomagneticActivity = -1 ): solarActivityContainer_( solarActivityData )
+                           const bool useIdealGasLaw = true, const int geomagneticActivity = 1 ): solarActivityContainer_( solarActivityData )
      {
          nrlmsise00InputFunction_ = std::bind( &tudat::aerodynamics::nrlmsiseInputFunction,
                                                std::placeholders::_1,

--- a/include/tudat/astro/aerodynamics/nrlmsise00Atmosphere.h
+++ b/include/tudat/astro/aerodynamics/nrlmsise00Atmosphere.h
@@ -8,588 +8,590 @@
  *    http://tudat.tudelft.nl/LICENSE.
  */
 
-#ifndef TUDAT_NRLMSISE00_ATMOSPHERE_H
-#define TUDAT_NRLMSISE00_ATMOSPHERE_H
-
-#include <vector>
-#include <utility>
-#include <cmath>
-#include <algorithm>
-
-#include <functional>
-#include <boost/functional/hash.hpp>
-
-#include "tudat/astro/basic_astro/physicalConstants.h"
-#include "tudat/astro/aerodynamics/atmosphereModel.h"
-#include "tudat/astro/aerodynamics/aerodynamics.h"
-#include "tudat/astro/aerodynamics/nrlmsise00InputFunctions.h"
-#include "tudat/math/basic/mathematicalConstants.h"
-#include "tudat/io/solarActivityData.h"
-
-extern "C" {
-#include <nrlmsise00/nrlmsise-00.h>
-}
-
-namespace tudat
-{
-
-namespace aerodynamics
-{
-
-//! Gas component properties data structure
-/*!
- * This data structure contains the molar mass and collision diameter of
- * the most frequently observed gasses in the atmosphere.
- */
-struct GasComponentProperties {
-    //! default constructor
-    /*!
-     * Constructs a GasComponentProperties data structure with values obtained from the following sources:
-     * Collision diameters from: Tables of Physical & Chemical Constants Kaye & Laby Online, Kaye & Laby Online, 2016
-     * (http://www.kayelaby.npl.co.uk/general_physics/2_2/2_2_4.html)
-     * Molar mass from: NIST,2016 (http://www.nist.gov/pml/data/images/illo_for_2014_PT_1.PNG)
-     *
-     * Data to be verified
-     *
-     */
-    GasComponentProperties( ):
-        diameterArgon( 340E-12 ), diameterAtomicHydrogen( 260E-12 ), diameterHelium( 256E-12 ), diameterNitrogen( 370E-12 ),
-        diameterOxygen( 358E-12 ), diameterAtomicNitrogen( 290E-12 ), diameterAtomicOxygen( 280E-12 ), molarMassArgon( 39.948E-3 ),
-        molarMassAtomicHydrogen( 1.008E-3 ), molarMassHelium( 4.002602E-3 ), molarMassNitrogen( 2.0 * 14.007E-3 ),
-        molarMassOxygen( 2.0 * 15.999E-3 ), molarMassAtomicNitrogen( 14.007E-3 ), molarMassAtomicOxygen( 15.999E-3 )
-    { }
-
-    //! Molecular colision diameter of Argon in m
-    double diameterArgon;
-
-    //! Molecular colision diameter of Atomic Hydrogen in m
-    double diameterAtomicHydrogen;
-
-    //! Molecular colision diameter of Helium in m
-    double diameterHelium;
-
-    //! Molecular colision diameter of Nitrogen in m
-    double diameterNitrogen;
-
-    //! Molecular colision diameter of Oxygen in m
-    double diameterOxygen;
-
-    //! Molecular colision diameter of Atomic Nitrogen in m
-    double diameterAtomicNitrogen;
-
-    //! Molecular colision diameter of Atomic Oxygen in m
-    double diameterAtomicOxygen;
-
-    //! molar mass of Argon in kg/mole
-    double molarMassArgon;
-
-    //! Molar mass of Atomic Hydrogen in kg/mole
-    double molarMassAtomicHydrogen;
-
-    //! Molar mass of Helium in kg/mole
-    double molarMassHelium;
-
-    //! Molar mass of Nitrogen in kg/mole
-    double molarMassNitrogen;
-
-    //! Molar mass of Oxygen in kg/mole
-    double molarMassOxygen;
-
-    //! Molar mass of Atomic Nitrogen in kg/mole
-    double molarMassAtomicNitrogen;
-
-    //! Molar mass of Atomic Oxygen in kg/mole
-    double molarMassAtomicOxygen;
-};
-
-//! NRLMSISE-00 atmosphere model class.
-/*!
- *  NRLMSISE-00 atmosphere model class. This class uses the NRLMSISE00 atmosphere model to calculate atmospheric
- *  density and temperature. The GTD7 function is used: Neutral Atmosphere Empircial Model from the surface to lower
- *  exosphere.
- *  Currently the ideal gas law is used to compute the speed of sound.
- *  The specific heat ratio is assumed to be constant and equal to 1.4.
- */
-class NRLMSISE00Atmosphere : public AtmosphereModel
-{
-public:
-    //! NRLMSISEInput function
-    /*!
-     * Boost function that accepts (altitude, longitude, latitude, time ) and returns NRLMSISEInput data.
-     */
-    typedef std::function< NRLMSISE00Input( double, double, double, double ) > NRLMSISE00InputFunction;
-
-    //! Default constructor.
-    /*!
-     * Default constructor.
-     * \param nrlmsise00InputFunction Function which provides the NRLMSISE00 model input as a function of
-     * (altitude, longitude, latitude, time ).
-     * \param useIdealGasLaw Variable denoting whether to use the ideal gas law for computation of pressure.
-     */
-    NRLMSISE00Atmosphere( const NRLMSISE00InputFunction nrlmsise00InputFunction, const bool useIdealGasLaw = true ):
-        nrlmsise00InputFunction_( nrlmsise00InputFunction )
-    {
-        resetHashKey( );
-        molarGasConstant_ = tudat::physical_constants::MOLAR_GAS_CONSTANT;
-        specificHeatRatio_ = 1.4;
-        GasComponentProperties gasProperties;
-        gasComponentProperties_ = gasProperties;  // Default gas properties
-        useIdealGasLaw_ = useIdealGasLaw;
-    }
-
-    NRLMSISE00Atmosphere( const tudat::input_output::solar_activity::SolarActivityDataMap solarActivityData,
-                          const bool useIdealGasLaw = true ): solarActivityContainer_( solarActivityData )
-    {
-        nrlmsise00InputFunction_ = std::bind( &tudat::aerodynamics::nrlmsiseInputFunction,
-                                              std::placeholders::_1,
-                                              std::placeholders::_2,
-                                              std::placeholders::_3,
-                                              std::placeholders::_4,
-                                              solarActivityContainer_,
-                                              false,
-                                              TUDAT_NAN );
-
-        resetHashKey( );
-        molarGasConstant_ = tudat::physical_constants::MOLAR_GAS_CONSTANT;
-        specificHeatRatio_ = 1.4;
-        GasComponentProperties gasProperties;
-        gasComponentProperties_ = gasProperties;  // Default gas properties
-        useIdealGasLaw_ = useIdealGasLaw;
-    }
-
-    //! Constructor
-    /*!
-     * Constructor that sets the gas component properties and specific heat ratio.
-     * \param nrlmsise00InputFunction shared function pointer to provide all necessary input.
-     * \param specificHeatRatio value of the specific heat ratio.
-     * \param gasProperties a GasComponentProperties data structure that contains
-     *  the molecule collision diameters and the molar mass.
-     * \param useIdealGasLaw Boolean denoting whether the ideal gas law is to be used.
-     */
-    NRLMSISE00Atmosphere( const tudat::input_output::solar_activity::SolarActivityDataMap solarActivityData,
-                          const double specificHeatRatio,
-                          const GasComponentProperties gasProperties,
-                          const bool useIdealGasLaw = true ): solarActivityContainer_( solarActivityData )
-    {
-        nrlmsise00InputFunction_ = std::bind( &tudat::aerodynamics::nrlmsiseInputFunction,
-                                              std::placeholders::_1,
-                                              std::placeholders::_2,
-                                              std::placeholders::_3,
-                                              std::placeholders::_4,
-                                              solarActivityContainer_,
-                                              false,
-                                              TUDAT_NAN );
-
-        resetHashKey( );
-        molarGasConstant_ = tudat::physical_constants::MOLAR_GAS_CONSTANT;
-        specificHeatRatio_ = specificHeatRatio;
-        gasComponentProperties_ = gasProperties;
-        useIdealGasLaw_ = useIdealGasLaw;
-    }
-
-    //! Set gas component properties.
-    /*!
-     * Sets the gas component properties.
-     * These are required for the calculation of the speed of sound and the mean free path.
-     * \param gasComponentProperties Properties of the gas components
-     */
-    void setGasComponentProperties( const GasComponentProperties gasComponentProperties )
-    {
-        gasComponentProperties_ = gasComponentProperties;
-    }
-
-    //! Get local density.
-    /*!
-     * Returns the local density of the atmosphere in kg per meter^3.
-     * \param altitude Altitude at which density is to be computed [m].
-     * \param longitude Longitude at which density is to be computed [rad].
-     * \param latitude Latitude at which density is to be computed [rad].
-     * \param time Time at which density is to be computed (seconds since J2000).
-     * \return Atmospheric density [kg/m^3].
-     */
-    double getDensity( const double altitude, const double longitude, const double latitude, const double time )
-    {
-        computeProperties( altitude, longitude, latitude, time );
-        return density_;
-    }
-
-    //! Get local pressure.
-    /*!
-     * Returns the local pressure of the atmosphere in Newton per meter^2.
-     * The pressure is not implemented in the current version (returns NaN).
-     * \param altitude Altitude at which pressure is to be computed [m].
-     * \param longitude Longitude at which pressure is to be computed [rad].
-     * \param latitude Latitude at which pressure is to be computed [rad].
-     * \param time Time at which pressure is to be computed (seconds since J2000).
-     * \return Atmospheric pressure.
-     */
-    double getPressure( const double altitude, const double longitude, const double latitude, const double time )
-    {
-        if( useIdealGasLaw_ )
-        {
-            computeProperties( altitude, longitude, latitude, time );
-        }
-        else
-        {
-            throw std::runtime_error( "Error, non-ideal gas-law pressure-computation not yet implemented in NRLMSISE00Atmosphere." );
-        }
-        return pressure_;
-    }
-
-    //! Get local temperature.
-    /*!
-     * Returns the local temperature of the atmosphere parameter in Kelvin.
-     * \param altitude Altitude at which temperature is to be computed [m].
-     * \param longitude Longitude at which temperature is to be computed [rad].
-     * \param latitude Latitude at which temperature is to be computed [rad].
-     * \param time Time at which temperature is to be computed (seconds since J2000).
-     * \return Atmospheric temperature.
-     */
-    double getTemperature( const double altitude, const double longitude, const double latitude, const double time )
-    {
-        computeProperties( altitude, longitude, latitude, time );
-        return temperature_;
-    }
-
-    //! Get local speed of sound.
-    /*!
-     * Returns the local speed of sound in m/s.
-     * \param altitude Altitude at which speed of sound is to be computed [m].
-     * \param longitude Longitude at which speed of sound is to be computed [rad].
-     * \param latitude Latitude at whichspeed of sound is to be computed [rad].
-     * \param time Time at which speed of sound is to be computed (seconds since J2000).
-     * \return Speed of sound.
-     */
-    double getSpeedOfSound( const double altitude, const double longitude, const double latitude, const double time )
-    {
-        computeProperties( altitude, longitude, latitude, time );
-        return speedOfSound_;
-    }
-
-    //! Get local mean free path.
-    /*!
-     * Returns the local mean free path in m.
-     * \param altitude Altitude at which mean free path is to be computed [m].
-     * \param longitude Longitude at which mean free path is to be computed [rad].
-     * \param latitude Latitude at which mean free path is to be computed [rad].
-     * \param time Time at which mean free path is to be computed (seconds since J2000).
-     * \return Mean free path.
-     */
-    double getMeanFreePath( const double altitude, const double longitude, const double latitude, const double time )
-    {
-        computeProperties( altitude, longitude, latitude, time );
-        return meanFreePath_;
-    }
-
-    //! Get local mean molar mass.
-    /*!
-     * Returns the local mean molar mass in kg/mol.
-     * \param altitude Altitude at which mean molar mass is to be computed [m].
-     * \param longitude Longitude at which mean molar mass  is to be computed [rad].
-     * \param latitude Latitude at which mean molar mass  is to be computed [rad].
-     * \param time Time at which mean molar mass  is to be computed (seconds since J2000).
-     * \return mean molar mass.
-     */
-    double getMeanMolarMass( const double altitude, const double longitude, const double latitude, const double time )
-    {
-        computeProperties( altitude, longitude, latitude, time );
-        return meanMolarMass_;
-    }
-
-    //! get local number density of the gas components.
-    /*!
-     * Returns the number density of each gas component in a vector.
-     * \param altitude Altitude at which number density is to be computed [m].
-     * \param longitude Longitude at which number density is to be computed [rad].
-     * \param latitude Latitude at which number density is to be computed [rad].
-     * \param time Time at which number density is to be computed (seconds since J2000).
-     * \return Number densities of gas components
-     */
-    std::vector< double > getNumberDensities( const double altitude, const double longitude, const double latitude, const double time )
-    {
-        computeProperties( altitude, longitude, latitude, time );
-        return numberDensities_;
-    }
-
-    virtual double getNumberDensity( const AtmosphericCompositionSpecies species,
-                                     const double altitude,
-                                     const double longitude,
-                                     const double latitude,
-                                     const double time )
-    {
-        if( !( speciesIndices.count( species ) > 0 ) )
-        {
-            throw std::runtime_error( "Error, NRLMSISE00 has no dependency on species " + std::to_string( species ) + "." );
-        }
-        computeProperties( altitude, longitude, latitude, time );
-        return numberDensities_.at( speciesIndices.at( species ) );
-    }
-
-    bool doesModelDefineSpeciesNumberDensity( const AtmosphericCompositionSpecies species )
-    {
-        if( speciesIndices.count( species ) > 0 )
-        {
-            return true;
-        }
-        else
-        {
-            return false;
-        }
-    }
-
-    //! Get local average number density.
-    /*!
-     * Returns the local average number density in m^-3
-     * \param altitude Altitude at which density is to be computed [m].
-     * \param longitude Longitude at which density is to be computed [rad].
-     * \param latitude Latitude at which density is to be computed [rad].
-     * \param time Time at which density is to be computed (seconds since J2000).
-     * \return average number density.
-     */
-    double getAverageNumberDensity( const double altitude, const double longitude, const double latitude, const double time )
-    {
-        computeProperties( altitude, longitude, latitude, time );
-        return averageNumberDensity_;
-    }
-
-    //! Get local weighted average collision diameter.
-    /*!
-     * Returns the local weighted average collision diameter using the number densities as weights.
-     * \param altitude Altitude at which average collision diameter is to be computed [m].
-     * \param longitude Longitude at which average collision diameter is to be computed [rad].
-     * \param latitude Latitude at which average collision diameter is to be computed [rad].
-     * \param time Time at which average collision diameter is to be computed (seconds since J2000).
-     * \return weighted average collision diameter.
-     */
-    double getWeightedAverageCollisionDiameter( const double altitude, const double longitude, const double latitude, const double time )
-    {
-        computeProperties( altitude, longitude, latitude, time );
-        return weightedAverageCollisionDiameter_;
-    }
-
-    //! Get the full model output
-    /*!
-     * Gets the output directly from the model. This will return a
-     * pair of double vectors containing density and temperature
-     * values.
-     * \param altitude Altitude at which output is to be computed [m].
-     * \param longitude Longitude at which output is to be computed [rad].
-     * \param latitude Latitude at which output is to be computed [rad].
-     * \param time Time at which output is to be computed (seconds since J2000).
-     * \return Full density and temperature values
-     */
-    std::pair< std::vector< double >, std::vector< double > > getFullOutput( const double altitude,
-                                                                             const double longitude,
-                                                                             const double latitude,
-                                                                             const double time );
-
-    //! Reset the hash key
-    /*!
-     * Resets the hash key, this allows re-computation even if the
-     * independent parameters haven't changed. Such as in the case of
-     * changes to the model.
-     */
-    void resetHashKey( )
-    {
-        hashKey_ = 0;
-    }
-
-    input_output::solar_activity::SolarActivityContainer& getSolarActivityContainer( )
-    {
-        return solarActivityContainer_;
-    }
-
-    //! Function to get  Input data to NRLMSISE00 atmosphere model
-    /*!
-     *  Function to get input data to NRLMSISE00 atmosphere model
-     *  \return Input data to NRLMSISE00 atmosphere model
-     */
-    NRLMSISE00Input getNRLMSISE00Input( )
-    {
-        return inputData_;
-    }
-
-    NRLMSISE00InputFunction getNrlmsise00InputFunction( )
-    {
-        return nrlmsise00InputFunction_;
-    }
-
-    nrlmsise_input getNRLMSISE00InputStruct( )
-    {
-        return input_;
-    }
-
-    void setInputStruct( const double altitude, const double longitude, const double latitude, const double time );
-
-private:
-    //! Shared pointer to solar activity function
-    NRLMSISE00InputFunction nrlmsise00InputFunction_;
-
-    //! Use the ideal gas law for the computation of the pressure.
-    bool useIdealGasLaw_;
-
-    //! Current key hash
-    size_t hashKey_;
-
-    //!  Current local density (kg/m3)
-    double density_;
-
-    //! Current local temperature (K)
-    double temperature_;
-
-    //! Current local pressure (Implemented with ideal gass law only!)
-    double pressure_;
-
-    //! Current speed of sound (m/s)
-    double speedOfSound_;
-
-    //! Current mean free path (m)
-    double meanFreePath_;
-
-    /*!
-     *  Current number densities of gas components
-     *      numberDensities_[0] - HE NUMBER DENSITY     (M-3)
-     *      numberDensities_[1] - O NUMBER DENSITY      (M-3)
-     *      numberDensities_[2] - N2 NUMBER DENSITY     (M-3)
-     *      numberDensities_[3] - O2 NUMBER DENSITY     (M-3)
-     *      numberDensities_[4] - AR NUMBER DENSITY     (M-3)
-     *      numberDensities_[5] - H NUMBER DENSITY      (M-3)
-     *      numberDensities_[6] - N NUMBER DENSITY      (M-3)
-     *      numberDensities_[7] - Anomalous oxygen NUMBER DENSITY   (M-3)
-     */
-    std::vector< double > numberDensities_;
-
-    //! Current average number density (M-3)
-    double averageNumberDensity_;
-
-    //! Current weighted average of the collision diameter using the number density as weights in (M)
-    double weightedAverageCollisionDiameter_;
-
-    //! mean molar mass (kg/mole)
-    double meanMolarMass_;
-
-    //! Data structure that contains the colision diameter
-    GasComponentProperties gasComponentProperties_;
-
-    //! Specific heat ratio
-    double specificHeatRatio_;
-
-    //! Molar gas constant (J/mol K)
-    double molarGasConstant_;
-
-    //! Flags set for NRLMSISE computations
-    nrlmsise_flags flags_;
-
-    //!  Magnetic index structure of 7d array.
-    /*!
-     *   Magnetic index structure of 7d array:
-     *   0 : daily AP
-     *   1 : 3 hr AP index for current time
-     *   2 : 3 hr AP index for 3 hrs before current time
-     *   3 : 3 hr AP index for 6 hrs before current time
-     *   4 : 3 hr AP index for 9 hrs before current time
-     *   5 : Average of eight 3 hr AP indicies from 12 to 33 hrs
-     *           prior to current time
-     *   6 : Average of eight 3 hr AP indicies from 36 to 57 hrs
-     *           prior to current time
-     */
-    ap_array aph_;
-
-    //! Input structure with 10 scalar settings and magnetic values struct.
-    /*!
-     *  Input structure with 10 scalar settings and magnetic values struct.
-     *      year   - year, currently ignored           (int)
-     *      doy    - day of the year                   (int)
-     *      sec    - seconds in the day (UT)           (double)
-     *      alt    - altitude in kilometers            (double)
-     *      g_lat  - geodetic latitude in deg          (double)
-     *      g_long - geodetic longitude in deg         (double)
-     *      lst    - local apparent solar time (hours) (double)
-     *      f107A  - 81 day average of F10.7 flux (centered on doy) (double)
-     *      f107   - daily F10.7 flux for previous day (double)
-     *      ap     - magnetic index (daily)            (double)
-     *      ap_a   - magnetic index struct (see above) (ap_array)
-     */
-    nrlmsise_input input_;
-
-    //! Ouput structure of densities (9d) and temperature (2d) arrays.
-    /*!
-     *  Ouput structure of densities (9d) and temperature (2d) arrays:
-     *      d[0] - HE NUMBER DENSITY(CM-3)
-     *      d[1] - O NUMBER DENSITY(CM-3)
-     *      d[2] - N2 NUMBER DENSITY(CM-3)
-     *      d[3] - O2 NUMBER DENSITY(CM-3)
-     *      d[4] - AR NUMBER DENSITY(CM-3)
-     *      d[5] - TOTAL MASS DENSITY(GM/CM3) [includes d[8] in td7d]
-     *      d[6] - H NUMBER DENSITY(CM-3)
-     *      d[7] - N NUMBER DENSITY(CM-3)
-     *      d[8] - Anomalous oxygen NUMBER DENSITY(CM-3)
-     *      t[0] - EXOSPHERIC TEMPERATURE
-     *      t[1] - TEMPERATURE AT ALT
-     *
-     *
-     *      O, H, and N are set to zero below 72.5 km
-     *
-     *      t[0], Exospheric temperature, is set to global average for
-     *      altitudes below 120 km. The 120 km gradient is left at global
-     *      average value for altitudes below 72 km.
-     *
-     *      d[5], TOTAL MASS DENSITY, is NOT the same for subroutines GTD7
-     *      and GTD7D
-     *
-     *        SUBROUTINE GTD7 -- d[5] is the sum of the mass densities of the
-     *        species labeled by indices 0-4 and 6-7 in output variable d.
-     *        This includes He, O, N2, O2, Ar, H, and N but does NOT include
-     *        anomalous oxygen (species index 8).
-     *
-     *        SUBROUTINE GTD7D -- d[5] is the "effective total mass density
-     *        for drag" and is the sum of the mass densities of all species
-     *        in this model, INCLUDING anomalous oxygen.
-     */
-    nrlmsise_output output_;
-
-    //! Get Hash Key.
-    /*!
-     * Returns hash key value based on a vector of keys
-     * \param altitude Altitude [m].
-     * \param longitude Longitude [rad].
-     * \param latitude Latitude [rad].
-     * \param time time.
-     * \return hash key value.
-     */
-    size_t hashFunc( const double altitude, const double longitude, const double latitude, const double time )
-    {
-        size_t seed = 0;
-        boost::hash_combine( seed, boost::hash< double >( )( altitude ) );
-        boost::hash_combine( seed, boost::hash< double >( )( longitude ) );
-        boost::hash_combine( seed, boost::hash< double >( )( latitude ) );
-        boost::hash_combine( seed, boost::hash< double >( )( time ) );
-        return seed;
-    }
-
-    //! Compute the local atmospheric properties.
-    /*!
-     * Computes the local atmospheric density, pressure and temperature.
-     * \param altitude Altitude at which output is to be computed [m].
-     * \param longitude Longitude at which output is to be computed [rad].
-     * \param latitude Latitude at which output is to be computed [rad].
-     * \param time Time at which output is to be computed (seconds since J2000).
-     */
-    void computeProperties( const double altitude, const double longitude, const double latitude, const double time );
-
-    //! Input data to NRLMSISE00 atmosphere model
-    NRLMSISE00Input inputData_;
-
-    input_output::solar_activity::SolarActivityContainer solarActivityContainer_;
-
-    std::map< AtmosphericCompositionSpecies, int > speciesIndices = { { he_species, 0 }, { o_species, 1 },          { n2_species, 2 },
-                                                                      { o2_species, 3 }, { ar_species, 4 },         { h_species, 5 },
-                                                                      { n_species, 6 },  { anomalous_o_species, 7 } };
-};
-
-Eigen::VectorXd getNrlmsiseInputAsVector( const nrlmsise_input& input );
-
-}  // namespace aerodynamics
-}  // namespace tudat
-
-#endif  // TUDAT_NRLMSISE00_ATMOSPHERE_H_
+ #ifndef TUDAT_NRLMSISE00_ATMOSPHERE_H
+ #define TUDAT_NRLMSISE00_ATMOSPHERE_H
+ 
+ #include <vector>
+ #include <utility>
+ #include <cmath>
+ #include <algorithm>
+ 
+ #include <functional>
+ #include <boost/functional/hash.hpp>
+ 
+ #include "tudat/astro/basic_astro/physicalConstants.h"
+ #include "tudat/astro/aerodynamics/atmosphereModel.h"
+ #include "tudat/astro/aerodynamics/aerodynamics.h"
+ #include "tudat/astro/aerodynamics/nrlmsise00InputFunctions.h"
+ #include "tudat/math/basic/mathematicalConstants.h"
+ #include "tudat/io/solarActivityData.h"
+ 
+ extern "C" {
+ #include <nrlmsise00/nrlmsise-00.h>
+ }
+ 
+ namespace tudat
+ {
+ 
+ namespace aerodynamics
+ {
+ 
+ //! Gas component properties data structure
+ /*!
+  * This data structure contains the molar mass and collision diameter of
+  * the most frequently observed gasses in the atmosphere.
+  */
+ struct GasComponentProperties {
+     //! default constructor
+     /*!
+      * Constructs a GasComponentProperties data structure with values obtained from the following sources:
+      * Collision diameters from: Tables of Physical & Chemical Constants Kaye & Laby Online, Kaye & Laby Online, 2016
+      * (http://www.kayelaby.npl.co.uk/general_physics/2_2/2_2_4.html)
+      * Molar mass from: NIST,2016 (http://www.nist.gov/pml/data/images/illo_for_2014_PT_1.PNG)
+      *
+      * Data to be verified
+      *
+      */
+     GasComponentProperties( ):
+         diameterArgon( 340E-12 ), diameterAtomicHydrogen( 260E-12 ), diameterHelium( 256E-12 ), diameterNitrogen( 370E-12 ),
+         diameterOxygen( 358E-12 ), diameterAtomicNitrogen( 290E-12 ), diameterAtomicOxygen( 280E-12 ), molarMassArgon( 39.948E-3 ),
+         molarMassAtomicHydrogen( 1.008E-3 ), molarMassHelium( 4.002602E-3 ), molarMassNitrogen( 2.0 * 14.007E-3 ),
+         molarMassOxygen( 2.0 * 15.999E-3 ), molarMassAtomicNitrogen( 14.007E-3 ), molarMassAtomicOxygen( 15.999E-3 )
+     { }
+ 
+     //! Molecular colision diameter of Argon in m
+     double diameterArgon;
+ 
+     //! Molecular colision diameter of Atomic Hydrogen in m
+     double diameterAtomicHydrogen;
+ 
+     //! Molecular colision diameter of Helium in m
+     double diameterHelium;
+ 
+     //! Molecular colision diameter of Nitrogen in m
+     double diameterNitrogen;
+ 
+     //! Molecular colision diameter of Oxygen in m
+     double diameterOxygen;
+ 
+     //! Molecular colision diameter of Atomic Nitrogen in m
+     double diameterAtomicNitrogen;
+ 
+     //! Molecular colision diameter of Atomic Oxygen in m
+     double diameterAtomicOxygen;
+ 
+     //! molar mass of Argon in kg/mole
+     double molarMassArgon;
+ 
+     //! Molar mass of Atomic Hydrogen in kg/mole
+     double molarMassAtomicHydrogen;
+ 
+     //! Molar mass of Helium in kg/mole
+     double molarMassHelium;
+ 
+     //! Molar mass of Nitrogen in kg/mole
+     double molarMassNitrogen;
+ 
+     //! Molar mass of Oxygen in kg/mole
+     double molarMassOxygen;
+ 
+     //! Molar mass of Atomic Nitrogen in kg/mole
+     double molarMassAtomicNitrogen;
+ 
+     //! Molar mass of Atomic Oxygen in kg/mole
+     double molarMassAtomicOxygen;
+ };
+ 
+ //! NRLMSISE-00 atmosphere model class.
+ /*!
+  *  NRLMSISE-00 atmosphere model class. This class uses the NRLMSISE00 atmosphere model to calculate atmospheric
+  *  density and temperature. The GTD7 function is used: Neutral Atmosphere Empircial Model from the surface to lower
+  *  exosphere.
+  *  Currently the ideal gas law is used to compute the speed of sound.
+  *  The specific heat ratio is assumed to be constant and equal to 1.4.
+  */
+ class NRLMSISE00Atmosphere : public AtmosphereModel
+ {
+ public:
+     //! NRLMSISEInput function
+     /*!
+      * Boost function that accepts (altitude, longitude, latitude, time ) and returns NRLMSISEInput data.
+      */
+     typedef std::function< NRLMSISE00Input( double, double, double, double ) > NRLMSISE00InputFunction;
+ 
+     //! Default constructor.
+     /*!
+      * Default constructor.
+      * \param nrlmsise00InputFunction Function which provides the NRLMSISE00 model input as a function of
+      * (altitude, longitude, latitude, time ).
+      * \param useIdealGasLaw Variable denoting whether to use the ideal gas law for computation of pressure.
+      */
+     NRLMSISE00Atmosphere( const NRLMSISE00InputFunction nrlmsise00InputFunction, const bool useIdealGasLaw = true ):
+         nrlmsise00InputFunction_( nrlmsise00InputFunction )
+     {
+         resetHashKey( );
+         molarGasConstant_ = tudat::physical_constants::MOLAR_GAS_CONSTANT;
+         specificHeatRatio_ = 1.4;
+         GasComponentProperties gasProperties;
+         gasComponentProperties_ = gasProperties;  // Default gas properties
+         useIdealGasLaw_ = useIdealGasLaw;
+     }
+ 
+     NRLMSISE00Atmosphere( const tudat::input_output::solar_activity::SolarActivityDataMap solarActivityData, 
+                           const bool useIdealGasLaw = true, const int geomagneticActivity = -1 ): solarActivityContainer_( solarActivityData )
+     {
+         nrlmsise00InputFunction_ = std::bind( &tudat::aerodynamics::nrlmsiseInputFunction,
+                                               std::placeholders::_1,
+                                               std::placeholders::_2,
+                                               std::placeholders::_3,
+                                               std::placeholders::_4,
+                                               solarActivityContainer_,
+                                               false,
+                                               TUDAT_NAN,
+                                               geomagneticActivity );
+ 
+         resetHashKey( );
+         molarGasConstant_ = tudat::physical_constants::MOLAR_GAS_CONSTANT;
+         specificHeatRatio_ = 1.4;
+         GasComponentProperties gasProperties;
+         gasComponentProperties_ = gasProperties;  // Default gas properties
+         useIdealGasLaw_ = useIdealGasLaw;
+     }
+ 
+     //! Constructor
+     /*!
+      * Constructor that sets the gas component properties and specific heat ratio.
+      * \param nrlmsise00InputFunction shared function pointer to provide all necessary input.
+      * \param specificHeatRatio value of the specific heat ratio.
+      * \param gasProperties a GasComponentProperties data structure that contains
+      *  the molecule collision diameters and the molar mass.
+      * \param useIdealGasLaw Boolean denoting whether the ideal gas law is to be used.
+      */
+     NRLMSISE00Atmosphere( const tudat::input_output::solar_activity::SolarActivityDataMap solarActivityData,
+                           const double specificHeatRatio,
+                           const GasComponentProperties gasProperties,
+                           const bool useIdealGasLaw = true, const int geomagneticActivity = -1 ): solarActivityContainer_( solarActivityData )
+     {
+         nrlmsise00InputFunction_ = std::bind( &tudat::aerodynamics::nrlmsiseInputFunction,
+                                               std::placeholders::_1,
+                                               std::placeholders::_2,
+                                               std::placeholders::_3,
+                                               std::placeholders::_4,
+                                               solarActivityContainer_,
+                                               false,
+                                               TUDAT_NAN,
+                                               geomagneticActivity );
+ 
+         resetHashKey( );
+         molarGasConstant_ = tudat::physical_constants::MOLAR_GAS_CONSTANT;
+         specificHeatRatio_ = specificHeatRatio;
+         gasComponentProperties_ = gasProperties;
+         useIdealGasLaw_ = useIdealGasLaw;
+     }
+ 
+     //! Set gas component properties.
+     /*!
+      * Sets the gas component properties.
+      * These are required for the calculation of the speed of sound and the mean free path.
+      * \param gasComponentProperties Properties of the gas components
+      */
+     void setGasComponentProperties( const GasComponentProperties gasComponentProperties )
+     {
+         gasComponentProperties_ = gasComponentProperties;
+     }
+ 
+     //! Get local density.
+     /*!
+      * Returns the local density of the atmosphere in kg per meter^3.
+      * \param altitude Altitude at which density is to be computed [m].
+      * \param longitude Longitude at which density is to be computed [rad].
+      * \param latitude Latitude at which density is to be computed [rad].
+      * \param time Time at which density is to be computed (seconds since J2000).
+      * \return Atmospheric density [kg/m^3].
+      */
+     double getDensity( const double altitude, const double longitude, const double latitude, const double time )
+     {
+         computeProperties( altitude, longitude, latitude, time );
+         return density_;
+     }
+ 
+     //! Get local pressure.
+     /*!
+      * Returns the local pressure of the atmosphere in Newton per meter^2.
+      * The pressure is not implemented in the current version (returns NaN).
+      * \param altitude Altitude at which pressure is to be computed [m].
+      * \param longitude Longitude at which pressure is to be computed [rad].
+      * \param latitude Latitude at which pressure is to be computed [rad].
+      * \param time Time at which pressure is to be computed (seconds since J2000).
+      * \return Atmospheric pressure.
+      */
+     double getPressure( const double altitude, const double longitude, const double latitude, const double time )
+     {
+         if( useIdealGasLaw_ )
+         {
+             computeProperties( altitude, longitude, latitude, time );
+         }
+         else
+         {
+             throw std::runtime_error( "Error, non-ideal gas-law pressure-computation not yet implemented in NRLMSISE00Atmosphere." );
+         }
+         return pressure_;
+     }
+ 
+     //! Get local temperature.
+     /*!
+      * Returns the local temperature of the atmosphere parameter in Kelvin.
+      * \param altitude Altitude at which temperature is to be computed [m].
+      * \param longitude Longitude at which temperature is to be computed [rad].
+      * \param latitude Latitude at which temperature is to be computed [rad].
+      * \param time Time at which temperature is to be computed (seconds since J2000).
+      * \return Atmospheric temperature.
+      */
+     double getTemperature( const double altitude, const double longitude, const double latitude, const double time )
+     {
+         computeProperties( altitude, longitude, latitude, time );
+         return temperature_;
+     }
+ 
+     //! Get local speed of sound.
+     /*!
+      * Returns the local speed of sound in m/s.
+      * \param altitude Altitude at which speed of sound is to be computed [m].
+      * \param longitude Longitude at which speed of sound is to be computed [rad].
+      * \param latitude Latitude at whichspeed of sound is to be computed [rad].
+      * \param time Time at which speed of sound is to be computed (seconds since J2000).
+      * \return Speed of sound.
+      */
+     double getSpeedOfSound( const double altitude, const double longitude, const double latitude, const double time )
+     {
+         computeProperties( altitude, longitude, latitude, time );
+         return speedOfSound_;
+     }
+ 
+     //! Get local mean free path.
+     /*!
+      * Returns the local mean free path in m.
+      * \param altitude Altitude at which mean free path is to be computed [m].
+      * \param longitude Longitude at which mean free path is to be computed [rad].
+      * \param latitude Latitude at which mean free path is to be computed [rad].
+      * \param time Time at which mean free path is to be computed (seconds since J2000).
+      * \return Mean free path.
+      */
+     double getMeanFreePath( const double altitude, const double longitude, const double latitude, const double time )
+     {
+         computeProperties( altitude, longitude, latitude, time );
+         return meanFreePath_;
+     }
+ 
+     //! Get local mean molar mass.
+     /*!
+      * Returns the local mean molar mass in kg/mol.
+      * \param altitude Altitude at which mean molar mass is to be computed [m].
+      * \param longitude Longitude at which mean molar mass  is to be computed [rad].
+      * \param latitude Latitude at which mean molar mass  is to be computed [rad].
+      * \param time Time at which mean molar mass  is to be computed (seconds since J2000).
+      * \return mean molar mass.
+      */
+     double getMeanMolarMass( const double altitude, const double longitude, const double latitude, const double time )
+     {
+         computeProperties( altitude, longitude, latitude, time );
+         return meanMolarMass_;
+     }
+ 
+     //! get local number density of the gas components.
+     /*!
+      * Returns the number density of each gas component in a vector.
+      * \param altitude Altitude at which number density is to be computed [m].
+      * \param longitude Longitude at which number density is to be computed [rad].
+      * \param latitude Latitude at which number density is to be computed [rad].
+      * \param time Time at which number density is to be computed (seconds since J2000).
+      * \return Number densities of gas components
+      */
+     std::vector< double > getNumberDensities( const double altitude, const double longitude, const double latitude, const double time )
+     {
+         computeProperties( altitude, longitude, latitude, time );
+         return numberDensities_;
+     }
+ 
+     virtual double getNumberDensity( const AtmosphericCompositionSpecies species,
+                                      const double altitude,
+                                      const double longitude,
+                                      const double latitude,
+                                      const double time )
+     {
+         if( !( speciesIndices.count( species ) > 0 ) )
+         {
+             throw std::runtime_error( "Error, NRLMSISE00 has no dependency on species " + std::to_string( species ) + "." );
+         }
+         computeProperties( altitude, longitude, latitude, time );
+         return numberDensities_.at( speciesIndices.at( species ) );
+     }
+ 
+     bool doesModelDefineSpeciesNumberDensity( const AtmosphericCompositionSpecies species )
+     {
+         if( speciesIndices.count( species ) > 0 )
+         {
+             return true;
+         }
+         else
+         {
+             return false;
+         }
+     }
+ 
+     //! Get local average number density.
+     /*!
+      * Returns the local average number density in m^-3
+      * \param altitude Altitude at which density is to be computed [m].
+      * \param longitude Longitude at which density is to be computed [rad].
+      * \param latitude Latitude at which density is to be computed [rad].
+      * \param time Time at which density is to be computed (seconds since J2000).
+      * \return average number density.
+      */
+     double getAverageNumberDensity( const double altitude, const double longitude, const double latitude, const double time )
+     {
+         computeProperties( altitude, longitude, latitude, time );
+         return averageNumberDensity_;
+     }
+ 
+     //! Get local weighted average collision diameter.
+     /*!
+      * Returns the local weighted average collision diameter using the number densities as weights.
+      * \param altitude Altitude at which average collision diameter is to be computed [m].
+      * \param longitude Longitude at which average collision diameter is to be computed [rad].
+      * \param latitude Latitude at which average collision diameter is to be computed [rad].
+      * \param time Time at which average collision diameter is to be computed (seconds since J2000).
+      * \return weighted average collision diameter.
+      */
+     double getWeightedAverageCollisionDiameter( const double altitude, const double longitude, const double latitude, const double time )
+     {
+         computeProperties( altitude, longitude, latitude, time );
+         return weightedAverageCollisionDiameter_;
+     }
+ 
+     //! Get the full model output
+     /*!
+      * Gets the output directly from the model. This will return a
+      * pair of double vectors containing density and temperature
+      * values.
+      * \param altitude Altitude at which output is to be computed [m].
+      * \param longitude Longitude at which output is to be computed [rad].
+      * \param latitude Latitude at which output is to be computed [rad].
+      * \param time Time at which output is to be computed (seconds since J2000).
+      * \return Full density and temperature values
+      */
+     std::pair< std::vector< double >, std::vector< double > > getFullOutput( const double altitude,
+                                                                              const double longitude,
+                                                                              const double latitude,
+                                                                              const double time );
+ 
+     //! Reset the hash key
+     /*!
+      * Resets the hash key, this allows re-computation even if the
+      * independent parameters haven't changed. Such as in the case of
+      * changes to the model.
+      */
+     void resetHashKey( )
+     {
+         hashKey_ = 0;
+     }
+ 
+     input_output::solar_activity::SolarActivityContainer& getSolarActivityContainer( )
+     {
+         return solarActivityContainer_;
+     }
+
+     //! Function to get  Input data to NRLMSISE00 atmosphere model
+     /*!
+      *  Function to get input data to NRLMSISE00 atmosphere model
+      *  \return Input data to NRLMSISE00 atmosphere model
+      */
+     NRLMSISE00Input getNRLMSISE00Input( )
+     {
+         return inputData_;
+     }
+ 
+     NRLMSISE00InputFunction getNrlmsise00InputFunction( )
+     {
+         return nrlmsise00InputFunction_;
+     }
+ 
+     nrlmsise_input getNRLMSISE00InputStruct( )
+     {
+         return input_;
+     }
+ 
+     void setInputStruct( const double altitude, const double longitude, const double latitude, const double time );
+ 
+ private:
+     //! Shared pointer to solar activity function
+     NRLMSISE00InputFunction nrlmsise00InputFunction_;
+ 
+     //! Use the ideal gas law for the computation of the pressure.
+     bool useIdealGasLaw_;
+ 
+     //! Current key hash
+     size_t hashKey_;
+ 
+     //!  Current local density (kg/m3)
+     double density_;
+ 
+     //! Current local temperature (K)
+     double temperature_;
+ 
+     //! Current local pressure (Implemented with ideal gass law only!)
+     double pressure_;
+ 
+     //! Current speed of sound (m/s)
+     double speedOfSound_;
+ 
+     //! Current mean free path (m)
+     double meanFreePath_;
+ 
+     /*!
+      *  Current number densities of gas components
+      *      numberDensities_[0] - HE NUMBER DENSITY     (M-3)
+      *      numberDensities_[1] - O NUMBER DENSITY      (M-3)
+      *      numberDensities_[2] - N2 NUMBER DENSITY     (M-3)
+      *      numberDensities_[3] - O2 NUMBER DENSITY     (M-3)
+      *      numberDensities_[4] - AR NUMBER DENSITY     (M-3)
+      *      numberDensities_[5] - H NUMBER DENSITY      (M-3)
+      *      numberDensities_[6] - N NUMBER DENSITY      (M-3)
+      *      numberDensities_[7] - Anomalous oxygen NUMBER DENSITY   (M-3)
+      */
+     std::vector< double > numberDensities_;
+ 
+     //! Current average number density (M-3)
+     double averageNumberDensity_;
+ 
+     //! Current weighted average of the collision diameter using the number density as weights in (M)
+     double weightedAverageCollisionDiameter_;
+ 
+     //! mean molar mass (kg/mole)
+     double meanMolarMass_;
+ 
+     //! Data structure that contains the colision diameter
+     GasComponentProperties gasComponentProperties_;
+ 
+     //! Specific heat ratio
+     double specificHeatRatio_;
+ 
+     //! Molar gas constant (J/mol K)
+     double molarGasConstant_;
+ 
+     //! Flags set for NRLMSISE computations
+     nrlmsise_flags flags_;
+ 
+     //!  Magnetic index structure of 7d array.
+     /*!
+      *   Magnetic index structure of 7d array:
+      *   0 : daily AP
+      *   1 : 3 hr AP index for current time
+      *   2 : 3 hr AP index for 3 hrs before current time
+      *   3 : 3 hr AP index for 6 hrs before current time
+      *   4 : 3 hr AP index for 9 hrs before current time
+      *   5 : Average of eight 3 hr AP indicies from 12 to 33 hrs
+      *           prior to current time
+      *   6 : Average of eight 3 hr AP indicies from 36 to 57 hrs
+      *           prior to current time
+      */
+     ap_array aph_;
+ 
+     //! Input structure with 10 scalar settings and magnetic values struct.
+     /*!
+      *  Input structure with 10 scalar settings and magnetic values struct.
+      *      year   - year, currently ignored           (int)
+      *      doy    - day of the year                   (int)
+      *      sec    - seconds in the day (UT)           (double)
+      *      alt    - altitude in kilometers            (double)
+      *      g_lat  - geodetic latitude in deg          (double)
+      *      g_long - geodetic longitude in deg         (double)
+      *      lst    - local apparent solar time (hours) (double)
+      *      f107A  - 81 day average of F10.7 flux (centered on doy) (double)
+      *      f107   - daily F10.7 flux for previous day (double)
+      *      ap     - magnetic index (daily)            (double)
+      *      ap_a   - magnetic index struct (see above) (ap_array)
+      */
+     nrlmsise_input input_;
+ 
+     //! Ouput structure of densities (9d) and temperature (2d) arrays.
+     /*!
+      *  Ouput structure of densities (9d) and temperature (2d) arrays:
+      *      d[0] - HE NUMBER DENSITY(CM-3)
+      *      d[1] - O NUMBER DENSITY(CM-3)
+      *      d[2] - N2 NUMBER DENSITY(CM-3)
+      *      d[3] - O2 NUMBER DENSITY(CM-3)
+      *      d[4] - AR NUMBER DENSITY(CM-3)
+      *      d[5] - TOTAL MASS DENSITY(GM/CM3) [includes d[8] in td7d]
+      *      d[6] - H NUMBER DENSITY(CM-3)
+      *      d[7] - N NUMBER DENSITY(CM-3)
+      *      d[8] - Anomalous oxygen NUMBER DENSITY(CM-3)
+      *      t[0] - EXOSPHERIC TEMPERATURE
+      *      t[1] - TEMPERATURE AT ALT
+      *
+      *
+      *      O, H, and N are set to zero below 72.5 km
+      *
+      *      t[0], Exospheric temperature, is set to global average for
+      *      altitudes below 120 km. The 120 km gradient is left at global
+      *      average value for altitudes below 72 km.
+      *
+      *      d[5], TOTAL MASS DENSITY, is NOT the same for subroutines GTD7
+      *      and GTD7D
+      *
+      *        SUBROUTINE GTD7 -- d[5] is the sum of the mass densities of the
+      *        species labeled by indices 0-4 and 6-7 in output variable d.
+      *        This includes He, O, N2, O2, Ar, H, and N but does NOT include
+      *        anomalous oxygen (species index 8).
+      *
+      *        SUBROUTINE GTD7D -- d[5] is the "effective total mass density
+      *        for drag" and is the sum of the mass densities of all species
+      *        in this model, INCLUDING anomalous oxygen.
+      */
+     nrlmsise_output output_;
+ 
+     //! Get Hash Key.
+     /*!
+      * Returns hash key value based on a vector of keys
+      * \param altitude Altitude [m].
+      * \param longitude Longitude [rad].
+      * \param latitude Latitude [rad].
+      * \param time time.
+      * \return hash key value.
+      */
+     size_t hashFunc( const double altitude, const double longitude, const double latitude, const double time )
+     {
+         size_t seed = 0;
+         boost::hash_combine( seed, boost::hash< double >( )( altitude ) );
+         boost::hash_combine( seed, boost::hash< double >( )( longitude ) );
+         boost::hash_combine( seed, boost::hash< double >( )( latitude ) );
+         boost::hash_combine( seed, boost::hash< double >( )( time ) );
+         return seed;
+     }
+ 
+     //! Compute the local atmospheric properties.
+     /*!
+      * Computes the local atmospheric density, pressure and temperature.
+      * \param altitude Altitude at which output is to be computed [m].
+      * \param longitude Longitude at which output is to be computed [rad].
+      * \param latitude Latitude at which output is to be computed [rad].
+      * \param time Time at which output is to be computed (seconds since J2000).
+      */
+     void computeProperties( const double altitude, const double longitude, const double latitude, const double time );
+ 
+     //! Input data to NRLMSISE00 atmosphere model
+     NRLMSISE00Input inputData_;
+ 
+     input_output::solar_activity::SolarActivityContainer solarActivityContainer_;
+ 
+     std::map< AtmosphericCompositionSpecies, int > speciesIndices = { { he_species, 0 }, { o_species, 1 },          { n2_species, 2 },
+                                                                       { o2_species, 3 }, { ar_species, 4 },         { h_species, 5 },
+                                                                       { n_species, 6 },  { anomalous_o_species, 7 } };
+ };
+ 
+ Eigen::VectorXd getNrlmsiseInputAsVector( const nrlmsise_input& input );
+ 
+ }  // namespace aerodynamics
+ }  // namespace tudat
+ 
+ #endif  // TUDAT_NRLMSISE00_ATMOSPHERE_H_

--- a/include/tudat/astro/aerodynamics/nrlmsise00InputFunctions.h
+++ b/include/tudat/astro/aerodynamics/nrlmsise00InputFunctions.h
@@ -8,118 +8,119 @@
  *    http://tudat.tudelft.nl/LICENSE.
  */
 
-#ifndef TUDAT_NRLMSISE00_INPUT_FUNCTIONS_H
-#define TUDAT_NRLMSISE00_INPUT_FUNCTIONS_H
-
-#include <vector>
-#include <cmath>
-
-#include "tudat/io/solarActivityData.h"
-
-namespace tudat
-{
-
-namespace aerodynamics
-{
-
-//! Struct for Solar Activity data.
-/*!
- *
- */
-struct NRLMSISE00Input {
-    //! Input for computation of NRLMSISE00 atmospheric conditions at current time and position.
-    /*!
-     * Input for computation of NRLMSISE00 atmospheric conditions at current time and position. The computation of
-     * this struct may be reperformed every time step, to reflect the changes in atmospheric condition.
-     * \param year Current year
-     * \param dayOfTheYear Day in the current year
-     * \param secondOfTheDay Number of seconds into the current day.
-     * \param localSolarTime Local solar time at the computation position
-     * \param f107 Current daily F10.7 flux for previous day
-     * \param f107a 81 day average of F10.7 flux (centered on current dayOfTheYear).
-     * \param apDaily Current daily magnetic index
-     * \param apVector Current magnetic index data vector: \sa ap_array
-     * \param switches List of NRLMSISE-specific flags: \sa nrlmsise_flags
-     */
-    NRLMSISE00Input( int year = 0,
-                     int dayOfTheYear = 0,
-                     double secondOfTheDay = 0.0,
-                     double localSolarTime = 0.0,
-                     double f107 = 0.0,
-                     double f107a = 0.0,
-                     double apDaily = 0.0,
-                     std::vector< double > apVector = std::vector< double >( 6, 0.0 ),
-                     std::vector< int > switches = std::vector< int >( ) ):
-        year( year ), dayOfTheYear( dayOfTheYear ), secondOfTheDay( secondOfTheDay ), localSolarTime( localSolarTime ), f107( f107 ),
-        f107a( f107a ), apDaily( apDaily ), apVector( apVector ), switches( switches )
-    {
-        if( switches.empty( ) )
-        {
-            this->switches = std::vector< int >( 24, 1 );
-            this->switches[ 0 ] = 0;
-            this->switches[ 9 ] = -1;
-        }
-    }
-
-    //! Current year
-    int year;
-
-    //! Day in the current year
-    int dayOfTheYear;
-
-    //! Number of seconds into the current day.
-    double secondOfTheDay;
-
-    //! Local solar time at the computation position
-    double localSolarTime;
-
-    //! Current daily F10.7 flux for previous day
-    double f107;
-
-    //! 81 day average of F10.7 flux (centered on current dayOfTheYear).
-    double f107a;
-
-    //! Current daily magnetic index
-    double apDaily;
-
-    //! Current magnetic index data vector: \sa ap_array
-    std::vector< double > apVector;
-
-    //! List of NRLMSISE-specific flags: \sa nrlmsise_flag
-    std::vector< int > switches;
-};
-
-//! NRLMSISE00 Input function
-/*!
- * This function is used to define the input for the NRLMSISE model.
- * This function reads solar activity data and defines the input using this data.
- * \param altitude Altitude at which output is to be computed [m].
- * \param longitude Longitude at which output is to be computed [rad].
- * \param latitude Latitude at which output is to be computed [rad].
- * \param time Time at which output is to be computed (seconds since J2000).
- * \param solarActivityMap SolarActivityData structure
- * \param adjustSolarTime Boolean denoting whether the computed local solar time should be overidden with localSolarTime
- * input.
- * \param localSolarTime Local solar time that is used when adjustSolarTime is set to true.
- * \return NRLMSISE00Input nrlmsiseInputFunction
- */
-NRLMSISE00Input nrlmsiseInputFunctionFromMap( const double altitude,
-                                              const double longitude,
-                                              const double latitude,
-                                              const double time,
-                                              const tudat::input_output::solar_activity::SolarActivityDataMap& solarActivityMap,
-                                              const bool adjustSolarTime = false,
-                                              const double localSolarTime = 0.0 );
-
-NRLMSISE00Input nrlmsiseInputFunction( const double altitude,
-                                       const double longitude,
-                                       const double latitude,
-                                       const double time,
-                                       const tudat::input_output::solar_activity::SolarActivityContainer& solarActivityContainer,
-                                       const bool adjustSolarTime = false,
-                                       const double localSolarTime = 0.0 );
-
-}  // namespace aerodynamics
-}  // namespace tudat
-
-#endif  // TUDAT_NRLMSISE00_ATMOSPHERE_H_
+ #ifndef TUDAT_NRLMSISE00_INPUT_FUNCTIONS_H
+ #define TUDAT_NRLMSISE00_INPUT_FUNCTIONS_H
+ 
+ #include <vector>
+ #include <cmath>
+ 
+ #include "tudat/io/solarActivityData.h"
+ 
+ namespace tudat
+ {
+ 
+ namespace aerodynamics
+ {
+ 
+ //! Struct for Solar Activity data.
+ /*!
+  *
+  */
+ struct NRLMSISE00Input {
+     //! Input for computation of NRLMSISE00 atmospheric conditions at current time and position.
+     /*!
+      * Input for computation of NRLMSISE00 atmospheric conditions at current time and position. The computation of
+      * this struct may be reperformed every time step, to reflect the changes in atmospheric condition.
+      * \param year Current year
+      * \param dayOfTheYear Day in the current year
+      * \param secondOfTheDay Number of seconds into the current day.
+      * \param localSolarTime Local solar time at the computation position
+      * \param f107 Current daily F10.7 flux for previous day
+      * \param f107a 81 day average of F10.7 flux (centered on current dayOfTheYear).
+      * \param apDaily Current daily magnetic index
+      * \param apVector Current magnetic index data vector: \sa ap_array
+      * \param switches List of NRLMSISE-specific flags: \sa nrlmsise_flags
+      */
+     NRLMSISE00Input( int year = 0,
+                      int dayOfTheYear = 0,
+                      double secondOfTheDay = 0.0,
+                      double localSolarTime = 0.0,
+                      double f107 = 0.0,
+                      double f107a = 0.0,
+                      double apDaily = 0.0,
+                      std::vector< double > apVector = std::vector< double >( 6, 0.0 ),
+                      std::vector< int > switches = std::vector< int >( ) ):
+         year( year ), dayOfTheYear( dayOfTheYear ), secondOfTheDay( secondOfTheDay ), localSolarTime( localSolarTime ), f107( f107 ),
+         f107a( f107a ), apDaily( apDaily ), apVector( apVector ), switches( switches )
+         {
+            if( switches.empty( ) )
+            {
+                this->switches = std::vector< int >( 24, 1 );
+                this->switches[ 0 ] = 0;
+                this->switches[ 9 ] = -1;
+            }
+         }
+ 
+     //! Current year
+     int year;
+ 
+     //! Day in the current year
+     int dayOfTheYear;
+ 
+     //! Number of seconds into the current day.
+     double secondOfTheDay;
+ 
+     //! Local solar time at the computation position
+     double localSolarTime;
+ 
+     //! Current daily F10.7 flux for previous day
+     double f107;
+ 
+     //! 81 day average of F10.7 flux (centered on current dayOfTheYear).
+     double f107a;
+ 
+     //! Current daily magnetic index
+     double apDaily;
+ 
+     //! Current magnetic index data vector: \sa ap_array
+     std::vector< double > apVector;
+ 
+     //! List of NRLMSISE-specific flags: \sa nrlmsise_flag
+     std::vector< int > switches;
+ };
+ 
+ //! NRLMSISE00 Input function
+ /*!
+  * This function is used to define the input for the NRLMSISE model.
+  * This function reads solar activity data and defines the input using this data.
+  * \param altitude Altitude at which output is to be computed [m].
+  * \param longitude Longitude at which output is to be computed [rad].
+  * \param latitude Latitude at which output is to be computed [rad].
+  * \param time Time at which output is to be computed (seconds since J2000).
+  * \param solarActivityMap SolarActivityData structure
+  * \param adjustSolarTime Boolean denoting whether the computed local solar time should be overidden with localSolarTime
+  * input.
+  * \param localSolarTime Local solar time that is used when adjustSolarTime is set to true.
+  * \return NRLMSISE00Input nrlmsiseInputFunction
+  */
+ NRLMSISE00Input nrlmsiseInputFunctionFromMap( const double altitude,
+                                               const double longitude,
+                                               const double latitude,
+                                               const double time,
+                                               const tudat::input_output::solar_activity::SolarActivityDataMap& solarActivityMap,
+                                               const bool adjustSolarTime = false,
+                                               const double localSolarTime = 0.0 );
+ 
+ NRLMSISE00Input nrlmsiseInputFunction( const double altitude,
+                                        const double longitude,
+                                        const double latitude,
+                                        const double time,
+                                        const tudat::input_output::solar_activity::SolarActivityContainer& solarActivityContainer,
+                                        const bool adjustSolarTime = false,
+                                        const double localSolarTime = 0.0,
+                                        const int geomagneticActivity = -1 );
+ 
+ }  // namespace aerodynamics
+ }  // namespace tudat
+ 
+ #endif  // TUDAT_NRLMSISE00_ATMOSPHERE_H_

--- a/include/tudat/astro/aerodynamics/nrlmsise00InputFunctions.h
+++ b/include/tudat/astro/aerodynamics/nrlmsise00InputFunctions.h
@@ -118,7 +118,7 @@
                                         const tudat::input_output::solar_activity::SolarActivityContainer& solarActivityContainer,
                                         const bool adjustSolarTime = false,
                                         const double localSolarTime = 0.0,
-                                        const int geomagneticActivity = -1 );
+                                        const int geomagneticActivity = 1 );
  
  }  // namespace aerodynamics
  }  // namespace tudat

--- a/include/tudat/io/solarActivityData.h
+++ b/include/tudat/io/solarActivityData.h
@@ -16,270 +16,276 @@
  *
  */
 
-#ifndef TUDAT_SOLAR_ACTIVITY_DATA_H
-#define TUDAT_SOLAR_ACTIVITY_DATA_H
-
-#include <string>
-#include <map>
-
-#include <Eigen/Core>
-
-#include <memory>
-
-#include "tudat/astro/basic_astro/timeConversions.h"
-#include "tudat/basics/utilities.h"
-#include "tudat/math/interpolators/lookupScheme.h"
-#include "tudat/astro/basic_astro/timeConversions.h"
-
-namespace tudat
-{
-namespace input_output
-{
-namespace solar_activity
-{
-
-//! Solar activity data class.
-/*!
- * Class containing all variables provided in the http://celestrak.com/SpaceData/sw19571001.txt
- * file, describing "space weather" on each day since October 1957. See reference for details on
- * variables.
- */
-struct SolarActivityData {
-public:
-    //! Default constructor.
-    /*!
-     * Default constructor.
-     */
-    SolarActivityData( const int yearInput = 0, const int monthInput = 0, const int dayInput = 0 );
-
-    //! Year.
-    unsigned int year;
-
-    //! Month.
-    unsigned int month;
-
-    //! Day.
-    unsigned int day;
-
-    //! Bartels Solar Rotation Number.
-    unsigned int bartelsSolarRotationNumber;
-
-    //! Day within the Bartels 27-day cycle (01-27).
-    unsigned int dayOfBartelsCycle;
-
-    //! Sum of the 8 planetary range indices.
-    /*! Sum of the 8 planetary range indices (Kp) for the day expressed to the nearest third of a
-     *   unit.
-     */
-    unsigned int planetaryRangeIndexSum;
-
-    //! Arithmetic average of the 8 planetary equivalent amplitudes (Ap) indices for the day.
-    unsigned int planetaryEquivalentAmplitudeAverage;
-
-    //! Cp or Planetary Daily Character Figure.
-    /*! A qualitative estimate of overall level of magnetic activity for the day determined from
-     *  the sum of the 8 Ap indices. planetaryDailyCharacterFigure ranges, in steps of one-tenth,
-     *  from 0 (quiet) to 2.5 (highly disturbed).
-     */
-    double planetaryDailyCharacterFigure;
-
-    //! planetaryDailyCharacterFigureConverted.
-    /*! A conversion of the 0-to-2.5 range of the planetaryDailyCharacterFigure index to one digit
-     *  between 0 and 9.
-     */
-    unsigned int planetaryDailyCharacterFigureConverted;
-
-    //! International sunspot number.
-    /*! International sunspot number. Records contain the Zurich number through 1980 Dec 31 and
-     * the International Brussels
-     * number thereafter.
-     */
-    unsigned int internationalSunspotNumber;
-
-    //! 10.7-cm Solar Radio Flux (F10.7) Adjusted to 1 AU.
-    /*! 10.7-cm Solar Radio Flux (F10.7) measured at Ottawa at 1700 UT daily from 1947 Feb 14
-     * until 1991 May 31 and measured at Penticton at 2000 UT from 1991 Jun 01 on.
-     * Expressed in units of 10-22 W/m2/Hz.
-     */
-    double solarRadioFlux107Adjusted;
-
-    //! Flux Qualifier.
-    /*! Flux Qualifier with one of following values:
-     * 0 indicates flux required no adjustment;
-     * 1 indicates flux required adjustment for burst in progress at time of measurement;
-     * 2 indicates a flux approximated by either interpolation or extrapolation;
-     * 3 indicates no observation; and
-     * 4 indicates CSSI interpolation of missing data.
-     */
-    unsigned int fluxQualifier;
-
-    //! Centered 81-day arithmetic average of F10.7 (adjusted).
-    /*! Centered 81-day arithmetic average of F10.7, adjusted to 1 AU.
-     */
-    double centered81DaySolarRadioFlux107Adjusted;
-
-    //! Last 81-day arithmetic average of F10.7 (adjusted).
-    /*! Last 81-day arithmetic average of F10.7, adjusted to 1 AU.
-     */
-    double last81DaySolarRadioFlux107Adjusted;
-
-    //! Observed (unadjusted) value of F10.7.
-    double solarRadioFlux107Observed;
-
-    //! Centered 81-day arithmetic average of F10.7 (observed).
-    double centered81DaySolarRadioFlux107Observed;
-
-    //! Last 81-day arithmetic average of F10.7 (observed).
-    double last81DaySolarRadioFlux107Observed;
-
-    //! Vector containing 3-hourly planetary range indices (Kp).
-    /*! Vector of eight 3-hourly planetary range indices.
-     */
-    Eigen::VectorXd planetaryRangeIndexVector;
-
-    //! Vector containing 3-hourly planetary equivalent amplitude indices (Ap).
-    /*! Vector of eight 3-hourly planetary equivalent amplitude indices.
-     */
-    Eigen::VectorXd planetaryEquivalentAmplitudeVector;
-
-    //! String defining line's data-type
-    /*! 1: "Observed"
-     *  2: "Daily Predicted"
-     *  3: "Monthly Predicted"
-     *  4: "Monthly Fit"
-     */
-    unsigned int dataType;
-
-    //! Overloaded ostream to print class information.
-    /*! Overloaded ostream to print class information; prints all converted Solar Activity
-     * variables listed in the http://celestrak.com/SpaceData/sw19571001.txt file.
-     */
-    friend std::ostream& operator<<( std::ostream& stream, SolarActivityData& solarActivityData );
-
-protected:
-private:
-};
-
-//! Pointer to a SolarActivityData structure
-typedef std::shared_ptr< SolarActivityData > SolarActivityDataPtr;
-
-//! Data map of SolarActivityData structure Pointers
-typedef std::map< double, SolarActivityDataPtr > SolarActivityDataMap;
-
-struct SolarActivityContainer {
-
-    SolarActivityContainer( ):currentJulianDay_( TUDAT_NAN ), nearestJulianDay_( TUDAT_NAN ){ }
-
-    SolarActivityContainer( const std::map< double, SolarActivityDataPtr >& solarActivityDataMap ):
-        solarActivityDataMap_( solarActivityDataMap ), currentJulianDay_( TUDAT_NAN ), nearestJulianDay_( TUDAT_NAN )
-    {
-        lookUpScheme_ = std::make_shared< interpolators::BinarySearchLookupScheme< double > >(
-                utilities::createVectorFromMapKeys( solarActivityDataMap ) );
-    }
-
-    std::shared_ptr< SolarActivityData > getSolarActivityData( const double time ) const
-    {
-        currentJulianDay_ = basic_astrodynamics::convertSecondsSinceEpochToJulianDay( time );
-        return getSolarActivityDataAtJulianDay( );
-    }
-
-    std::shared_ptr< SolarActivityData > getDelayedSolarActivityData( const double time, const double delayInDays ) const
-    {
-        currentJulianDay_ = basic_astrodynamics::convertSecondsSinceEpochToJulianDay( time ) - delayInDays;
-        return getSolarActivityDataAtJulianDay( );
-    }
-
-    void getDelayedApValues( const double time, std::vector< double >& delayedApValues ) const
-    {
-        std::shared_ptr< SolarActivityData > activityData = getSolarActivityData( time );
-        double julianDayFraction = currentJulianDay_ - nearestJulianDay_;
-        int currentDayApIndex = std::floor( julianDayFraction * 8.0 );
-        delayedApValues[ 0 ] = activityData->planetaryEquivalentAmplitudeVector( currentDayApIndex );
-
-        std::shared_ptr< SolarActivityData > activityDataOneDayOld = getDelayedSolarActivityData( time, 1.0 );
-        for( int i = 1; i < 4; i++ )
-        {
-            int currentIndex = currentDayApIndex - i;
-            if( currentIndex >= 0 )
+ #ifndef TUDAT_SOLAR_ACTIVITY_DATA_H
+ #define TUDAT_SOLAR_ACTIVITY_DATA_H
+ 
+ #include <string>
+ #include <map>
+ 
+ #include <Eigen/Core>
+ 
+ #include <memory>
+ 
+ #include "tudat/astro/basic_astro/timeConversions.h"
+ #include "tudat/basics/utilities.h"
+ #include "tudat/math/interpolators/lookupScheme.h"
+ #include "tudat/astro/basic_astro/timeConversions.h"
+ 
+ namespace tudat
+ {
+ namespace input_output
+ {
+ namespace solar_activity
+ {
+ 
+ //! Solar activity data class.
+ /*!
+  * Class containing all variables provided in the http://celestrak.com/SpaceData/sw19571001.txt
+  * file, describing "space weather" on each day since October 1957. See reference for details on
+  * variables.
+  */
+ struct SolarActivityData {
+ public:
+     //! Default constructor.
+     /*!
+      * Default constructor.
+      */
+     SolarActivityData( const int yearInput = 0, const int monthInput = 0, const int dayInput = 0 );
+ 
+     //! Year.
+     unsigned int year;
+ 
+     //! Month.
+     unsigned int month;
+ 
+     //! Day.
+     unsigned int day;
+ 
+     //! Bartels Solar Rotation Number.
+     unsigned int bartelsSolarRotationNumber;
+ 
+     //! Day within the Bartels 27-day cycle (01-27).
+     unsigned int dayOfBartelsCycle;
+ 
+     //! Sum of the 8 planetary range indices.
+     /*! Sum of the 8 planetary range indices (Kp) for the day expressed to the nearest third of a
+      *   unit.
+      */
+     unsigned int planetaryRangeIndexSum;
+ 
+     //! Arithmetic average of the 8 planetary equivalent amplitudes (Ap) indices for the day.
+     unsigned int planetaryEquivalentAmplitudeAverage;
+ 
+     //! Cp or Planetary Daily Character Figure.
+     /*! A qualitative estimate of overall level of magnetic activity for the day determined from
+      *  the sum of the 8 Ap indices. planetaryDailyCharacterFigure ranges, in steps of one-tenth,
+      *  from 0 (quiet) to 2.5 (highly disturbed).
+      */
+     double planetaryDailyCharacterFigure;
+ 
+     //! planetaryDailyCharacterFigureConverted.
+     /*! A conversion of the 0-to-2.5 range of the planetaryDailyCharacterFigure index to one digit
+      *  between 0 and 9.
+      */
+     unsigned int planetaryDailyCharacterFigureConverted;
+ 
+     //! International sunspot number.
+     /*! International sunspot number. Records contain the Zurich number through 1980 Dec 31 and
+      * the International Brussels
+      * number thereafter.
+      */
+     unsigned int internationalSunspotNumber;
+ 
+     //! 10.7-cm Solar Radio Flux (F10.7) Adjusted to 1 AU.
+     /*! 10.7-cm Solar Radio Flux (F10.7) measured at Ottawa at 1700 UT daily from 1947 Feb 14
+      * until 1991 May 31 and measured at Penticton at 2000 UT from 1991 Jun 01 on.
+      * Expressed in units of 10-22 W/m2/Hz.
+      */
+     double solarRadioFlux107Adjusted;
+ 
+     //! Flux Qualifier.
+     /*! Flux Qualifier with one of following values:
+      * 0 indicates flux required no adjustment;
+      * 1 indicates flux required adjustment for burst in progress at time of measurement;
+      * 2 indicates a flux approximated by either interpolation or extrapolation;
+      * 3 indicates no observation; and
+      * 4 indicates CSSI interpolation of missing data.
+      */
+     unsigned int fluxQualifier;
+ 
+     //! Centered 81-day arithmetic average of F10.7 (adjusted).
+     /*! Centered 81-day arithmetic average of F10.7, adjusted to 1 AU.
+      */
+     double centered81DaySolarRadioFlux107Adjusted;
+ 
+     //! Last 81-day arithmetic average of F10.7 (adjusted).
+     /*! Last 81-day arithmetic average of F10.7, adjusted to 1 AU.
+      */
+     double last81DaySolarRadioFlux107Adjusted;
+ 
+     //! Observed (unadjusted) value of F10.7.
+     double solarRadioFlux107Observed;
+ 
+     //! Centered 81-day arithmetic average of F10.7 (observed).
+     double centered81DaySolarRadioFlux107Observed;
+ 
+     //! Last 81-day arithmetic average of F10.7 (observed).
+     double last81DaySolarRadioFlux107Observed;
+ 
+     //! Vector containing 3-hourly planetary range indices (Kp).
+     /*! Vector of eight 3-hourly planetary range indices.
+      */
+     Eigen::VectorXd planetaryRangeIndexVector;
+ 
+     //! Vector containing 3-hourly planetary equivalent amplitude indices (Ap).
+     /*! Vector of eight 3-hourly planetary equivalent amplitude indices.
+      */
+     Eigen::VectorXd planetaryEquivalentAmplitudeVector;
+ 
+     //! String defining line's data-type
+     /*! 1: "Observed"
+      *  2: "Daily Predicted"
+      *  3: "Monthly Predicted"
+      *  4: "Monthly Fit"
+      */
+     unsigned int dataType;
+ 
+     //! Overloaded ostream to print class information.
+     /*! Overloaded ostream to print class information; prints all converted Solar Activity
+      * variables listed in the http://celestrak.com/SpaceData/sw19571001.txt file.
+      */
+     friend std::ostream& operator<<( std::ostream& stream, SolarActivityData& solarActivityData );
+ 
+ protected:
+ private:
+ };
+ 
+ //! Pointer to a SolarActivityData structure
+ typedef std::shared_ptr< SolarActivityData > SolarActivityDataPtr;
+ 
+ //! Data map of SolarActivityData structure Pointers
+ typedef std::map< double, SolarActivityDataPtr > SolarActivityDataMap;
+ 
+ struct SolarActivityContainer {
+ 
+     SolarActivityContainer( ):currentJulianDay_( TUDAT_NAN ), nearestJulianDay_( TUDAT_NAN ){ }
+ 
+     SolarActivityContainer( const std::map< double, SolarActivityDataPtr >& solarActivityDataMap ):
+         solarActivityDataMap_( solarActivityDataMap ), currentJulianDay_( TUDAT_NAN ), nearestJulianDay_( TUDAT_NAN )
+     {
+         lookUpScheme_ = std::make_shared< interpolators::BinarySearchLookupScheme< double > >(
+                 utilities::createVectorFromMapKeys( solarActivityDataMap ) );
+     }
+ 
+     std::shared_ptr< SolarActivityData > getSolarActivityData( const double time ) const
+     {
+         currentJulianDay_ = basic_astrodynamics::convertSecondsSinceEpochToJulianDay( time );
+         return getSolarActivityDataAtJulianDay( );
+     }
+ 
+     std::shared_ptr< SolarActivityData > getDelayedSolarActivityData( const double time, const double delayInDays ) const
+     {
+         currentJulianDay_ = basic_astrodynamics::convertSecondsSinceEpochToJulianDay( time ) - delayInDays;
+         return getSolarActivityDataAtJulianDay( );
+     }
+ 
+     void getDelayedApValues( const double time, std::vector< double >& delayedApValues ) const
+     {
+         std::shared_ptr< SolarActivityData > activityData = getSolarActivityData( time );
+         double julianDayFraction = currentJulianDay_ - nearestJulianDay_;
+         int currentDayApIndex = std::floor( julianDayFraction * 8.0 );
+         delayedApValues[ 0 ] = activityData->planetaryEquivalentAmplitudeVector( currentDayApIndex );
+ 
+         std::shared_ptr< SolarActivityData > activityDataOneDayOld = getDelayedSolarActivityData( time, 1.0 );
+         for( int i = 1; i < 4; i++ )
+         {
+             int currentIndex = currentDayApIndex - i;
+             if( currentIndex >= 0 )
+             {
+                 delayedApValues[ i ] = activityData->planetaryEquivalentAmplitudeVector( currentIndex );
+             }
+             else
+             {
+                 delayedApValues[ i ] = activityDataOneDayOld->planetaryEquivalentAmplitudeVector( currentIndex + 8 );
+             }
+         }
+ 
+         std::shared_ptr< SolarActivityData > activityDataTwoDayOld = getDelayedSolarActivityData( time, 2.0 );
+         std::shared_ptr< SolarActivityData > activityDataThreeDayOld = getDelayedSolarActivityData( time, 3.0 );
+ 
+         for( int j = 0; j < 2; j++ )
+         {
+             double averagedValue = 0.0;
+             for ( int i = 4 + j * 8; i < 12 + j * 8; i++ )
+             {
+                 int currentIndex = currentDayApIndex - i;
+                 if ( currentIndex >= 0 )
+                 {
+                     averagedValue += activityData->planetaryEquivalentAmplitudeVector( currentIndex );
+                 }
+                 else if ( currentIndex >= -8 )
+                 {
+                     averagedValue += activityDataOneDayOld->planetaryEquivalentAmplitudeVector( currentIndex + 8 );
+                 }
+                 else if ( currentIndex >= -16 )
+                 {
+                     averagedValue += activityDataTwoDayOld->planetaryEquivalentAmplitudeVector( currentIndex + 16 );
+                 }
+                 else
+                 {
+                     averagedValue += activityDataThreeDayOld->planetaryEquivalentAmplitudeVector( currentIndex + 24 );
+                 }
+             }
+             delayedApValues[ 4 + j ] = averagedValue / 8.0;
+         }
+     }
+ 
+     std::map< double, SolarActivityDataPtr > getSolarActivityDataMap( ) const
+     {
+         return solarActivityDataMap_;
+     }
+ 
+ private:
+ 
+     std::shared_ptr< SolarActivityData > getSolarActivityDataAtJulianDay( ) const
+     {
+         nearestJulianDay_ = lookUpScheme_->getIndependentVariableValue( lookUpScheme_->findNearestLowerNeighbour( currentJulianDay_ ) );
+         if( nearestJulianDay_ > currentJulianDay_ || currentJulianDay_ > nearestJulianDay_ + 1.0 )
+         {
+            if( !hasShownJulianDayWarning_ )
             {
-                delayedApValues[ i ] = activityData->planetaryEquivalentAmplitudeVector( currentIndex );
+                std::cerr << "[WARNING] Solar activity data lookup: Julian day out of bounds. "
+                          << "Nearest day = " << nearestJulianDay_
+                          << ", Requested day = " << currentJulianDay_
+                          << ", Difference = " << nearestJulianDay_ - currentJulianDay_ << std::endl;
+                hasShownJulianDayWarning_ = true;
             }
-            else
-            {
-                delayedApValues[ i ] = activityDataOneDayOld->planetaryEquivalentAmplitudeVector( currentIndex + 8 );
-            }
-        }
+         }
+         return solarActivityDataMap_.at( nearestJulianDay_ );
+     }
+ 
+     std::map< double, SolarActivityDataPtr > solarActivityDataMap_;
+ 
+     std::shared_ptr< interpolators::LookUpScheme< double > > lookUpScheme_;
+ 
+     mutable double currentJulianDay_;
+ 
+     mutable double nearestJulianDay_;
 
-        std::shared_ptr< SolarActivityData > activityDataTwoDayOld = getDelayedSolarActivityData( time, 2.0 );
-        std::shared_ptr< SolarActivityData > activityDataThreeDayOld = getDelayedSolarActivityData( time, 3.0 );
-
-        for( int j = 0; j < 2; j++ )
-        {
-            double averagedValue = 0.0;
-            for ( int i = 4 + j * 8; i < 12 + j * 8; i++ )
-            {
-                int currentIndex = currentDayApIndex - i;
-                if ( currentIndex >= 0 )
-                {
-                    averagedValue += activityData->planetaryEquivalentAmplitudeVector( currentIndex );
-                }
-                else if ( currentIndex >= -8 )
-                {
-                    averagedValue += activityDataOneDayOld->planetaryEquivalentAmplitudeVector( currentIndex + 8 );
-                }
-                else if ( currentIndex >= -16 )
-                {
-                    averagedValue += activityDataTwoDayOld->planetaryEquivalentAmplitudeVector( currentIndex + 16 );
-                }
-                else
-                {
-                    averagedValue += activityDataThreeDayOld->planetaryEquivalentAmplitudeVector( currentIndex + 24 );
-                }
-            }
-            delayedApValues[ 4 + j ] = averagedValue / 8.0;
-        }
-    }
-
-    std::map< double, SolarActivityDataPtr > getSolarActivityDataMap( ) const
-    {
-        return solarActivityDataMap_;
-    }
-
-private:
-
-    std::shared_ptr< SolarActivityData > getSolarActivityDataAtJulianDay( ) const
-    {
-        nearestJulianDay_ = lookUpScheme_->getIndependentVariableValue( lookUpScheme_->findNearestLowerNeighbour( currentJulianDay_ ) );
-        if( nearestJulianDay_ > currentJulianDay_ || currentJulianDay_ > nearestJulianDay_ + 1.0 )
-        {
-            throw std::runtime_error(
-                "Error when getting current Julian day for solar activity; data is incompatible " +
-                std::to_string( nearestJulianDay_ ) + " " + std::to_string( currentJulianDay_ ) + " " +
-                std::to_string( nearestJulianDay_ - currentJulianDay_ ));
-        }
-        return solarActivityDataMap_.at( nearestJulianDay_ );
-    }
-
-    std::map< double, SolarActivityDataPtr > solarActivityDataMap_;
-
-    std::shared_ptr< interpolators::LookUpScheme< double > > lookUpScheme_;
-
-    mutable double currentJulianDay_;
-
-    mutable double nearestJulianDay_;
-};
-
-//! Function that reads a SpaceWeather data file
-/*!
- * This function reads a SpaceWeather data file and returns a map with SolarActivityData
- *
- * \param filePath std::string
- * \return solarActivityDataMap std::map< double , SolarActivityDataPtr >
- */
-SolarActivityDataMap readSolarActivityData( std::string filePath );
-
-}  // namespace solar_activity
-}  // namespace input_output
-}  // namespace tudat
-
-#endif  // TUDAT_SOLAR_ACTIVITY_DATA_H
+     mutable bool hasShownJulianDayWarning_ = false;
+ };
+ 
+ //! Function that reads a SpaceWeather data file
+ /*!
+  * This function reads a SpaceWeather data file and returns a map with SolarActivityData
+  *
+  * \param filePath std::string
+  * \return solarActivityDataMap std::map< double , SolarActivityDataPtr >
+  */
+ SolarActivityDataMap readSolarActivityData( std::string filePath );
+ 
+ }  // namespace solar_activity
+ }  // namespace input_output
+ }  // namespace tudat
+ 
+ #endif  // TUDAT_SOLAR_ACTIVITY_DATA_H

--- a/include/tudat/simulation/environment_setup/createAtmosphereModel.h
+++ b/include/tudat/simulation/environment_setup/createAtmosphereModel.h
@@ -8,1054 +8,1073 @@
  *    http://tudat.tudelft.nl/LICENSE.
  */
 
-#ifndef TUDAT_CREATEATMOSPHEREMODEL_H
-#define TUDAT_CREATEATMOSPHEREMODEL_H
-
-#include <string>
-#include <map>
-
-#include <memory>
-
-#include "tudat/io/basicInputOutput.h"
-#include "tudat/astro/aerodynamics/atmosphereModel.h"
-#include "tudat/astro/aerodynamics/exponentialAtmosphere.h"
-#include "tudat/astro/aerodynamics/customConstantTemperatureAtmosphere.h"
-#include "tudat/astro/basic_astro/physicalConstants.h"
-#include "tudat/math/interpolators/interpolator.h"
-#include "tudat/basics/identityElements.h"
-
-namespace tudat
-{
-
-namespace simulation_setup
-{
-
-using namespace aerodynamics;
-
-//  List of wind models available in simulations
-/*
- *  List of wind models available in simulations. Wind models not defined by this
- *  given enum cannot be used for automatic model setup.
- */
-enum WindModelTypes { constant_wind_model, custom_wind_model };
-
-//  Class for providing settings for wind model.
-/*
- *  Class for providing settings for automatic wind model creation. This class is a
- *  functional (base) class for settings of wind models that require no information in
- *  addition to their type. Wind model classes defining requiring additional information
- *  must be created using an object derived from this class.
- */
-//! @get_docstring(WindModelSettings.__docstring__)
-class WindModelSettings
-{
-public:
-    //  Constructor
-    /*
-     * Constructor
-     * \param windModelType Type of wind model that is to be created
+ #ifndef TUDAT_CREATEATMOSPHEREMODEL_H
+ #define TUDAT_CREATEATMOSPHEREMODEL_H
+ 
+ #include <string>
+ #include <map>
+ 
+ #include <memory>
+ 
+ #include "tudat/io/basicInputOutput.h"
+ #include "tudat/astro/aerodynamics/atmosphereModel.h"
+ #include "tudat/astro/aerodynamics/exponentialAtmosphere.h"
+ #include "tudat/astro/aerodynamics/customConstantTemperatureAtmosphere.h"
+ #include "tudat/astro/basic_astro/physicalConstants.h"
+ #include "tudat/math/interpolators/interpolator.h"
+ #include "tudat/basics/identityElements.h"
+ 
+ namespace tudat
+ {
+ 
+ namespace simulation_setup
+ {
+ 
+ using namespace aerodynamics;
+ 
+ //  List of wind models available in simulations
+ /*
+  *  List of wind models available in simulations. Wind models not defined by this
+  *  given enum cannot be used for automatic model setup.
+  */
+ enum WindModelTypes { constant_wind_model, custom_wind_model };
+ 
+ //  Class for providing settings for wind model.
+ /*
+  *  Class for providing settings for automatic wind model creation. This class is a
+  *  functional (base) class for settings of wind models that require no information in
+  *  addition to their type. Wind model classes defining requiring additional information
+  *  must be created using an object derived from this class.
+  */
+ //! @get_docstring(WindModelSettings.__docstring__)
+ class WindModelSettings
+ {
+ public:
+     //  Constructor
+     /*
+      * Constructor
+      * \param windModelType Type of wind model that is to be created
+      */
+     WindModelSettings( const WindModelTypes windModelType,
+                        const reference_frames::AerodynamicsReferenceFrames associatedFrame = reference_frames::vertical_frame ):
+         windModelType_( windModelType ), associatedFrame_( associatedFrame )
+     { }
+ 
+     //  Destructor
+     virtual ~WindModelSettings( ) { }
+ 
+     //  Function to retrieve type of wind model that is to be created
+     /*
+      * Function to retrieve type of wind model that is to be created
+      * \return Type of wind model that is to be created
+      */
+     WindModelTypes getWindModelType( )
+     {
+         return windModelType_;
+     }
+ 
+     reference_frames::AerodynamicsReferenceFrames getAssociatedFrame( )
+     {
+         return associatedFrame_;
+     }
+ 
+ protected:
+     //  Type of wind model that is to be created
+     WindModelTypes windModelType_;
+ 
+     reference_frames::AerodynamicsReferenceFrames associatedFrame_;
+ };
+ 
+ class ConstantWindModelSettings : public WindModelSettings
+ {
+ public:
+     ConstantWindModelSettings( const Eigen::Vector3d constantWindVelocity,
+                                const reference_frames::AerodynamicsReferenceFrames associatedFrame = reference_frames::vertical_frame ):
+         WindModelSettings( constant_wind_model, associatedFrame ), constantWindVelocity_( constantWindVelocity )
+     { }
+ 
+     Eigen::Vector3d getConstantWindVelocity( )
+     {
+         return constantWindVelocity_;
+     }
+ 
+ private:
+     Eigen::Vector3d constantWindVelocity_;
+ };
+ 
+ //  Class to define settings for a custom, user-defined, wind model
+ class CustomWindModelSettings : public WindModelSettings
+ {
+ public:
+     //  Constructor
+     /*
+      * Constructor
+      * \param windFunction Function that returns wind vector as a function of altitude, longitude, latitude and time (in that
+      * order).
+      */
+     CustomWindModelSettings( const std::function< Eigen::Vector3d( const double, const double, const double, const double ) > windFunction,
+                              const reference_frames::AerodynamicsReferenceFrames associatedFrame = reference_frames::vertical_frame ):
+         WindModelSettings( custom_wind_model, associatedFrame ), windFunction_( windFunction )
+     { }
+ 
+     //  Destructor
+     ~CustomWindModelSettings( ) { }
+ 
+     //  Function to retrieve function that returns wind vector as a function of altitude, longitude, latitude and time
+     /*
+      * Function to retrieve function that returns wind vector as a function of altitude, longitude, latitude and time
+      * \return Function that returns wind vector as a function of altitude, longitude, latitude and time
+      */
+     std::function< Eigen::Vector3d( const double, const double, const double, const double ) > getWindFunction( )
+     {
+         return windFunction_;
+     }
+ 
+     //  Function to reset function that returns wind vector as a function of altitude, longitude, latitude and time
+     /*
+      * Function to reset function that returns wind vector as a function of altitude, longitude, latitude and time
+      * \param windFunction New function that returns wind vector as a function of altitude, longitude, latitude and time
+      */
+     void setWindFunction( const std::function< Eigen::Vector3d( const double, const double, const double, const double ) > windFunction )
+     {
+         windFunction_ = windFunction;
+     }
+ 
+ protected:
+     //  Function that returns wind vector as a function of altitude, longitude, latitude and time (in that order).
+     std::function< Eigen::Vector3d( const double, const double, const double, const double ) > windFunction_;
+ };
+ 
+ //  List of atmosphere models available in simulations
+ /*
+  *  List of atmosphere models available in simulations. Atmosphere models not defined by this
+  *  given enum cannot be used for automatic model setup.
+  */
+ enum AtmosphereTypes {
+     exponential_atmosphere,
+     custom_constant_temperature_atmosphere,
+     tabulated_atmosphere,
+     nrlmsise00,
+     scaled_atmosphere
+ };
+ 
+ //  Class for providing settings for atmosphere model.
+ /*
+  *  Class for providing settings for automatic atmosphere model creation. This class is a
+  *  functional (base) class for settings of atmosphere models that require no information in
+  *  addition to their type. Atmosphere model classes defining requiring additional information
+  *  must be created using an object derived from this class.
+  */
+ //! @get_docstring(AtmosphereSettings.__docstring__)
+ class AtmosphereSettings
+ {
+ public:
+     //  Constructor, sets type of atmosphere model.
+     /*
+      *  Constructor, sets type of atmosphere model. Settings for atmosphere models requiring
+      *  additional information should be defined in a derived class.
+      *  \param atmosphereType Type of atmosphere model that is to be created.
+      */
+     AtmosphereSettings( const AtmosphereTypes atmosphereType ): atmosphereType_( atmosphereType ) { }
+ 
+     //  Destructor
+     virtual ~AtmosphereSettings( ) { }
+ 
+     //  Function to return type of atmosphere model that is to be created.
+     /*
+      *  Function to return type of atmosphere model that is to be created.
+      *  \return Type of atmosphere model that is to be created.
+      */
+     AtmosphereTypes getAtmosphereType( )
+     {
+         return atmosphereType_;
+     }
+ 
+     //  Function to return settings for the atmosphere's wind model.
+     /*
+      *  Function to return settings for the atmosphere's wind model.
+      *  \return Settings for the atmosphere's wind model.
+      */
+     std::shared_ptr< WindModelSettings > getWindSettings( )
+     {
+         return windSettings_;
+     }
+ 
+     //  Function to (re)set settings for the atmosphere's wind model.
+     /*
+      *  Function to (re)set settings for the atmosphere's wind model.
+      *  \param windSettings Settings for the atmosphere's wind model.
+      */
+     void setWindSettings( const std::shared_ptr< WindModelSettings > windSettings )
+     {
+         windSettings_ = windSettings;
+     }
+ 
+ private:
+     //   Type of atmosphere model that is to be created.
+     AtmosphereTypes atmosphereType_;
+ 
+     //  Settings for the atmosphere's wind model.
+     std::shared_ptr< WindModelSettings > windSettings_;
+ };
+ 
+ //  AtmosphereSettings for defining an exponential atmosphere.
+ //! @get_docstring(ExponentialAtmosphereSettings.__docstring__)
+ class ExponentialAtmosphereSettings : public AtmosphereSettings
+ {
+ public:
+     //  Default constructor.
+     /*
+      *  Default constructor, taking full atmosphere model parameters.
+      *  \param densityScaleHeight Scale height for density profile of atmosphere.
+      *  \param constantTemperature Constant atmospheric temperature.
+      *  \param densityAtZeroAltitude Atmospheric density at ground level.
+      *  \param specificGasConstant Specific gas constant for (constant) atmospheric chemical
+      *  composition.
+      *  \param ratioOfSpecificHeats Ratio of specific heats for (constant) atmospheric chemical
+      *  composition.
+      */
+     ExponentialAtmosphereSettings( const double densityScaleHeight,
+                                    const double constantTemperature,
+                                    const double densityAtZeroAltitude,
+                                    const double specificGasConstant = physical_constants::SPECIFIC_GAS_CONSTANT_AIR,
+                                    const double ratioOfSpecificHeats = 1.4 ):
+         AtmosphereSettings( exponential_atmosphere ), densityScaleHeight_( densityScaleHeight ),
+         constantTemperature_( constantTemperature ), densityAtZeroAltitude_( densityAtZeroAltitude ),
+         specificGasConstant_( specificGasConstant ), ratioOfSpecificHeats_( ratioOfSpecificHeats ),
+         bodyWithPredefinedExponentialAtmosphere_( undefined_body )
+     { }
+ 
+     //  Default constructor.
+     /*
+      *  Default constructor, taking only the name of the body for which to load the predefined
+      *  exponential atmosphere model parameters.
+      *  \param bodyWithPredefinedExponentialAtmosphere Enumeration denoting the name of the body for which the
+      *  predefined atmosphere model is to be loaded.
+      */
+     ExponentialAtmosphereSettings( const BodiesWithPredefinedExponentialAtmospheres bodyWithPredefinedExponentialAtmosphere ):
+         AtmosphereSettings( exponential_atmosphere ), bodyWithPredefinedExponentialAtmosphere_( bodyWithPredefinedExponentialAtmosphere )
+     {
+         // Check that the body name inserted is available
+         switch( bodyWithPredefinedExponentialAtmosphere )
+         {
+             case earth:
+             case mars:
+                 // all is good
+                 break;
+             default:
+                 throw std::runtime_error(
+                         "Error while creating exponential atmosphere. The body name provided "
+                         "does not match any predefined atmosphere model. Available models for: "
+                         "Earth, Mars." );
+         }
+     }
+ 
+     //  Function to return scale heigh for density profile of atmosphere.
+     /*
+      *  Function to return scale heigh for density profile of atmosphere.
+      *  \return Scale heigh for density profile of atmosphere.
+      */
+     double getDensityScaleHeight( )
+     {
+         return densityScaleHeight_;
+     }
+ 
+     //  Function to return constant atmospheric temperature.
+     /*
+      *  Function to return constant atmospheric temperature.
+      *  \return Constant atmospheric temperature.
+      */
+     double getConstantTemperature( )
+     {
+         return constantTemperature_;
+     }
+ 
+     //  Function to return atmospheric density at ground level.
+     /*
+      *  Function to return atmospheric density at ground level.
+      *  \return Atmospheric density at ground level.
+      */
+     double getDensityAtZeroAltitude( )
+     {
+         return densityAtZeroAltitude_;
+     }
+ 
+     //  Function to return specific gas constant for (constant) atmospheric chemical
+     /*
+      *  Function to return specific gas constant for (constant) atmospheric chemical
+      *  \return Specific gas constant for (constant) atmospheric chemical
+      */
+     double getSpecificGasConstant( )
+     {
+         return specificGasConstant_;
+     }
+ 
+     //  Function to return ratio of specific heats for (constant) atmospheric chemical
+     /*
+      *  Function to return ratio of specific heats for (constant) atmospheric chemical
+      *  \return Specific gas constant for (constant) atmospheric chemical
+      */
+     double getRatioOfSpecificHeats( )
+     {
+         return ratioOfSpecificHeats_;
+     }
+ 
+     //  Function to return the name of the body for which to load the predefined
+     //  atmosphere model parameters.
+     BodiesWithPredefinedExponentialAtmospheres getBodyName( )
+     {
+         return bodyWithPredefinedExponentialAtmosphere_;
+     }
+ 
+ private:
+     //  Scale heigh for density profile of atmosphere.
+     double densityScaleHeight_;
+ 
+     //  Constant atmospheric temperature.
+     double constantTemperature_;
+ 
+     //  Atmospheric density at ground level.
+     double densityAtZeroAltitude_;
+ 
+     //  Specific gas constant for (constant) atmospheric chemical
+     double specificGasConstant_;
+ 
+     //  Ratio of specific heats for (constant) atmospheric chemical
+     double ratioOfSpecificHeats_;
+ 
+     //  Enumeration denoting the name of the body for which to load the predefined
+     //  atmosphere model.
+     BodiesWithPredefinedExponentialAtmospheres bodyWithPredefinedExponentialAtmosphere_;
+ };
+ 
+ //  AtmosphereSettings for defining custom constant temperature atmosphere.
+ class CustomConstantTemperatureAtmosphereSettings : public AtmosphereSettings
+ {
+ public:
+     //  Typedef for density function.
+     typedef std::function< double( const double, const double, const double, const double ) > DensityFunction;
+ 
+     //  Default constructor.
+     /*
+      *  Default constructor setting all parameters manually.
+      *  \param densityFunction Function to retireve the density at the current altitude,
+      *      longitude, latitude and time.
+      *  \param constantTemperature Constant atmospheric temperature.
+      *  \param specificGasConstant The constant specific gas constant of the atmosphere.
+      *  \param ratioOfSpecificHeats The constant ratio of specific heats of the atmosphere.
+      */
+     CustomConstantTemperatureAtmosphereSettings( const DensityFunction& densityFunction,
+                                                  const double constantTemperature,
+                                                  const double specificGasConstant = physical_constants::SPECIFIC_GAS_CONSTANT_AIR,
+                                                  const double ratioOfSpecificHeats = 1.4 ):
+         AtmosphereSettings( custom_constant_temperature_atmosphere ), densityFunction_( densityFunction ),
+         constantTemperature_( constantTemperature ), specificGasConstant_( specificGasConstant ),
+         ratioOfSpecificHeats_( ratioOfSpecificHeats )
+     { }
+ 
+     //  Constructor.
+     /*
+      *  Constructor which uses one of the built-in density functions as input.
+      *  \param densityFunctionType Enumeration denoting which density function to implement.
+      *  \param constantTemperature Constant atmospheric temperature.
+      *  \param specificGasConstant The constant specific gas constant of the atmosphere.
+      *  \param ratioOfSpecificHeats The constant ratio of specific heats of the atmosphere.
+      *  \param modelSpecificParameters Vector of parameters to be used to set up the density
+      *      function. Both meaning and number of parameters depends on the model.
+      */
+     CustomConstantTemperatureAtmosphereSettings( const AvailableConstantTemperatureAtmosphereModels densityFunctionType,
+                                                  const double constantTemperature,
+                                                  const double specificGasConstant,
+                                                  const double ratioOfSpecificHeats,
+                                                  const std::vector< double >& modelSpecificParameters ):
+         AtmosphereSettings( custom_constant_temperature_atmosphere ), densityFunctionType_( densityFunctionType ),
+         constantTemperature_( constantTemperature ), specificGasConstant_( specificGasConstant ),
+         ratioOfSpecificHeats_( ratioOfSpecificHeats ), modelSpecificParameters_( modelSpecificParameters )
+     { }
+ 
+     //  Get the function to compute the density at the current conditions.
+     /*
+      *  Get the function to compute the density at the current conditions.
+      *  \return Function to compute the density at the current conditions.
+      */
+     DensityFunction getDensityFunction( )
+     {
+         return densityFunction_;
+     }
+ 
+     //  Get the type of function to compute the density at the current conditions.
+     /*
+      *  Get the type of function to compute the density at the current conditions.
+      *  \return Type of function to compute the density at the current conditions.
+      */
+     AvailableConstantTemperatureAtmosphereModels getDensityFunctionType( )
+     {
+         return densityFunctionType_;
+     }
+ 
+     //  Get constant temperature.
+     /*
+      *  Returns the atmospheric temperature (constant, property of exponential atmosphere) in
+      *  Kelvin.
+      *  \return constantTemperature Constant atmospheric temperature in exponential atmosphere.
+      */
+     double getConstantTemperature( )
+     {
+         return constantTemperature_;
+     }
+ 
+     //  Get specific gas constant.
+     /*
+      *  Returns the specific gas constant of the atmosphere in J/(kg K), its value is assumed constant,
+      *  due to the assumption of constant atmospheric composition.
+      *  \return Specific gas constant in exponential atmosphere.
+      */
+     double getSpecificGasConstant( )
+     {
+         return specificGasConstant_;
+     }
+ 
+     //  Get ratio of specific heats.
+     /*
+      *  Returns the ratio of specific hears of the atmosphere, its value is assumed constant,
+      *  due to the assumption of constant atmospheric composition.
+      *  \return Ratio of specific heats exponential atmosphere.
+      */
+     double getRatioOfSpecificHeats( )
+     {
+         return ratioOfSpecificHeats_;
+     }
+ 
+     //  Get model specific parameters.
+     /*
+      *  Get model specific parameters.
+      *  \return Vector of parameters to be used to set up the density function.
+      */
+     std::vector< double > getModelSpecificParameters( )
+     {
+         return modelSpecificParameters_;
+     }
+ 
+ private:
+     //  Function to compute the density at the current conditions.
+     /*
+      *  Function to compute the density at the current conditions. Note that the independent
+      *  variables need to be altitude, longitude, latitude and time, in this precise order.
+      */
+     DensityFunction densityFunction_;
+ 
+     //  Enumeration denoting which density function to implement.
+     /*
+      *  Enumeration denoting which density function to implement
+      */
+     AvailableConstantTemperatureAtmosphereModels densityFunctionType_;
+ 
+     //  Constant temperature.
+     /*
+      *  The atmospheric temperature (constant, property of exponential atmosphere) in Kelvin.
+      */
+     const double constantTemperature_;
+ 
+     //  Specific gas constant.
+     /*
+      *  Specific gas constant of the atmosphere, its value is assumed constant, due to the
+      *  assumption of constant atmospheric composition.
+      */
+     const double specificGasConstant_;
+ 
+     //  Ratio of specific heats at constant pressure and constant volume.
+     /*
+      *  Ratio of specific heats of the atmosphere at constant pressure and constant volume.
+      *  This value is set to a constant, implying constant atmospheric composition.
+      */
+     const double ratioOfSpecificHeats_;
+ 
+     //  Vector of parameters to be used to set up the density function.
+     /*
+      *  Vector of parameters to be used to set up the density function. Both meaning and number of parameters depends on the model.
+      */
+     std::vector< double > modelSpecificParameters_;
+ };
+ 
+ //  AtmosphereSettings for defining an NRLMSISE00 atmosphere reading space weather data from a text file.
+ class NRLMSISE00AtmosphereSettings : public AtmosphereSettings
+ {
+ public:
+     //  Constructor.
+     /*
+      *  Constructor.
+      *  \param spaceWeatherFile File containing space weather data, as in
+      *  https://celestrak.com/SpaceData/sw19571001.txt
+      */
+     NRLMSISE00AtmosphereSettings( const std::string& spaceWeatherFile, const int geomagneticActivity = -1 ):
+             AtmosphereSettings( nrlmsise00 ), spaceWeatherFile_( spaceWeatherFile ), geomagneticActivity_( geomagneticActivity ) 
+     { }
+ 
+     //  Function to return file containing space weather data.
+     /*
+      *  Function to return file containing space weather data.
+      *  \return Filename containing space weather data.
+      */
+     std::string getSpaceWeatherFile( )
+     {
+         return spaceWeatherFile_;
+     }
+ 
+     //  Function to return geomagnetic activity setting.
+     /*
+      *  Function to return geomagnetic activity setting.
+      *  \return Geomagnetic activity value.
      */
-    WindModelSettings( const WindModelTypes windModelType,
-                       const reference_frames::AerodynamicsReferenceFrames associatedFrame = reference_frames::vertical_frame ):
-        windModelType_( windModelType ), associatedFrame_( associatedFrame )
-    { }
-
-    //  Destructor
-    virtual ~WindModelSettings( ) { }
-
-    //  Function to retrieve type of wind model that is to be created
-    /*
-     * Function to retrieve type of wind model that is to be created
-     * \return Type of wind model that is to be created
-     */
-    WindModelTypes getWindModelType( )
-    {
-        return windModelType_;
-    }
-
-    reference_frames::AerodynamicsReferenceFrames getAssociatedFrame( )
-    {
-        return associatedFrame_;
-    }
-
-protected:
-    //  Type of wind model that is to be created
-    WindModelTypes windModelType_;
-
-    reference_frames::AerodynamicsReferenceFrames associatedFrame_;
-};
-
-class ConstantWindModelSettings : public WindModelSettings
-{
-public:
-    ConstantWindModelSettings( const Eigen::Vector3d constantWindVelocity,
-                               const reference_frames::AerodynamicsReferenceFrames associatedFrame = reference_frames::vertical_frame ):
-        WindModelSettings( constant_wind_model, associatedFrame ), constantWindVelocity_( constantWindVelocity )
-    { }
-
-    Eigen::Vector3d getConstantWindVelocity( )
-    {
-        return constantWindVelocity_;
-    }
-
-private:
-    Eigen::Vector3d constantWindVelocity_;
-};
-
-//  Class to define settings for a custom, user-defined, wind model
-class CustomWindModelSettings : public WindModelSettings
-{
-public:
-    //  Constructor
-    /*
-     * Constructor
-     * \param windFunction Function that returns wind vector as a function of altitude, longitude, latitude and time (in that
-     * order).
-     */
-    CustomWindModelSettings( const std::function< Eigen::Vector3d( const double, const double, const double, const double ) > windFunction,
-                             const reference_frames::AerodynamicsReferenceFrames associatedFrame = reference_frames::vertical_frame ):
-        WindModelSettings( custom_wind_model, associatedFrame ), windFunction_( windFunction )
-    { }
-
-    //  Destructor
-    ~CustomWindModelSettings( ) { }
-
-    //  Function to retrieve function that returns wind vector as a function of altitude, longitude, latitude and time
-    /*
-     * Function to retrieve function that returns wind vector as a function of altitude, longitude, latitude and time
-     * \return Function that returns wind vector as a function of altitude, longitude, latitude and time
-     */
-    std::function< Eigen::Vector3d( const double, const double, const double, const double ) > getWindFunction( )
-    {
-        return windFunction_;
-    }
-
-    //  Function to reset function that returns wind vector as a function of altitude, longitude, latitude and time
-    /*
-     * Function to reset function that returns wind vector as a function of altitude, longitude, latitude and time
-     * \param windFunction New function that returns wind vector as a function of altitude, longitude, latitude and time
-     */
-    void setWindFunction( const std::function< Eigen::Vector3d( const double, const double, const double, const double ) > windFunction )
-    {
-        windFunction_ = windFunction;
-    }
-
-protected:
-    //  Function that returns wind vector as a function of altitude, longitude, latitude and time (in that order).
-    std::function< Eigen::Vector3d( const double, const double, const double, const double ) > windFunction_;
-};
-
-//  List of atmosphere models available in simulations
-/*
- *  List of atmosphere models available in simulations. Atmosphere models not defined by this
- *  given enum cannot be used for automatic model setup.
- */
-enum AtmosphereTypes {
-    exponential_atmosphere,
-    custom_constant_temperature_atmosphere,
-    tabulated_atmosphere,
-    nrlmsise00,
-    scaled_atmosphere
-};
-
-//  Class for providing settings for atmosphere model.
-/*
- *  Class for providing settings for automatic atmosphere model creation. This class is a
- *  functional (base) class for settings of atmosphere models that require no information in
- *  addition to their type. Atmosphere model classes defining requiring additional information
- *  must be created using an object derived from this class.
- */
-//! @get_docstring(AtmosphereSettings.__docstring__)
-class AtmosphereSettings
-{
-public:
-    //  Constructor, sets type of atmosphere model.
-    /*
-     *  Constructor, sets type of atmosphere model. Settings for atmosphere models requiring
-     *  additional information should be defined in a derived class.
-     *  \param atmosphereType Type of atmosphere model that is to be created.
-     */
-    AtmosphereSettings( const AtmosphereTypes atmosphereType ): atmosphereType_( atmosphereType ) { }
-
-    //  Destructor
-    virtual ~AtmosphereSettings( ) { }
-
-    //  Function to return type of atmosphere model that is to be created.
-    /*
-     *  Function to return type of atmosphere model that is to be created.
-     *  \return Type of atmosphere model that is to be created.
-     */
-    AtmosphereTypes getAtmosphereType( )
-    {
-        return atmosphereType_;
-    }
-
-    //  Function to return settings for the atmosphere's wind model.
-    /*
-     *  Function to return settings for the atmosphere's wind model.
-     *  \return Settings for the atmosphere's wind model.
-     */
-    std::shared_ptr< WindModelSettings > getWindSettings( )
-    {
-        return windSettings_;
-    }
-
-    //  Function to (re)set settings for the atmosphere's wind model.
-    /*
-     *  Function to (re)set settings for the atmosphere's wind model.
-     *  \param windSettings Settings for the atmosphere's wind model.
-     */
-    void setWindSettings( const std::shared_ptr< WindModelSettings > windSettings )
-    {
-        windSettings_ = windSettings;
-    }
-
-private:
-    //   Type of atmosphere model that is to be created.
-    AtmosphereTypes atmosphereType_;
-
-    //  Settings for the atmosphere's wind model.
-    std::shared_ptr< WindModelSettings > windSettings_;
-};
-
-//  AtmosphereSettings for defining an exponential atmosphere.
-//! @get_docstring(ExponentialAtmosphereSettings.__docstring__)
-class ExponentialAtmosphereSettings : public AtmosphereSettings
-{
-public:
-    //  Default constructor.
-    /*
-     *  Default constructor, taking full atmosphere model parameters.
-     *  \param densityScaleHeight Scale height for density profile of atmosphere.
-     *  \param constantTemperature Constant atmospheric temperature.
-     *  \param densityAtZeroAltitude Atmospheric density at ground level.
-     *  \param specificGasConstant Specific gas constant for (constant) atmospheric chemical
-     *  composition.
-     *  \param ratioOfSpecificHeats Ratio of specific heats for (constant) atmospheric chemical
-     *  composition.
-     */
-    ExponentialAtmosphereSettings( const double densityScaleHeight,
-                                   const double constantTemperature,
-                                   const double densityAtZeroAltitude,
-                                   const double specificGasConstant = physical_constants::SPECIFIC_GAS_CONSTANT_AIR,
-                                   const double ratioOfSpecificHeats = 1.4 ):
-        AtmosphereSettings( exponential_atmosphere ), densityScaleHeight_( densityScaleHeight ),
-        constantTemperature_( constantTemperature ), densityAtZeroAltitude_( densityAtZeroAltitude ),
-        specificGasConstant_( specificGasConstant ), ratioOfSpecificHeats_( ratioOfSpecificHeats ),
-        bodyWithPredefinedExponentialAtmosphere_( undefined_body )
-    { }
-
-    //  Default constructor.
-    /*
-     *  Default constructor, taking only the name of the body for which to load the predefined
-     *  exponential atmosphere model parameters.
-     *  \param bodyWithPredefinedExponentialAtmosphere Enumeration denoting the name of the body for which the
-     *  predefined atmosphere model is to be loaded.
-     */
-    ExponentialAtmosphereSettings( const BodiesWithPredefinedExponentialAtmospheres bodyWithPredefinedExponentialAtmosphere ):
-        AtmosphereSettings( exponential_atmosphere ), bodyWithPredefinedExponentialAtmosphere_( bodyWithPredefinedExponentialAtmosphere )
-    {
-        // Check that the body name inserted is available
-        switch( bodyWithPredefinedExponentialAtmosphere )
-        {
-            case earth:
-            case mars:
-                // all is good
-                break;
-            default:
-                throw std::runtime_error(
-                        "Error while creating exponential atmosphere. The body name provided "
-                        "does not match any predefined atmosphere model. Available models for: "
-                        "Earth, Mars." );
-        }
-    }
-
-    //  Function to return scale heigh for density profile of atmosphere.
-    /*
-     *  Function to return scale heigh for density profile of atmosphere.
-     *  \return Scale heigh for density profile of atmosphere.
-     */
-    double getDensityScaleHeight( )
-    {
-        return densityScaleHeight_;
-    }
-
-    //  Function to return constant atmospheric temperature.
-    /*
-     *  Function to return constant atmospheric temperature.
-     *  \return Constant atmospheric temperature.
-     */
-    double getConstantTemperature( )
-    {
-        return constantTemperature_;
-    }
-
-    //  Function to return atmospheric density at ground level.
-    /*
-     *  Function to return atmospheric density at ground level.
-     *  \return Atmospheric density at ground level.
-     */
-    double getDensityAtZeroAltitude( )
-    {
-        return densityAtZeroAltitude_;
-    }
-
-    //  Function to return specific gas constant for (constant) atmospheric chemical
-    /*
-     *  Function to return specific gas constant for (constant) atmospheric chemical
-     *  \return Specific gas constant for (constant) atmospheric chemical
-     */
-    double getSpecificGasConstant( )
-    {
-        return specificGasConstant_;
-    }
-
-    //  Function to return ratio of specific heats for (constant) atmospheric chemical
-    /*
-     *  Function to return ratio of specific heats for (constant) atmospheric chemical
-     *  \return Specific gas constant for (constant) atmospheric chemical
-     */
-    double getRatioOfSpecificHeats( )
-    {
-        return ratioOfSpecificHeats_;
-    }
-
-    //  Function to return the name of the body for which to load the predefined
-    //  atmosphere model parameters.
-    BodiesWithPredefinedExponentialAtmospheres getBodyName( )
-    {
-        return bodyWithPredefinedExponentialAtmosphere_;
-    }
-
-private:
-    //  Scale heigh for density profile of atmosphere.
-    double densityScaleHeight_;
-
-    //  Constant atmospheric temperature.
-    double constantTemperature_;
-
-    //  Atmospheric density at ground level.
-    double densityAtZeroAltitude_;
-
-    //  Specific gas constant for (constant) atmospheric chemical
-    double specificGasConstant_;
-
-    //  Ratio of specific heats for (constant) atmospheric chemical
-    double ratioOfSpecificHeats_;
-
-    //  Enumeration denoting the name of the body for which to load the predefined
-    //  atmosphere model.
-    BodiesWithPredefinedExponentialAtmospheres bodyWithPredefinedExponentialAtmosphere_;
-};
-
-//  AtmosphereSettings for defining custom constant temperature atmosphere.
-class CustomConstantTemperatureAtmosphereSettings : public AtmosphereSettings
-{
-public:
-    //  Typedef for density function.
-    typedef std::function< double( const double, const double, const double, const double ) > DensityFunction;
-
-    //  Default constructor.
-    /*
-     *  Default constructor setting all parameters manually.
-     *  \param densityFunction Function to retireve the density at the current altitude,
-     *      longitude, latitude and time.
-     *  \param constantTemperature Constant atmospheric temperature.
-     *  \param specificGasConstant The constant specific gas constant of the atmosphere.
-     *  \param ratioOfSpecificHeats The constant ratio of specific heats of the atmosphere.
-     */
-    CustomConstantTemperatureAtmosphereSettings( const DensityFunction& densityFunction,
-                                                 const double constantTemperature,
-                                                 const double specificGasConstant = physical_constants::SPECIFIC_GAS_CONSTANT_AIR,
-                                                 const double ratioOfSpecificHeats = 1.4 ):
-        AtmosphereSettings( custom_constant_temperature_atmosphere ), densityFunction_( densityFunction ),
-        constantTemperature_( constantTemperature ), specificGasConstant_( specificGasConstant ),
-        ratioOfSpecificHeats_( ratioOfSpecificHeats )
-    { }
-
-    //  Constructor.
-    /*
-     *  Constructor which uses one of the built-in density functions as input.
-     *  \param densityFunctionType Enumeration denoting which density function to implement.
-     *  \param constantTemperature Constant atmospheric temperature.
-     *  \param specificGasConstant The constant specific gas constant of the atmosphere.
-     *  \param ratioOfSpecificHeats The constant ratio of specific heats of the atmosphere.
-     *  \param modelSpecificParameters Vector of parameters to be used to set up the density
-     *      function. Both meaning and number of parameters depends on the model.
-     */
-    CustomConstantTemperatureAtmosphereSettings( const AvailableConstantTemperatureAtmosphereModels densityFunctionType,
-                                                 const double constantTemperature,
-                                                 const double specificGasConstant,
-                                                 const double ratioOfSpecificHeats,
-                                                 const std::vector< double >& modelSpecificParameters ):
-        AtmosphereSettings( custom_constant_temperature_atmosphere ), densityFunctionType_( densityFunctionType ),
-        constantTemperature_( constantTemperature ), specificGasConstant_( specificGasConstant ),
-        ratioOfSpecificHeats_( ratioOfSpecificHeats ), modelSpecificParameters_( modelSpecificParameters )
-    { }
-
-    //  Get the function to compute the density at the current conditions.
-    /*
-     *  Get the function to compute the density at the current conditions.
-     *  \return Function to compute the density at the current conditions.
-     */
-    DensityFunction getDensityFunction( )
-    {
-        return densityFunction_;
-    }
-
-    //  Get the type of function to compute the density at the current conditions.
-    /*
-     *  Get the type of function to compute the density at the current conditions.
-     *  \return Type of function to compute the density at the current conditions.
-     */
-    AvailableConstantTemperatureAtmosphereModels getDensityFunctionType( )
-    {
-        return densityFunctionType_;
-    }
-
-    //  Get constant temperature.
-    /*
-     *  Returns the atmospheric temperature (constant, property of exponential atmosphere) in
-     *  Kelvin.
-     *  \return constantTemperature Constant atmospheric temperature in exponential atmosphere.
-     */
-    double getConstantTemperature( )
-    {
-        return constantTemperature_;
-    }
-
-    //  Get specific gas constant.
-    /*
-     *  Returns the specific gas constant of the atmosphere in J/(kg K), its value is assumed constant,
-     *  due to the assumption of constant atmospheric composition.
-     *  \return Specific gas constant in exponential atmosphere.
-     */
-    double getSpecificGasConstant( )
-    {
-        return specificGasConstant_;
-    }
-
-    //  Get ratio of specific heats.
-    /*
-     *  Returns the ratio of specific hears of the atmosphere, its value is assumed constant,
-     *  due to the assumption of constant atmospheric composition.
-     *  \return Ratio of specific heats exponential atmosphere.
-     */
-    double getRatioOfSpecificHeats( )
-    {
-        return ratioOfSpecificHeats_;
-    }
-
-    //  Get model specific parameters.
-    /*
-     *  Get model specific parameters.
-     *  \return Vector of parameters to be used to set up the density function.
-     */
-    std::vector< double > getModelSpecificParameters( )
-    {
-        return modelSpecificParameters_;
-    }
-
-private:
-    //  Function to compute the density at the current conditions.
-    /*
-     *  Function to compute the density at the current conditions. Note that the independent
-     *  variables need to be altitude, longitude, latitude and time, in this precise order.
-     */
-    DensityFunction densityFunction_;
-
-    //  Enumeration denoting which density function to implement.
-    /*
-     *  Enumeration denoting which density function to implement
-     */
-    AvailableConstantTemperatureAtmosphereModels densityFunctionType_;
-
-    //  Constant temperature.
-    /*
-     *  The atmospheric temperature (constant, property of exponential atmosphere) in Kelvin.
-     */
-    const double constantTemperature_;
-
-    //  Specific gas constant.
-    /*
-     *  Specific gas constant of the atmosphere, its value is assumed constant, due to the
-     *  assumption of constant atmospheric composition.
-     */
-    const double specificGasConstant_;
-
-    //  Ratio of specific heats at constant pressure and constant volume.
-    /*
-     *  Ratio of specific heats of the atmosphere at constant pressure and constant volume.
-     *  This value is set to a constant, implying constant atmospheric composition.
-     */
-    const double ratioOfSpecificHeats_;
-
-    //  Vector of parameters to be used to set up the density function.
-    /*
-     *  Vector of parameters to be used to set up the density function. Both meaning and number of parameters depends on the model.
-     */
-    std::vector< double > modelSpecificParameters_;
-};
-
-//  AtmosphereSettings for defining an NRLMSISE00 atmosphere reading space weather data from a text file.
-class NRLMSISE00AtmosphereSettings : public AtmosphereSettings
-{
-public:
-    //  Constructor.
-    /*
-     *  Constructor.
-     *  \param spaceWeatherFile File containing space weather data, as in
-     *  https://celestrak.com/SpaceData/sw19571001.txt
-     */
-    NRLMSISE00AtmosphereSettings( const std::string& spaceWeatherFile ):
-        AtmosphereSettings( nrlmsise00 ), spaceWeatherFile_( spaceWeatherFile )
-    { }
-
-    //  Function to return file containing space weather data.
-    /*
-     *  Function to return file containing space weather data.
-     *  \return Filename containing space weather data.
-     */
-    std::string getSpaceWeatherFile( )
-    {
-        return spaceWeatherFile_;
-    }
-
-private:
-    //  File containing space weather data.
-    /*
-     *  File containing space weather data, as in https://celestrak.com/SpaceData/sw19571001.txt
-     */
-    std::string spaceWeatherFile_;
-};
-
-//  AtmosphereSettings for defining an atmosphere with tabulated data from file.
-// //! @get_docstring(TabulatedAtmosphereSettings.__docstring__)
-class TabulatedAtmosphereSettings : public AtmosphereSettings
-{
-public:
-    //  Default constructor.
-    /*
-     *  Default constructor.
-     *  \param atmosphereTableFile Map of files containing information on the atmosphere. The order of both
-     *      independent and dependent parameters needs to be specified in the independentVariablesNames and
-     *      dependentVariablesNames vectors, respectively. Note that specific gas constant and specific heat ratio
-     *      will be given the default constant values for Earth, unless they are included in the file map.
-     *  \param independentVariablesNames List of independent parameters describing the atmosphere.
-     *  \param dependentVariablesNames List of dependent parameters output by the atmosphere.
-     *  \param specificGasConstant The constant specific gas constant of the atmosphere.
-     *  \param ratioOfSpecificHeats The constant ratio of specific heats of the atmosphere.
-     *  \param boundaryHandling List of methods for interpolation behavior when independent variable is out of range.
-     *  \param defaultExtrapolationValue List of default values to be used for extrapolation, in case of
-     *      use_default_value or use_default_value_with_warning as methods for boundaryHandling.
-     */
-    TabulatedAtmosphereSettings(
-            const std::map< int, std::string >& atmosphereTableFile,
-            const std::vector< AtmosphereIndependentVariables >& independentVariablesNames = { altitude_dependent_atmosphere },
-            const std::vector< AtmosphereDependentVariables >& dependentVariablesNames = { density_dependent_atmosphere,
-                                                                                           pressure_dependent_atmosphere,
-                                                                                           temperature_dependent_atmosphere },
-            const double specificGasConstant = physical_constants::SPECIFIC_GAS_CONSTANT_AIR,
-            const double ratioOfSpecificHeats = 1.4,
-            const std::vector< interpolators::BoundaryInterpolationType >& boundaryHandling = { },
-            const std::vector< std::vector< std::pair< double, double > > >& defaultExtrapolationValue = { } ):
-        AtmosphereSettings( tabulated_atmosphere ), atmosphereFile_( atmosphereTableFile ),
-        independentVariables_( independentVariablesNames ), dependentVariables_( dependentVariablesNames ),
-        specificGasConstant_( specificGasConstant ), ratioOfSpecificHeats_( ratioOfSpecificHeats ), boundaryHandling_( boundaryHandling ),
-        defaultExtrapolationValue_( defaultExtrapolationValue )
-    { }
-
-    //  Constructor with single boundary handling parameters.
-    /*
-     *  Constructor with single boundary handling parameters. The specifier is assumed to be the same for
-     *  each (in)dependent variable.
-     *  \param atmosphereTableFile Map of files containing information on the atmosphere. The order of both
-     *      independent and dependent parameters needs to be specified in the independentVariablesNames and
-     *      dependentVariablesNames vectors, respectively. Note that specific gas constant and specific heat ratio
-     *      will be given the default constant values for Earth, unless they are included in the file map.
-     *  \param independentVariablesNames List of independent parameters describing the atmosphere.
-     *  \param dependentVariablesNames List of dependent parameters output by the atmosphere.
-     *  \param specificGasConstant The constant specific gas constant of the atmosphere.
-     *  \param ratioOfSpecificHeats The constant ratio of specific heats of the atmosphere.
-     *  \param boundaryHandling Method for interpolation behavior when independent variable is out of range.
-     *  \param defaultExtrapolationValue Default value to be used for extrapolation, in case of use_default_value or
-     *      use_default_value_with_warning as methods for boundaryHandling.
-     */
-    TabulatedAtmosphereSettings( const std::map< int, std::string >& atmosphereTableFile,
-                                 const std::vector< AtmosphereIndependentVariables >& independentVariablesNames,
-                                 const std::vector< AtmosphereDependentVariables >& dependentVariablesNames,
-                                 const double specificGasConstant,
-                                 const double ratioOfSpecificHeats,
-                                 const interpolators::BoundaryInterpolationType boundaryHandling,
-                                 const double defaultExtrapolationValue = IdentityElement::getAdditionIdentity< double >( ) ):
-        TabulatedAtmosphereSettings(
-                atmosphereTableFile,
-                independentVariablesNames,
-                dependentVariablesNames,
-                specificGasConstant,
-                ratioOfSpecificHeats,
-                std::vector< interpolators::BoundaryInterpolationType >( independentVariablesNames.size( ), boundaryHandling ),
-                std::vector< std::vector< std::pair< double, double > > >(
-                        dependentVariablesNames.size( ),
-                        std::vector< std::pair< double, double > >(
-                                independentVariablesNames.size( ),
-                                std::make_pair( defaultExtrapolationValue, defaultExtrapolationValue ) ) ) )
-    { }
-
-    //  Constructor compatible with old version.
-    /*
-     *  Constructor compatible with old version.
-     *  \param atmosphereTableFile File containing atmospheric properties. The file name of the atmosphere table. The file
-     *      should contain four columns of data, containing altitude (first column), and the associated density, pressure and
-     *      density values in the second, third and fourth columns.
-     *  \param dependentVariablesNames List of dependent parameters output by the atmosphere.
-     *  \param specificGasConstant The constant specific gas constant of the atmosphere.
-     *  \param ratioOfSpecificHeats The constant ratio of specific heats of the atmosphere.
-     *  \param boundaryHandling Method for interpolation behavior when independent variable is out of range.
-     *  \param defaultExtrapolationValue Default value to be used for extrapolation, in case of use_default_value or
-     *      use_default_value_with_warning as methods for boundaryHandling.
-     */
-    TabulatedAtmosphereSettings(
-            const std::string& atmosphereTableFile,
-            const std::vector< AtmosphereDependentVariables >& dependentVariablesNames = { density_dependent_atmosphere,
-                                                                                           pressure_dependent_atmosphere,
-                                                                                           temperature_dependent_atmosphere },
-            const double specificGasConstant = physical_constants::SPECIFIC_GAS_CONSTANT_AIR,
-            const double ratioOfSpecificHeats = 1.4,
-            const interpolators::BoundaryInterpolationType boundaryHandling = interpolators::use_boundary_value,
-            const double defaultExtrapolationValue = IdentityElement::getAdditionIdentity< double >( ) ):
-        TabulatedAtmosphereSettings( { { 0, atmosphereTableFile } },
-                                     { altitude_dependent_atmosphere },
-                                     dependentVariablesNames,
-                                     specificGasConstant,
-                                     ratioOfSpecificHeats,
-                                     { boundaryHandling },
-                                     std::vector< std::vector< std::pair< double, double > > >(
-                                             dependentVariablesNames.size( ),
-                                             std::vector< std::pair< double, double > >(
-                                                     1,
-                                                     std::make_pair( defaultExtrapolationValue, defaultExtrapolationValue ) ) ) )
-    { }
-
-    //  Constructor with no specific gas constant nor ratio of specific heats.
-    /*
-     *  Constructor with no specific gas constant nor ratio of specific heats.
-     *  \param atmosphereTableFile Map of files containing information on the atmosphere. The order of both
-     *      independent and dependent parameters needs to be specified in the independentVariablesNames and
-     *      dependentVariablesNames vectors, respectively. Note that specific gas constant and specific heat ratio
-     *      will be given the default constant values for Earth, unless they are included in the file map.
-     *  \param independentVariablesNames List of independent parameters describing the atmosphere.
-     *  \param dependentVariablesNames List of dependent parameters output by the atmosphere.
-     *  \param boundaryHandling List of methods for interpolation behavior when independent variable is out of range.
-     *  \param defaultExtrapolationValue List of default values to be used for extrapolation, in case of
-     *      use_default_value or use_default_value_with_warning as methods for boundaryHandling.
-     */
-    TabulatedAtmosphereSettings( const std::map< int, std::string >& atmosphereTableFile,
-                                 const std::vector< AtmosphereIndependentVariables >& independentVariablesNames,
-                                 const std::vector< AtmosphereDependentVariables >& dependentVariablesNames,
-                                 const std::vector< interpolators::BoundaryInterpolationType >& boundaryHandling,
-                                 const std::vector< std::vector< std::pair< double, double > > >& defaultExtrapolationValue = { } ):
-        AtmosphereSettings( tabulated_atmosphere ), atmosphereFile_( atmosphereTableFile ),
-        independentVariables_( independentVariablesNames ), dependentVariables_( dependentVariablesNames ),
-        specificGasConstant_( physical_constants::SPECIFIC_GAS_CONSTANT_AIR ), ratioOfSpecificHeats_( 1.4 ),
-        boundaryHandling_( boundaryHandling ), defaultExtrapolationValue_( defaultExtrapolationValue )
-    { }
-
-    //  Constructor with no specific gas constant nor ratio of specific heats.
-    /*
-     *  Constructor with no specific gas constant nor ratio of specific heats. These two values will be given
-     *  the default Earth value, or are specified inside the atmosphere table file (and thus, inside the
-     *  dependent variables vector).
-     *  \param atmosphereTableFile Map of files containing information on the atmosphere. The order of both
-     *      independent and dependent parameters needs to be specified in the independentVariablesNames and
-     *      dependentVariablesNames vectors, respectively. Note that specific gas constant and specific heat ratio
-     *      will be given the default constant values for Earth, unless they are included in the file map.
-     *  \param independentVariablesNames List of independent parameters describing the atmosphere.
-     *  \param dependentVariablesNames List of dependent parameters output by the atmosphere.
-     *  \param boundaryHandling List of methods for interpolation behavior when independent variable is out of range.
-     *  \param defaultExtrapolationValue List of default values to be used for extrapolation, in case of
-     *      use_default_value or use_default_value_with_warning as methods for boundaryHandling.
-     */
-    TabulatedAtmosphereSettings( const std::map< int, std::string >& atmosphereTableFile,
-                                 const std::vector< AtmosphereIndependentVariables >& independentVariablesNames,
-                                 const std::vector< AtmosphereDependentVariables >& dependentVariablesNames,
-                                 const std::vector< interpolators::BoundaryInterpolationType >& boundaryHandling,
-                                 const std::vector< double >& defaultExtrapolationValue ):
-        AtmosphereSettings( tabulated_atmosphere ), atmosphereFile_( atmosphereTableFile ),
-        independentVariables_( independentVariablesNames ), dependentVariables_( dependentVariablesNames ),
-        specificGasConstant_( physical_constants::SPECIFIC_GAS_CONSTANT_AIR ), ratioOfSpecificHeats_( 1.4 ),
-        boundaryHandling_( boundaryHandling )
-    {
-        // Assign default values
-        defaultExtrapolationValue_.resize( dependentVariablesNames.size( ) );
-        for( unsigned int i = 0; i < dependentVariablesNames.size( ); i++ )
-        {
-            for( unsigned int j = 0; j < independentVariablesNames.size( ); j++ )
-            {
-                if( boundaryHandling_.at( j ) == interpolators::use_default_value ||
-                    boundaryHandling_.at( j ) == interpolators::use_default_value_with_warning )
-                {
-                    defaultExtrapolationValue_.at( i ).push_back(
-                            std::make_pair( defaultExtrapolationValue.at( i ), defaultExtrapolationValue.at( i ) ) );
-                }
-                else
-                {
-                    defaultExtrapolationValue_.at( i ).push_back( std::make_pair( IdentityElement::getAdditionIdentity< double >( ),
-                                                                                  IdentityElement::getAdditionIdentity< double >( ) ) );
-                }
-            }
-        }
-    }
-
-    //  Constructor with no specific gas constant nor ratio of specific heats, and with
-    //  single boundary handling parameters.
-    /*
-     *  Constructor with no specific gas constant nor ratio of specific heats. These two values will be given
-     *  the default Earth value, or are specified inside the atmosphere table file (and thus, inside the
-     *  dependent variables vector). Only one boundary handling parameter is specified, which is then repeated for
-     *  dimension.
-     *  \param atmosphereTableFile Map of files containing information on the atmosphere. The order of both
-     *      independent and dependent parameters needs to be specified in the independentVariablesNames and
-     *      dependentVariablesNames vectors, respectively. Note that specific gas constant and specific heat ratio
-     *      will be given the default constant values for Earth, unless they are included in the file map.
-     *  \param independentVariablesNames List of independent parameters describing the atmosphere.
-     *  \param dependentVariablesNames List of dependent parameters output by the atmosphere.
-     *  \param boundaryHandling Method for interpolation behavior when independent variable is out of range.
-     *  \param defaultExtrapolationValue Default value to be used for extrapolation, in case of use_default_value or
-     *      use_default_value_with_warning as methods for boundaryHandling.
-     */
-    TabulatedAtmosphereSettings( const std::map< int, std::string >& atmosphereTableFile,
-                                 const std::vector< AtmosphereIndependentVariables >& independentVariablesNames,
-                                 const std::vector< AtmosphereDependentVariables >& dependentVariablesNames,
-                                 const interpolators::BoundaryInterpolationType boundaryHandling,
-                                 const double defaultExtrapolationValue = IdentityElement::getAdditionIdentity< double >( ) ):
-        TabulatedAtmosphereSettings(
-                atmosphereTableFile,
-                independentVariablesNames,
-                dependentVariablesNames,
-                physical_constants::SPECIFIC_GAS_CONSTANT_AIR,
-                1.4,
-                std::vector< interpolators::BoundaryInterpolationType >( independentVariablesNames.size( ), boundaryHandling ),
-                std::vector< std::vector< std::pair< double, double > > >(
-                        dependentVariablesNames.size( ),
-                        std::vector< std::pair< double, double > >(
-                                independentVariablesNames.size( ),
-                                std::make_pair( defaultExtrapolationValue, defaultExtrapolationValue ) ) ) )
-    { }
-
-    //  Function to return file containing atmospheric properties.
-    /*
-     *  Function to return file containing atmospheric properties.
-     *  \return Map of filenames containing atmospheric properties.
-     */
-    std::map< int, std::string > getAtmosphereFile( )
-    {
-        return atmosphereFile_;
-    }
-
-    //  Function to return file containing atmospheric properties.
-    /*
-     *  Function to return file containing atmospheric properties.
-     *  \return Filename containing atmospheric properties.
-     */
-    std::string getAtmosphereFile( const unsigned int fileIndex )
-    {
-        return atmosphereFile_.at( fileIndex );
-    }
-
-    //  Function to return independent variables names.
-    /*
-     *  Function to return independent variables names.
-     *  \return Independent variables.
-     */
-    std::vector< AtmosphereIndependentVariables > getIndependentVariables( )
-    {
-        return independentVariables_;
-    }
-
-    //  Function to return dependent variables names.
-    /*
-     *  Function to return dependent variables names.
-     *  \return Dependent variables.
-     */
-    std::vector< AtmosphereDependentVariables > getDependentVariables( )
-    {
-        return dependentVariables_;
-    }
-
-    //  Function to return specific gas constant of the atmosphere.
-    /*
-     *  Function to return specific gas constant of the atmosphere.
-     *  \return Specific gas constant of the atmosphere.
-     */
-    double getSpecificGasConstant( )
-    {
-        return specificGasConstant_;
-    }
-
-    //  Function to return ratio of specific heats of the atmosphere.
-    /*
-     *  Function to return ratio of specific heats of the atmosphere.
-     *  \return Ratio of specific heats of the atmosphere at constant pressure and constant volume.
-     */
-    double getRatioOfSpecificHeats( )
-    {
-        return ratioOfSpecificHeats_;
-    }
-
-    //  Function to return boundary handling method.
-    /*
-     *  Function to return boundary handling method.
-     *  \return Boundary handling method for when independent variables are outside specified range.
-     */
-    std::vector< interpolators::BoundaryInterpolationType > getBoundaryHandling( )
-    {
-        return boundaryHandling_;
-    }
-
-    //  Function to return default extrapolation value.
-    /*
-     *  Function to return boundary handling method.
-     *  \return Boundary handling method for when independent variables are outside specified range.
-     */
-    std::vector< std::vector< std::pair< double, double > > > getDefaultExtrapolationValue( )
-    {
-        return defaultExtrapolationValue_;
-    }
-
-private:
-    //  File containing atmospheric properties.
-    /*
-     *  File containing atmospheric properties, file should contain
-     *  columns of atmospheric data with at least density, pressure and temperature,
-     *  (whose order is specified in dependentVariables), and with at least one
-     *  indendent variables.
-     */
-    std::map< int, std::string > atmosphereFile_;
-
-    //  A vector of strings containing the names of the independent variables contained in the atmosphere file
-    /*
-     * A vector of strings containing the names of the independent variables contained in the atmosphere file,
-     * in the correct order (from left, being the first entry in the vector, to the right).
-     */
-    std::vector< AtmosphereIndependentVariables > independentVariables_;
-
-    //  A vector of strings containing the names of the variables contained in the atmosphere file
-    /*
-     * A vector of strings containing the names of the variables contained in the atmosphere file,
-     * in the correct order (from left, being the first entry in the vector, to the right).
-     */
-    std::vector< AtmosphereDependentVariables > dependentVariables_;
-
-    //  Specific gas constant of the atmosphere.
-    /*
-     * Specific gas constant of the atmosphere.
-     */
-    double specificGasConstant_;
-
-    //  Ratio of specific heats of the atmosphere at constant pressure and constant volume.
-    /*
-     *  Ratio of specific heats of the atmosphere at constant pressure and constant volume.
-     */
-    double ratioOfSpecificHeats_;
-
-    //  Behavior of interpolator when independent variable is outside range.
-    /*
-     *  Behavior of interpolator when independent variable is outside range.
-     */
-    std::vector< interpolators::BoundaryInterpolationType > boundaryHandling_;
-
-    //  Default value to be used for extrapolation.
-    /*
-     *  Default value to be used for extrapolation.
-     */
-    std::vector< std::vector< std::pair< double, double > > > defaultExtrapolationValue_;
-};
-
-class ScaledAtmosphereSettings : public AtmosphereSettings
-{
-public:
-    ScaledAtmosphereSettings( const std::shared_ptr< AtmosphereSettings > baseSettings,
-                              const double scaling,
-                              const bool isScalingAbsolute ):
-        AtmosphereSettings( scaled_atmosphere ), baseSettings_( baseSettings ), scaling_( [ = ]( const double ) { return scaling; } ),
-        isScalingAbsolute_( isScalingAbsolute )
-    { }
-
-    ScaledAtmosphereSettings( const std::shared_ptr< AtmosphereSettings > baseSettings,
-                              const std::function< double( const double ) > scaling,
-                              const bool isScalingAbsolute ):
-        AtmosphereSettings( scaled_atmosphere ), baseSettings_( baseSettings ), scaling_( scaling ), isScalingAbsolute_( isScalingAbsolute )
-    { }
-
-    std::shared_ptr< AtmosphereSettings > getBaseSettings( )
-    {
-        return baseSettings_;
-    }
-
-    std::function< double( const double ) > getScaling( )
-    {
-        return scaling_;
-    }
-
-    bool getIsScalingAbsolute( )
-    {
-        return isScalingAbsolute_;
-    }
-
-protected:
-    std::shared_ptr< AtmosphereSettings > baseSettings_;
-
-    std::function< double( const double ) > scaling_;
-
-    bool isScalingAbsolute_;
-};
-
-//! @get_docstring(exponentialAtmosphereSettings,2)
-inline std::shared_ptr< AtmosphereSettings > exponentialAtmosphereSettings(
-        const double densityScaleHeight,
-        const double densityAtZeroAltitude,
-        const double constantTemperature,
-        const double specificGasConstant = physical_constants::SPECIFIC_GAS_CONSTANT_AIR,
-        const double ratioOfSpecificHeats = 1.4 )
-{
-    return std::make_shared< ExponentialAtmosphereSettings >(
-            densityScaleHeight, constantTemperature, densityAtZeroAltitude, specificGasConstant, ratioOfSpecificHeats );
-}
-
-//! @get_docstring(exponentialAtmosphereSettings,1)
-inline std::shared_ptr< AtmosphereSettings > exponentialAtmosphereSettings( const double densityScaleHeight,
-                                                                            const double densityAtZeroAltitude )
-{
-    return std::make_shared< ExponentialAtmosphereSettings >( densityScaleHeight, TUDAT_NAN, densityAtZeroAltitude, TUDAT_NAN, TUDAT_NAN );
-}
-
-//! @get_docstring(exponentialAtmosphereSettings,0)
-inline std::shared_ptr< AtmosphereSettings > exponentialAtmosphereSettings( const std::string& bodyName )
-{
-    BodiesWithPredefinedExponentialAtmospheres bodyId;
-    if( bodyName == "Earth" )
-    {
-        bodyId = BodiesWithPredefinedExponentialAtmospheres::earth;
-    }
-    else if( bodyName == "Mars" )
-    {
-        bodyId = BodiesWithPredefinedExponentialAtmospheres::mars;
-    }
-    else
-    {
-        throw std::runtime_error(
-                "Error while creating exponential atmosphere. The body name provided "
-                "does not match any predefined atmosphere model. Available models for: "
-                "Earth, Mars." );
-    }
-    return std::make_shared< ExponentialAtmosphereSettings >( bodyId );
-}
-
-//! @get_docstring(nrlmsise00AtmosphereSettings)
-inline std::shared_ptr< AtmosphereSettings > nrlmsise00AtmosphereSettings( const std::string dataFile = paths::getSpaceWeatherDataPath( ) +
-                                                                                   "/sw19571001.txt" )
-{
-    return std::make_shared< NRLMSISE00AtmosphereSettings >( dataFile );
-}
-
-typedef std::function< double( const double, const double, const double, const double ) > DensityFunction;
-//! @get_docstring(customConstantTemperatureAtmosphereSettings,0)
-inline std::shared_ptr< AtmosphereSettings > customConstantTemperatureAtmosphereSettings(
-        const std::function< double( const double ) > densityFunction,
-        const double constantTemperature,
-        const double specificGasConstant = physical_constants::SPECIFIC_GAS_CONSTANT_AIR,
-        const double ratioOfSpecificHeats = 1.4 )
-{
-    DensityFunction fullDensityFunction = [ = ]( const double altitude, const double, const double, const double ) {
-        return densityFunction( altitude );
-    };
-    return std::make_shared< CustomConstantTemperatureAtmosphereSettings >(
-            fullDensityFunction, constantTemperature, specificGasConstant, ratioOfSpecificHeats );
-}
-
-//! @get_docstring(customConstantTemperatureAtmosphereSettings,1)
-inline std::shared_ptr< AtmosphereSettings > customConstantTemperatureAtmosphereSettings(
-        const DensityFunction densityFunction,
-        const double constantTemperature,
-        const double specificGasConstant = physical_constants::SPECIFIC_GAS_CONSTANT_AIR,
-        const double ratioOfSpecificHeats = 1.4 )
-{
-    return std::make_shared< CustomConstantTemperatureAtmosphereSettings >(
-            densityFunction, constantTemperature, specificGasConstant, ratioOfSpecificHeats );
-}
-
-//! @get_docstring(scaledAtmosphereSettings,0)
-inline std::shared_ptr< AtmosphereSettings > scaledAtmosphereSettings( const std::shared_ptr< AtmosphereSettings > baseSettings,
-                                                                       const std::function< double( const double ) > scaling,
-                                                                       const bool isScalingAbsolute )
-{
-    return std::make_shared< ScaledAtmosphereSettings >( baseSettings, scaling, isScalingAbsolute );
-}
-
-//! @get_docstring(scaledAtmosphereSettings,1)
-inline std::shared_ptr< AtmosphereSettings > scaledAtmosphereSettings( const std::shared_ptr< AtmosphereSettings > baseSettings,
-                                                                       const double scaling,
-                                                                       const bool isScalingAbsolute )
-{
-    return std::make_shared< ScaledAtmosphereSettings >( baseSettings, scaling, isScalingAbsolute );
-}
-
-inline std::shared_ptr< AtmosphereSettings > tabulatedAtmosphereSettings(
-        const std::string& atmosphereTableFile,
-        const std::vector< AtmosphereDependentVariables >& dependentVariablesNames = { density_dependent_atmosphere,
-                                                                                       pressure_dependent_atmosphere,
-                                                                                       temperature_dependent_atmosphere },
-        const double specificGasConstant = physical_constants::SPECIFIC_GAS_CONSTANT_AIR,
-        const double ratioOfSpecificHeats = 1.4 )
-{
-    return std::make_shared< TabulatedAtmosphereSettings >( atmosphereTableFile,
-                                                            dependentVariablesNames,
-                                                            specificGasConstant,
-                                                            ratioOfSpecificHeats,
-                                                            interpolators::throw_exception_at_boundary );
-}
-
-//! @get_docstring(customWindModelSettings)
-inline std::shared_ptr< WindModelSettings > customWindModelSettings(
-        const std::function< Eigen::Vector3d( const double, const double, const double, const double ) > windFunction,
-        const reference_frames::AerodynamicsReferenceFrames associatedFrame = reference_frames::vertical_frame )
-{
-    return std::make_shared< CustomWindModelSettings >( windFunction, associatedFrame );
-}
-
-//! @get_docstring(constantWindModelSettings)
-inline std::shared_ptr< WindModelSettings > constantWindModelSettings(
-        const Eigen::Vector3d constantWindVelocity,
-        const reference_frames::AerodynamicsReferenceFrames associatedFrame = reference_frames::vertical_frame )
-{
-    return std::make_shared< ConstantWindModelSettings >( constantWindVelocity, associatedFrame );
-}
-
-//  Function to create a wind model.
-/*
- *  Function to create a wind model based on model-specific settings for the wind model.
- *  \param windSettings Settings for the wind model that is to be created, defined
- *  a pointer to an object of class (derived from) WindModelSettings.
- *  \param body Name of the body for which the wind model is to be created.
- *  \return Wind model created according to settings in windSettings.
- */
-std::shared_ptr< aerodynamics::WindModel > createWindModel( const std::shared_ptr< WindModelSettings > windSettings,
-                                                            const std::string& body );
-
-//  Function to create an atmosphere model.
-/*
- *  Function to create an atmosphere model based on model-specific settings for the atmosphere.
- *  \param atmosphereSettings Settings for the atmosphere model that is to be created, defined
- *  a pointer to an object of class (derived from) AtmosphereSettings.
- *  \param body Name of the body for which the atmosphere model is to be created.
- *  \return Atmosphere model created according to settings in atmosphereSettings.
- */
-std::shared_ptr< aerodynamics::AtmosphereModel > createAtmosphereModel( const std::shared_ptr< AtmosphereSettings > atmosphereSettings,
-                                                                        const std::string& body );
-
-}  // namespace simulation_setup
-
-}  // namespace tudat
-
-#endif  // TUDAT_CREATEATMOSPHEREMODEL_H
+     int getGeomagneticActivity( )
+     {
+         return geomagneticActivity_;
+     }
+ 
+ private:
+     //  File containing space weather data.
+     /*
+      *  File containing space weather data, as in https://celestrak.com/SpaceData/sw19571001.txt
+      */
+     std::string spaceWeatherFile_;
+ 
+     //  Geomagnetic activity setting.
+     /*
+      *  Controls the geomagnetic activity behavior.
+      *  Default (-1) uses full vector of Ap values.
+      *  Set to 1 to use daily Ap value.
+      */
+     int geomagneticActivity_ = -1;
+ };
+ 
+ //  AtmosphereSettings for defining an atmosphere with tabulated data from file.
+ // //! @get_docstring(TabulatedAtmosphereSettings.__docstring__)
+ class TabulatedAtmosphereSettings : public AtmosphereSettings
+ {
+ public:
+     //  Default constructor.
+     /*
+      *  Default constructor.
+      *  \param atmosphereTableFile Map of files containing information on the atmosphere. The order of both
+      *      independent and dependent parameters needs to be specified in the independentVariablesNames and
+      *      dependentVariablesNames vectors, respectively. Note that specific gas constant and specific heat ratio
+      *      will be given the default constant values for Earth, unless they are included in the file map.
+      *  \param independentVariablesNames List of independent parameters describing the atmosphere.
+      *  \param dependentVariablesNames List of dependent parameters output by the atmosphere.
+      *  \param specificGasConstant The constant specific gas constant of the atmosphere.
+      *  \param ratioOfSpecificHeats The constant ratio of specific heats of the atmosphere.
+      *  \param boundaryHandling List of methods for interpolation behavior when independent variable is out of range.
+      *  \param defaultExtrapolationValue List of default values to be used for extrapolation, in case of
+      *      use_default_value or use_default_value_with_warning as methods for boundaryHandling.
+      */
+     TabulatedAtmosphereSettings(
+             const std::map< int, std::string >& atmosphereTableFile,
+             const std::vector< AtmosphereIndependentVariables >& independentVariablesNames = { altitude_dependent_atmosphere },
+             const std::vector< AtmosphereDependentVariables >& dependentVariablesNames = { density_dependent_atmosphere,
+                                                                                            pressure_dependent_atmosphere,
+                                                                                            temperature_dependent_atmosphere },
+             const double specificGasConstant = physical_constants::SPECIFIC_GAS_CONSTANT_AIR,
+             const double ratioOfSpecificHeats = 1.4,
+             const std::vector< interpolators::BoundaryInterpolationType >& boundaryHandling = { },
+             const std::vector< std::vector< std::pair< double, double > > >& defaultExtrapolationValue = { } ):
+         AtmosphereSettings( tabulated_atmosphere ), atmosphereFile_( atmosphereTableFile ),
+         independentVariables_( independentVariablesNames ), dependentVariables_( dependentVariablesNames ),
+         specificGasConstant_( specificGasConstant ), ratioOfSpecificHeats_( ratioOfSpecificHeats ), boundaryHandling_( boundaryHandling ),
+         defaultExtrapolationValue_( defaultExtrapolationValue )
+     { }
+ 
+     //  Constructor with single boundary handling parameters.
+     /*
+      *  Constructor with single boundary handling parameters. The specifier is assumed to be the same for
+      *  each (in)dependent variable.
+      *  \param atmosphereTableFile Map of files containing information on the atmosphere. The order of both
+      *      independent and dependent parameters needs to be specified in the independentVariablesNames and
+      *      dependentVariablesNames vectors, respectively. Note that specific gas constant and specific heat ratio
+      *      will be given the default constant values for Earth, unless they are included in the file map.
+      *  \param independentVariablesNames List of independent parameters describing the atmosphere.
+      *  \param dependentVariablesNames List of dependent parameters output by the atmosphere.
+      *  \param specificGasConstant The constant specific gas constant of the atmosphere.
+      *  \param ratioOfSpecificHeats The constant ratio of specific heats of the atmosphere.
+      *  \param boundaryHandling Method for interpolation behavior when independent variable is out of range.
+      *  \param defaultExtrapolationValue Default value to be used for extrapolation, in case of use_default_value or
+      *      use_default_value_with_warning as methods for boundaryHandling.
+      */
+     TabulatedAtmosphereSettings( const std::map< int, std::string >& atmosphereTableFile,
+                                  const std::vector< AtmosphereIndependentVariables >& independentVariablesNames,
+                                  const std::vector< AtmosphereDependentVariables >& dependentVariablesNames,
+                                  const double specificGasConstant,
+                                  const double ratioOfSpecificHeats,
+                                  const interpolators::BoundaryInterpolationType boundaryHandling,
+                                  const double defaultExtrapolationValue = IdentityElement::getAdditionIdentity< double >( ) ):
+         TabulatedAtmosphereSettings(
+                 atmosphereTableFile,
+                 independentVariablesNames,
+                 dependentVariablesNames,
+                 specificGasConstant,
+                 ratioOfSpecificHeats,
+                 std::vector< interpolators::BoundaryInterpolationType >( independentVariablesNames.size( ), boundaryHandling ),
+                 std::vector< std::vector< std::pair< double, double > > >(
+                         dependentVariablesNames.size( ),
+                         std::vector< std::pair< double, double > >(
+                                 independentVariablesNames.size( ),
+                                 std::make_pair( defaultExtrapolationValue, defaultExtrapolationValue ) ) ) )
+     { }
+ 
+     //  Constructor compatible with old version.
+     /*
+      *  Constructor compatible with old version.
+      *  \param atmosphereTableFile File containing atmospheric properties. The file name of the atmosphere table. The file
+      *      should contain four columns of data, containing altitude (first column), and the associated density, pressure and
+      *      density values in the second, third and fourth columns.
+      *  \param dependentVariablesNames List of dependent parameters output by the atmosphere.
+      *  \param specificGasConstant The constant specific gas constant of the atmosphere.
+      *  \param ratioOfSpecificHeats The constant ratio of specific heats of the atmosphere.
+      *  \param boundaryHandling Method for interpolation behavior when independent variable is out of range.
+      *  \param defaultExtrapolationValue Default value to be used for extrapolation, in case of use_default_value or
+      *      use_default_value_with_warning as methods for boundaryHandling.
+      */
+     TabulatedAtmosphereSettings(
+             const std::string& atmosphereTableFile,
+             const std::vector< AtmosphereDependentVariables >& dependentVariablesNames = { density_dependent_atmosphere,
+                                                                                            pressure_dependent_atmosphere,
+                                                                                            temperature_dependent_atmosphere },
+             const double specificGasConstant = physical_constants::SPECIFIC_GAS_CONSTANT_AIR,
+             const double ratioOfSpecificHeats = 1.4,
+             const interpolators::BoundaryInterpolationType boundaryHandling = interpolators::use_boundary_value,
+             const double defaultExtrapolationValue = IdentityElement::getAdditionIdentity< double >( ) ):
+         TabulatedAtmosphereSettings( { { 0, atmosphereTableFile } },
+                                      { altitude_dependent_atmosphere },
+                                      dependentVariablesNames,
+                                      specificGasConstant,
+                                      ratioOfSpecificHeats,
+                                      { boundaryHandling },
+                                      std::vector< std::vector< std::pair< double, double > > >(
+                                              dependentVariablesNames.size( ),
+                                              std::vector< std::pair< double, double > >(
+                                                      1,
+                                                      std::make_pair( defaultExtrapolationValue, defaultExtrapolationValue ) ) ) )
+     { }
+ 
+     //  Constructor with no specific gas constant nor ratio of specific heats.
+     /*
+      *  Constructor with no specific gas constant nor ratio of specific heats.
+      *  \param atmosphereTableFile Map of files containing information on the atmosphere. The order of both
+      *      independent and dependent parameters needs to be specified in the independentVariablesNames and
+      *      dependentVariablesNames vectors, respectively. Note that specific gas constant and specific heat ratio
+      *      will be given the default constant values for Earth, unless they are included in the file map.
+      *  \param independentVariablesNames List of independent parameters describing the atmosphere.
+      *  \param dependentVariablesNames List of dependent parameters output by the atmosphere.
+      *  \param boundaryHandling List of methods for interpolation behavior when independent variable is out of range.
+      *  \param defaultExtrapolationValue List of default values to be used for extrapolation, in case of
+      *      use_default_value or use_default_value_with_warning as methods for boundaryHandling.
+      */
+     TabulatedAtmosphereSettings( const std::map< int, std::string >& atmosphereTableFile,
+                                  const std::vector< AtmosphereIndependentVariables >& independentVariablesNames,
+                                  const std::vector< AtmosphereDependentVariables >& dependentVariablesNames,
+                                  const std::vector< interpolators::BoundaryInterpolationType >& boundaryHandling,
+                                  const std::vector< std::vector< std::pair< double, double > > >& defaultExtrapolationValue = { } ):
+         AtmosphereSettings( tabulated_atmosphere ), atmosphereFile_( atmosphereTableFile ),
+         independentVariables_( independentVariablesNames ), dependentVariables_( dependentVariablesNames ),
+         specificGasConstant_( physical_constants::SPECIFIC_GAS_CONSTANT_AIR ), ratioOfSpecificHeats_( 1.4 ),
+         boundaryHandling_( boundaryHandling ), defaultExtrapolationValue_( defaultExtrapolationValue )
+     { }
+ 
+     //  Constructor with no specific gas constant nor ratio of specific heats.
+     /*
+      *  Constructor with no specific gas constant nor ratio of specific heats. These two values will be given
+      *  the default Earth value, or are specified inside the atmosphere table file (and thus, inside the
+      *  dependent variables vector).
+      *  \param atmosphereTableFile Map of files containing information on the atmosphere. The order of both
+      *      independent and dependent parameters needs to be specified in the independentVariablesNames and
+      *      dependentVariablesNames vectors, respectively. Note that specific gas constant and specific heat ratio
+      *      will be given the default constant values for Earth, unless they are included in the file map.
+      *  \param independentVariablesNames List of independent parameters describing the atmosphere.
+      *  \param dependentVariablesNames List of dependent parameters output by the atmosphere.
+      *  \param boundaryHandling List of methods for interpolation behavior when independent variable is out of range.
+      *  \param defaultExtrapolationValue List of default values to be used for extrapolation, in case of
+      *      use_default_value or use_default_value_with_warning as methods for boundaryHandling.
+      */
+     TabulatedAtmosphereSettings( const std::map< int, std::string >& atmosphereTableFile,
+                                  const std::vector< AtmosphereIndependentVariables >& independentVariablesNames,
+                                  const std::vector< AtmosphereDependentVariables >& dependentVariablesNames,
+                                  const std::vector< interpolators::BoundaryInterpolationType >& boundaryHandling,
+                                  const std::vector< double >& defaultExtrapolationValue ):
+         AtmosphereSettings( tabulated_atmosphere ), atmosphereFile_( atmosphereTableFile ),
+         independentVariables_( independentVariablesNames ), dependentVariables_( dependentVariablesNames ),
+         specificGasConstant_( physical_constants::SPECIFIC_GAS_CONSTANT_AIR ), ratioOfSpecificHeats_( 1.4 ),
+         boundaryHandling_( boundaryHandling )
+     {
+         // Assign default values
+         defaultExtrapolationValue_.resize( dependentVariablesNames.size( ) );
+         for( unsigned int i = 0; i < dependentVariablesNames.size( ); i++ )
+         {
+             for( unsigned int j = 0; j < independentVariablesNames.size( ); j++ )
+             {
+                 if( boundaryHandling_.at( j ) == interpolators::use_default_value ||
+                     boundaryHandling_.at( j ) == interpolators::use_default_value_with_warning )
+                 {
+                     defaultExtrapolationValue_.at( i ).push_back(
+                             std::make_pair( defaultExtrapolationValue.at( i ), defaultExtrapolationValue.at( i ) ) );
+                 }
+                 else
+                 {
+                     defaultExtrapolationValue_.at( i ).push_back( std::make_pair( IdentityElement::getAdditionIdentity< double >( ),
+                                                                                   IdentityElement::getAdditionIdentity< double >( ) ) );
+                 }
+             }
+         }
+     }
+ 
+     //  Constructor with no specific gas constant nor ratio of specific heats, and with
+     //  single boundary handling parameters.
+     /*
+      *  Constructor with no specific gas constant nor ratio of specific heats. These two values will be given
+      *  the default Earth value, or are specified inside the atmosphere table file (and thus, inside the
+      *  dependent variables vector). Only one boundary handling parameter is specified, which is then repeated for
+      *  dimension.
+      *  \param atmosphereTableFile Map of files containing information on the atmosphere. The order of both
+      *      independent and dependent parameters needs to be specified in the independentVariablesNames and
+      *      dependentVariablesNames vectors, respectively. Note that specific gas constant and specific heat ratio
+      *      will be given the default constant values for Earth, unless they are included in the file map.
+      *  \param independentVariablesNames List of independent parameters describing the atmosphere.
+      *  \param dependentVariablesNames List of dependent parameters output by the atmosphere.
+      *  \param boundaryHandling Method for interpolation behavior when independent variable is out of range.
+      *  \param defaultExtrapolationValue Default value to be used for extrapolation, in case of use_default_value or
+      *      use_default_value_with_warning as methods for boundaryHandling.
+      */
+     TabulatedAtmosphereSettings( const std::map< int, std::string >& atmosphereTableFile,
+                                  const std::vector< AtmosphereIndependentVariables >& independentVariablesNames,
+                                  const std::vector< AtmosphereDependentVariables >& dependentVariablesNames,
+                                  const interpolators::BoundaryInterpolationType boundaryHandling,
+                                  const double defaultExtrapolationValue = IdentityElement::getAdditionIdentity< double >( ) ):
+         TabulatedAtmosphereSettings(
+                 atmosphereTableFile,
+                 independentVariablesNames,
+                 dependentVariablesNames,
+                 physical_constants::SPECIFIC_GAS_CONSTANT_AIR,
+                 1.4,
+                 std::vector< interpolators::BoundaryInterpolationType >( independentVariablesNames.size( ), boundaryHandling ),
+                 std::vector< std::vector< std::pair< double, double > > >(
+                         dependentVariablesNames.size( ),
+                         std::vector< std::pair< double, double > >(
+                                 independentVariablesNames.size( ),
+                                 std::make_pair( defaultExtrapolationValue, defaultExtrapolationValue ) ) ) )
+     { }
+ 
+     //  Function to return file containing atmospheric properties.
+     /*
+      *  Function to return file containing atmospheric properties.
+      *  \return Map of filenames containing atmospheric properties.
+      */
+     std::map< int, std::string > getAtmosphereFile( )
+     {
+         return atmosphereFile_;
+     }
+ 
+     //  Function to return file containing atmospheric properties.
+     /*
+      *  Function to return file containing atmospheric properties.
+      *  \return Filename containing atmospheric properties.
+      */
+     std::string getAtmosphereFile( const unsigned int fileIndex )
+     {
+         return atmosphereFile_.at( fileIndex );
+     }
+ 
+     //  Function to return independent variables names.
+     /*
+      *  Function to return independent variables names.
+      *  \return Independent variables.
+      */
+     std::vector< AtmosphereIndependentVariables > getIndependentVariables( )
+     {
+         return independentVariables_;
+     }
+ 
+     //  Function to return dependent variables names.
+     /*
+      *  Function to return dependent variables names.
+      *  \return Dependent variables.
+      */
+     std::vector< AtmosphereDependentVariables > getDependentVariables( )
+     {
+         return dependentVariables_;
+     }
+ 
+     //  Function to return specific gas constant of the atmosphere.
+     /*
+      *  Function to return specific gas constant of the atmosphere.
+      *  \return Specific gas constant of the atmosphere.
+      */
+     double getSpecificGasConstant( )
+     {
+         return specificGasConstant_;
+     }
+ 
+     //  Function to return ratio of specific heats of the atmosphere.
+     /*
+      *  Function to return ratio of specific heats of the atmosphere.
+      *  \return Ratio of specific heats of the atmosphere at constant pressure and constant volume.
+      */
+     double getRatioOfSpecificHeats( )
+     {
+         return ratioOfSpecificHeats_;
+     }
+ 
+     //  Function to return boundary handling method.
+     /*
+      *  Function to return boundary handling method.
+      *  \return Boundary handling method for when independent variables are outside specified range.
+      */
+     std::vector< interpolators::BoundaryInterpolationType > getBoundaryHandling( )
+     {
+         return boundaryHandling_;
+     }
+ 
+     //  Function to return default extrapolation value.
+     /*
+      *  Function to return boundary handling method.
+      *  \return Boundary handling method for when independent variables are outside specified range.
+      */
+     std::vector< std::vector< std::pair< double, double > > > getDefaultExtrapolationValue( )
+     {
+         return defaultExtrapolationValue_;
+     }
+ 
+ private:
+     //  File containing atmospheric properties.
+     /*
+      *  File containing atmospheric properties, file should contain
+      *  columns of atmospheric data with at least density, pressure and temperature,
+      *  (whose order is specified in dependentVariables), and with at least one
+      *  indendent variables.
+      */
+     std::map< int, std::string > atmosphereFile_;
+ 
+     //  A vector of strings containing the names of the independent variables contained in the atmosphere file
+     /*
+      * A vector of strings containing the names of the independent variables contained in the atmosphere file,
+      * in the correct order (from left, being the first entry in the vector, to the right).
+      */
+     std::vector< AtmosphereIndependentVariables > independentVariables_;
+ 
+     //  A vector of strings containing the names of the variables contained in the atmosphere file
+     /*
+      * A vector of strings containing the names of the variables contained in the atmosphere file,
+      * in the correct order (from left, being the first entry in the vector, to the right).
+      */
+     std::vector< AtmosphereDependentVariables > dependentVariables_;
+ 
+     //  Specific gas constant of the atmosphere.
+     /*
+      * Specific gas constant of the atmosphere.
+      */
+     double specificGasConstant_;
+ 
+     //  Ratio of specific heats of the atmosphere at constant pressure and constant volume.
+     /*
+      *  Ratio of specific heats of the atmosphere at constant pressure and constant volume.
+      */
+     double ratioOfSpecificHeats_;
+ 
+     //  Behavior of interpolator when independent variable is outside range.
+     /*
+      *  Behavior of interpolator when independent variable is outside range.
+      */
+     std::vector< interpolators::BoundaryInterpolationType > boundaryHandling_;
+ 
+     //  Default value to be used for extrapolation.
+     /*
+      *  Default value to be used for extrapolation.
+      */
+     std::vector< std::vector< std::pair< double, double > > > defaultExtrapolationValue_;
+ };
+ 
+ class ScaledAtmosphereSettings : public AtmosphereSettings
+ {
+ public:
+     ScaledAtmosphereSettings( const std::shared_ptr< AtmosphereSettings > baseSettings,
+                               const double scaling,
+                               const bool isScalingAbsolute ):
+         AtmosphereSettings( scaled_atmosphere ), baseSettings_( baseSettings ), scaling_( [ = ]( const double ) { return scaling; } ),
+         isScalingAbsolute_( isScalingAbsolute )
+     { }
+ 
+     ScaledAtmosphereSettings( const std::shared_ptr< AtmosphereSettings > baseSettings,
+                               const std::function< double( const double ) > scaling,
+                               const bool isScalingAbsolute ):
+         AtmosphereSettings( scaled_atmosphere ), baseSettings_( baseSettings ), scaling_( scaling ), isScalingAbsolute_( isScalingAbsolute )
+     { }
+ 
+     std::shared_ptr< AtmosphereSettings > getBaseSettings( )
+     {
+         return baseSettings_;
+     }
+ 
+     std::function< double( const double ) > getScaling( )
+     {
+         return scaling_;
+     }
+ 
+     bool getIsScalingAbsolute( )
+     {
+         return isScalingAbsolute_;
+     }
+ 
+ protected:
+     std::shared_ptr< AtmosphereSettings > baseSettings_;
+ 
+     std::function< double( const double ) > scaling_;
+ 
+     bool isScalingAbsolute_;
+ };
+ 
+ //! @get_docstring(exponentialAtmosphereSettings,2)
+ inline std::shared_ptr< AtmosphereSettings > exponentialAtmosphereSettings(
+         const double densityScaleHeight,
+         const double densityAtZeroAltitude,
+         const double constantTemperature,
+         const double specificGasConstant = physical_constants::SPECIFIC_GAS_CONSTANT_AIR,
+         const double ratioOfSpecificHeats = 1.4 )
+ {
+     return std::make_shared< ExponentialAtmosphereSettings >(
+             densityScaleHeight, constantTemperature, densityAtZeroAltitude, specificGasConstant, ratioOfSpecificHeats );
+ }
+ 
+ //! @get_docstring(exponentialAtmosphereSettings,1)
+ inline std::shared_ptr< AtmosphereSettings > exponentialAtmosphereSettings( const double densityScaleHeight,
+                                                                             const double densityAtZeroAltitude )
+ {
+     return std::make_shared< ExponentialAtmosphereSettings >( densityScaleHeight, TUDAT_NAN, densityAtZeroAltitude, TUDAT_NAN, TUDAT_NAN );
+ }
+ 
+ //! @get_docstring(exponentialAtmosphereSettings,0)
+ inline std::shared_ptr< AtmosphereSettings > exponentialAtmosphereSettings( const std::string& bodyName )
+ {
+     BodiesWithPredefinedExponentialAtmospheres bodyId;
+     if( bodyName == "Earth" )
+     {
+         bodyId = BodiesWithPredefinedExponentialAtmospheres::earth;
+     }
+     else if( bodyName == "Mars" )
+     {
+         bodyId = BodiesWithPredefinedExponentialAtmospheres::mars;
+     }
+     else
+     {
+         throw std::runtime_error(
+                 "Error while creating exponential atmosphere. The body name provided "
+                 "does not match any predefined atmosphere model. Available models for: "
+                 "Earth, Mars." );
+     }
+     return std::make_shared< ExponentialAtmosphereSettings >( bodyId );
+ }
+ 
+ //! @get_docstring(nrlmsise00AtmosphereSettings)
+ inline std::shared_ptr< AtmosphereSettings > nrlmsise00AtmosphereSettings( const std::string dataFile = paths::getSpaceWeatherDataPath( ) +
+                                                                                    "/sw19571001.txt",
+                                                                                    const int geomagneticActivity = -1 )
+ {
+     return std::make_shared< NRLMSISE00AtmosphereSettings >( dataFile, geomagneticActivity);
+ }
+ 
+ typedef std::function< double( const double, const double, const double, const double ) > DensityFunction;
+ //! @get_docstring(customConstantTemperatureAtmosphereSettings,0)
+ inline std::shared_ptr< AtmosphereSettings > customConstantTemperatureAtmosphereSettings(
+         const std::function< double( const double ) > densityFunction,
+         const double constantTemperature,
+         const double specificGasConstant = physical_constants::SPECIFIC_GAS_CONSTANT_AIR,
+         const double ratioOfSpecificHeats = 1.4 )
+ {
+     DensityFunction fullDensityFunction = [ = ]( const double altitude, const double, const double, const double ) {
+         return densityFunction( altitude );
+     };
+     return std::make_shared< CustomConstantTemperatureAtmosphereSettings >(
+             fullDensityFunction, constantTemperature, specificGasConstant, ratioOfSpecificHeats );
+ }
+ 
+ //! @get_docstring(customConstantTemperatureAtmosphereSettings,1)
+ inline std::shared_ptr< AtmosphereSettings > customConstantTemperatureAtmosphereSettings(
+         const DensityFunction densityFunction,
+         const double constantTemperature,
+         const double specificGasConstant = physical_constants::SPECIFIC_GAS_CONSTANT_AIR,
+         const double ratioOfSpecificHeats = 1.4 )
+ {
+     return std::make_shared< CustomConstantTemperatureAtmosphereSettings >(
+             densityFunction, constantTemperature, specificGasConstant, ratioOfSpecificHeats );
+ }
+ 
+ //! @get_docstring(scaledAtmosphereSettings,0)
+ inline std::shared_ptr< AtmosphereSettings > scaledAtmosphereSettings( const std::shared_ptr< AtmosphereSettings > baseSettings,
+                                                                        const std::function< double( const double ) > scaling,
+                                                                        const bool isScalingAbsolute )
+ {
+     return std::make_shared< ScaledAtmosphereSettings >( baseSettings, scaling, isScalingAbsolute );
+ }
+ 
+ //! @get_docstring(scaledAtmosphereSettings,1)
+ inline std::shared_ptr< AtmosphereSettings > scaledAtmosphereSettings( const std::shared_ptr< AtmosphereSettings > baseSettings,
+                                                                        const double scaling,
+                                                                        const bool isScalingAbsolute )
+ {
+     return std::make_shared< ScaledAtmosphereSettings >( baseSettings, scaling, isScalingAbsolute );
+ }
+ 
+ inline std::shared_ptr< AtmosphereSettings > tabulatedAtmosphereSettings(
+         const std::string& atmosphereTableFile,
+         const std::vector< AtmosphereDependentVariables >& dependentVariablesNames = { density_dependent_atmosphere,
+                                                                                        pressure_dependent_atmosphere,
+                                                                                        temperature_dependent_atmosphere },
+         const double specificGasConstant = physical_constants::SPECIFIC_GAS_CONSTANT_AIR,
+         const double ratioOfSpecificHeats = 1.4 )
+ {
+     return std::make_shared< TabulatedAtmosphereSettings >( atmosphereTableFile,
+                                                             dependentVariablesNames,
+                                                             specificGasConstant,
+                                                             ratioOfSpecificHeats,
+                                                             interpolators::throw_exception_at_boundary );
+ }
+ 
+ //! @get_docstring(customWindModelSettings)
+ inline std::shared_ptr< WindModelSettings > customWindModelSettings(
+         const std::function< Eigen::Vector3d( const double, const double, const double, const double ) > windFunction,
+         const reference_frames::AerodynamicsReferenceFrames associatedFrame = reference_frames::vertical_frame )
+ {
+     return std::make_shared< CustomWindModelSettings >( windFunction, associatedFrame );
+ }
+ 
+ //! @get_docstring(constantWindModelSettings)
+ inline std::shared_ptr< WindModelSettings > constantWindModelSettings(
+         const Eigen::Vector3d constantWindVelocity,
+         const reference_frames::AerodynamicsReferenceFrames associatedFrame = reference_frames::vertical_frame )
+ {
+     return std::make_shared< ConstantWindModelSettings >( constantWindVelocity, associatedFrame );
+ }
+ 
+ //  Function to create a wind model.
+ /*
+  *  Function to create a wind model based on model-specific settings for the wind model.
+  *  \param windSettings Settings for the wind model that is to be created, defined
+  *  a pointer to an object of class (derived from) WindModelSettings.
+  *  \param body Name of the body for which the wind model is to be created.
+  *  \return Wind model created according to settings in windSettings.
+  */
+ std::shared_ptr< aerodynamics::WindModel > createWindModel( const std::shared_ptr< WindModelSettings > windSettings,
+                                                             const std::string& body );
+ 
+ //  Function to create an atmosphere model.
+ /*
+  *  Function to create an atmosphere model based on model-specific settings for the atmosphere.
+  *  \param atmosphereSettings Settings for the atmosphere model that is to be created, defined
+  *  a pointer to an object of class (derived from) AtmosphereSettings.
+  *  \param body Name of the body for which the atmosphere model is to be created.
+  *  \return Atmosphere model created according to settings in atmosphereSettings.
+  */
+ std::shared_ptr< aerodynamics::AtmosphereModel > createAtmosphereModel( const std::shared_ptr< AtmosphereSettings > atmosphereSettings,
+                                                                         const std::string& body );
+ 
+ }  // namespace simulation_setup
+ 
+ }  // namespace tudat
+ 
+ #endif  // TUDAT_CREATEATMOSPHEREMODEL_H

--- a/include/tudat/simulation/environment_setup/createAtmosphereModel.h
+++ b/include/tudat/simulation/environment_setup/createAtmosphereModel.h
@@ -507,7 +507,7 @@
       *  \param spaceWeatherFile File containing space weather data, as in
       *  https://celestrak.com/SpaceData/sw19571001.txt
       */
-     NRLMSISE00AtmosphereSettings( const std::string& spaceWeatherFile, const int geomagneticActivity = -1 ):
+     NRLMSISE00AtmosphereSettings( const std::string& spaceWeatherFile, const int geomagneticActivity = 1 ):
              AtmosphereSettings( nrlmsise00 ), spaceWeatherFile_( spaceWeatherFile ), geomagneticActivity_( geomagneticActivity ) 
      { }
  
@@ -544,7 +544,7 @@
       *  Default (-1) uses full vector of Ap values.
       *  Set to 1 to use daily Ap value.
       */
-     int geomagneticActivity_ = -1;
+     int geomagneticActivity_ = 1;
  };
  
  //  AtmosphereSettings for defining an atmosphere with tabulated data from file.
@@ -973,7 +973,7 @@
  //! @get_docstring(nrlmsise00AtmosphereSettings)
  inline std::shared_ptr< AtmosphereSettings > nrlmsise00AtmosphereSettings( const std::string dataFile = paths::getSpaceWeatherDataPath( ) +
                                                                                     "/sw19571001.txt",
-                                                                                    const int geomagneticActivity = -1 )
+                                                                                    const int geomagneticActivity = 1 )
  {
      return std::make_shared< NRLMSISE00AtmosphereSettings >( dataFile, geomagneticActivity);
  }

--- a/src/astro/aerodynamics/nrlmsise00Atmosphere.cpp
+++ b/src/astro/aerodynamics/nrlmsise00Atmosphere.cpp
@@ -50,10 +50,52 @@ void NRLMSISE00Atmosphere::computeProperties( const double altitude, const doubl
     }
     hashKey_ = hashKey;
 
-    setInputStruct( altitude, longitude, latitude, time );
+    // Define the shape model for Earth (WGS-84)
+    double equatorialRadius = 6378137.0;
+    double flattening = 1.0 / 298.257223563;
 
-    // Call NRLMSISE00
-    gtd7( &input_, &flags_, &output_ );
+    // Compute ellipsoide emi-minor axis
+    const double polarRadius = equatorialRadius * (1.0 - flattening);
+
+    // Compute square of first eccentricity
+    const double eccentricitySquared = 1.0 - (polarRadius * polarRadius) / (equatorialRadius * equatorialRadius);
+
+    // Define initial guess for geodetic latitude as the geocentric latitude
+    double geodeticLatitudeGuess = latitude;
+
+    // Find geodetic latitude through iterative computation
+    const double tolerance = 1.0E-16;
+    const int maxIterations = 10;
+    double geodeticLatitude = 0.0;
+    for (int i = 0; i < maxIterations; ++i)
+    {
+        // Compute prime vertical radius
+        const double curvatureRadius = equatorialRadius / std::sqrt(1.0 - eccentricitySquared * std::sin(geodeticLatitudeGuess) * std::sin(geodeticLatitudeGuess));
+
+        // Compute corrected geodetic latitude
+        geodeticLatitude = std::atan(std::tan(latitude) / (1.0 - eccentricitySquared * equatorialRadius / (equatorialRadius + altitude)));
+
+        // Check for convergence
+        if (std::abs(geodeticLatitude - geodeticLatitudeGuess) < tolerance)
+        { 
+            break;
+        }
+
+        // Update geodetic latitude for the next iteration
+        geodeticLatitudeGuess = geodeticLatitude;
+
+        // Throw an exception if the maximum number of iterations is reached
+        if (i == maxIterations - 1)
+        {
+            throw std::runtime_error("Maximum number of iterations reached in the computation of geodetic latitude.");
+        }
+
+    }
+
+    setInputStruct( altitude, longitude, geodeticLatitude, time );
+
+    // Call NRLMSISE00 accounting for the contributions from anomalous oxygen
+    gtd7d( &input_, &flags_, &output_ );
 
     // Retrieve density and temperature
     density_ = output_.d[ 5 ] * 1000.0;  // GM/CM3 to kg/M3

--- a/src/astro/aerodynamics/nrlmsise00InputFunctions.cpp
+++ b/src/astro/aerodynamics/nrlmsise00InputFunctions.cpp
@@ -8,100 +8,116 @@
  *    http://tudat.tudelft.nl/LICENSE.
  */
 
-#include "tudat/astro/aerodynamics/nrlmsise00Atmosphere.h"
-#include "tudat/astro/aerodynamics/nrlmsise00InputFunctions.h"
-#include "tudat/math/basic/mathematicalConstants.h"
-#include "tudat/astro/basic_astro/timeConversions.h"
+ #include "tudat/astro/aerodynamics/nrlmsise00Atmosphere.h"
+ #include "tudat/astro/aerodynamics/nrlmsise00InputFunctions.h"
+ #include "tudat/math/basic/mathematicalConstants.h"
+ #include "tudat/astro/basic_astro/timeConversions.h"
+ 
+ // Tudat library namespace.
+ namespace tudat
+ {
+ namespace aerodynamics
+ {
+ 
+ //! Function to convert Eigen::VectorXd to std::vector<double>
+ std::vector< double > eigenToStlVector( const Eigen::VectorXd& vector )
+ {
+     std::vector< double > stdVector( vector.rows( ) );
+     for( int i = 0; i < vector.rows( ); i++ )
+     {
+         stdVector[ i ] = vector( i );
+     }
+     return stdVector;
+ }
+ 
+ //! NRLMSISE00Input function
+ NRLMSISE00Input nrlmsiseInputFunctionFromMap( const double altitude,
+                                        const double longitude,
+                                        const double latitude,
+                                        const double time,
+                                        const tudat::input_output::solar_activity::SolarActivityDataMap& solarActivityMap,
+                                        const bool adjustSolarTime,
+                                        const double localSolarTime )
+ {
+     return nrlmsiseInputFunction(
+         altitude, longitude, latitude, time,
+         tudat::input_output::solar_activity::SolarActivityContainer( solarActivityMap ), adjustSolarTime, localSolarTime );
+ }
+ 
+ NRLMSISE00Input nrlmsiseInputFunction( const double altitude,
+                                        const double longitude,
+                                        const double latitude,
+                                        const double time,
+                                        const tudat::input_output::solar_activity::SolarActivityContainer& solarActivityContainer,
+                                        const bool adjustSolarTime,
+                                        const double localSolarTime,
+                                        const int geomagneticActivity )
+ {
+     using namespace tudat::input_output::solar_activity;
+ 
+     // Declare input data class member
+     NRLMSISE00Input nrlmsiseInputData;
+ 
+     // Julian dates
+     double julianDate = tudat::basic_astrodynamics::convertSecondsSinceEpochToJulianDay( time, basic_astrodynamics::JULIAN_DAY_ON_J2000 );
+     double julianDay = std::floor( julianDate - 0.5 ) + 0.5;
+ 
+     // Check if solar activity is found for current day.
+     SolarActivityDataPtr solarActivity = solarActivityContainer.getSolarActivityData( time );
+     SolarActivityDataPtr solarActivityDayOld = solarActivityContainer.getDelayedSolarActivityData( time, 1.0 );
+ 
+     // Compute julian date at the first of januari
+     double julianDate1Jan = tudat::basic_astrodynamics::convertCalendarDateToJulianDay( solarActivity->year, 1, 1, 0, 0, 0.0 );
+ 
+     nrlmsiseInputData.year = solarActivity->year;  // int
+     nrlmsiseInputData.dayOfTheYear = julianDay - julianDate1Jan + 1;
+     nrlmsiseInputData.secondOfTheDay = time -
+             tudat::basic_astrodynamics::convertJulianDayToSecondsSinceEpoch( julianDay, tudat::basic_astrodynamics::JULIAN_DAY_ON_J2000 );
+ 
+     if( solarActivity->fluxQualifier == 1 )
+     {
+         // requires adjustment
+         nrlmsiseInputData.f107 = solarActivityDayOld->solarRadioFlux107Adjusted;
+         nrlmsiseInputData.f107a = solarActivity->centered81DaySolarRadioFlux107Adjusted;
+     }
+     else
+     {
+         // no adjustment required
+         nrlmsiseInputData.f107 = solarActivityDayOld->solarRadioFlux107Observed;
+         nrlmsiseInputData.f107a = solarActivity->centered81DaySolarRadioFlux107Observed;
+     }
+     nrlmsiseInputData.apDaily = solarActivity->planetaryEquivalentAmplitudeAverage;
 
-// Tudat library namespace.
-namespace tudat
-{
-namespace aerodynamics
-{
+     // Create switches vector
+     nrlmsiseInputData.switches = std::vector< int >( 24, 1 );
+     nrlmsiseInputData.switches[ 0 ] = 0;
 
-//! Function to convert Eigen::VectorXd to std::vector<double>
-std::vector< double > eigenToStlVector( const Eigen::VectorXd& vector )
-{
-    std::vector< double > stdVector( vector.rows( ) );
-    for( int i = 0; i < vector.rows( ); i++ )
-    {
-        stdVector[ i ] = vector( i );
-    }
-    return stdVector;
-}
-
-//! NRLMSISE00Input function
-NRLMSISE00Input nrlmsiseInputFunctionFromMap( const double altitude,
-                                       const double longitude,
-                                       const double latitude,
-                                       const double time,
-                                       const tudat::input_output::solar_activity::SolarActivityDataMap& solarActivityMap,
-                                       const bool adjustSolarTime,
-                                       const double localSolarTime )
-{
-    return nrlmsiseInputFunction(
-        altitude, longitude, latitude, time,
-        tudat::input_output::solar_activity::SolarActivityContainer( solarActivityMap ), adjustSolarTime, localSolarTime );
-}
-
-NRLMSISE00Input nrlmsiseInputFunction( const double altitude,
-                                       const double longitude,
-                                       const double latitude,
-                                       const double time,
-                                       const tudat::input_output::solar_activity::SolarActivityContainer& solarActivityContainer,
-                                       const bool adjustSolarTime,
-                                       const double localSolarTime )
-{
-    using namespace tudat::input_output::solar_activity;
-
-    // Declare input data class member
-    NRLMSISE00Input nrlmsiseInputData;
-
-    // Julian dates
-    double julianDate = tudat::basic_astrodynamics::convertSecondsSinceEpochToJulianDay( time, basic_astrodynamics::JULIAN_DAY_ON_J2000 );
-    double julianDay = std::floor( julianDate - 0.5 ) + 0.5;
-
-    // Check if solar activity is found for current day.
-    SolarActivityDataPtr solarActivity = solarActivityContainer.getSolarActivityData( time );
-    SolarActivityDataPtr solarActivityDayOld = solarActivityContainer.getDelayedSolarActivityData( time, 1.0 );
-
-    // Compute julian date at the first of januari
-    double julianDate1Jan = tudat::basic_astrodynamics::convertCalendarDateToJulianDay( solarActivity->year, 1, 1, 0, 0, 0.0 );
-
-    nrlmsiseInputData.year = solarActivity->year;  // int
-    nrlmsiseInputData.dayOfTheYear = julianDay - julianDate1Jan + 1;
-    nrlmsiseInputData.secondOfTheDay = time -
-            tudat::basic_astrodynamics::convertJulianDayToSecondsSinceEpoch( julianDay, tudat::basic_astrodynamics::JULIAN_DAY_ON_J2000 );
-
-    if( solarActivity->fluxQualifier == 1 )
-    {
-        // requires adjustment
-        nrlmsiseInputData.f107 = solarActivityDayOld->solarRadioFlux107Adjusted;
-        nrlmsiseInputData.f107a = solarActivity->centered81DaySolarRadioFlux107Adjusted;
-    }
-    else
-    {
-        // no adjustment required
-        nrlmsiseInputData.f107 = solarActivityDayOld->solarRadioFlux107Observed;
-        nrlmsiseInputData.f107a = solarActivity->centered81DaySolarRadioFlux107Observed;
-    }
-    nrlmsiseInputData.apDaily = solarActivity->planetaryEquivalentAmplitudeAverage;
-    solarActivityContainer.getDelayedApValues( time, nrlmsiseInputData.apVector );
-
-    // Compute local solar time
-    // Hrs since begin of the day at longitude 0 (GMT) + Hrs passed at current longitude
-    if( adjustSolarTime )
-    {
-        nrlmsiseInputData.localSolarTime = localSolarTime;
-    }
-    else
-    {
-        nrlmsiseInputData.localSolarTime =
-                nrlmsiseInputData.secondOfTheDay / 3600.0 + longitude / ( tudat::mathematical_constants::PI / 12.0 );
-    }
-
-    return nrlmsiseInputData;
-}
-
-}  // namespace aerodynamics
-}  // namespace tudat
+     if ( geomagneticActivity == - 1 )
+     {
+         // Custom behavior: maybe just use apDaily in vector, or do not fill the vector
+         solarActivityContainer.getDelayedApValues( time, nrlmsiseInputData.apVector );
+         nrlmsiseInputData.switches[ 9 ] = -1;
+     }
+     else if ( geomagneticActivity == 1 )
+     {
+         // Example: zero ap vector
+         nrlmsiseInputData.apVector = std::vector< double >( 6, 0.0 );
+     }
+ 
+     // Compute local solar time
+     // Hrs since begin of the day at longitude 0 (GMT) + Hrs passed at current longitude
+     if( adjustSolarTime )
+     {
+         nrlmsiseInputData.localSolarTime = localSolarTime;
+     }
+     else
+     {
+         nrlmsiseInputData.localSolarTime =
+                 nrlmsiseInputData.secondOfTheDay / 3600.0 + longitude / ( tudat::mathematical_constants::PI / 12.0 );
+     }
+ 
+     return nrlmsiseInputData;
+ }
+ 
+ }  // namespace aerodynamics
+ }  // namespace tudat

--- a/src/simulation/environment_setup/createAtmosphereModel.cpp
+++ b/src/simulation/environment_setup/createAtmosphereModel.cpp
@@ -8,216 +8,228 @@
  *    http://tudat.tudelft.nl/LICENSE.
  */
 
-#include "tudat/astro/aerodynamics/exponentialAtmosphere.h"
-#include "tudat/astro/aerodynamics/tabulatedAtmosphere.h"
-#if TUDAT_BUILD_WITH_NRLMSISE
-#include "tudat/astro/aerodynamics/nrlmsise00Atmosphere.h"
-#include "tudat/astro/aerodynamics/nrlmsise00InputFunctions.h"
-#endif
-#include "tudat/io/basicInputOutput.h"
-#include "tudat/io/solarActivityData.h"
-#include "tudat/simulation/environment_setup/createAtmosphereModel.h"
-
-namespace tudat
-{
-
-namespace simulation_setup
-{
-
-//! Function to create a wind model.
-std::shared_ptr< aerodynamics::WindModel > createWindModel( const std::shared_ptr< WindModelSettings > windSettings,
-                                                            const std::string& body )
-{
-    std::shared_ptr< aerodynamics::WindModel > windModel;
-
-    // Check wind model type and create requested model
-    switch( windSettings->getWindModelType( ) )
-    {
-        case constant_wind_model: {
-            // Check input consistency
-            std::shared_ptr< ConstantWindModelSettings > customWindModelSettings =
-                    std::dynamic_pointer_cast< ConstantWindModelSettings >( windSettings );
-
-            if( customWindModelSettings == nullptr )
-            {
-                throw std::runtime_error( "Error when making constant wind model for body " + body + ", input is incompatible" );
-            }
-            windModel = std::make_shared< aerodynamics::ConstantWindModel >( customWindModelSettings->getConstantWindVelocity( ),
-                                                                             customWindModelSettings->getAssociatedFrame( ) );
-            break;
-        }
-        case custom_wind_model: {
-            // Check input consistency
-            std::shared_ptr< CustomWindModelSettings > customWindModelSettings =
-                    std::dynamic_pointer_cast< CustomWindModelSettings >( windSettings );
-
-            if( customWindModelSettings == nullptr )
-            {
-                throw std::runtime_error( "Error when making custom wind model for body " + body + ", input is incompatible" );
-            }
-            windModel = std::make_shared< aerodynamics::CustomWindModel >( customWindModelSettings->getWindFunction( ),
-                                                                           customWindModelSettings->getAssociatedFrame( ) );
-
-            break;
-        }
-        default:
-            throw std::runtime_error( "Error when making wind model for body " + body + ", input type not recognized" );
-    }
-
-    return windModel;
-}
-
-//! Function to create an atmosphere model.
-std::shared_ptr< aerodynamics::AtmosphereModel > createAtmosphereModel( const std::shared_ptr< AtmosphereSettings > atmosphereSettings,
-                                                                        const std::string& body )
-{
-    using namespace tudat::aerodynamics;
-
-    // Declare return object.
-    std::shared_ptr< AtmosphereModel > atmosphereModel;
-
-    // Check which type of atmosphere model is to be created.
-    switch( atmosphereSettings->getAtmosphereType( ) )
-    {
-        case exponential_atmosphere: {
-            // Check whether settings for atmosphere are consistent with its type.
-            std::shared_ptr< ExponentialAtmosphereSettings > exponentialAtmosphereSettings =
-                    std::dynamic_pointer_cast< ExponentialAtmosphereSettings >( atmosphereSettings );
-
-            if( exponentialAtmosphereSettings == nullptr )
-            {
-                throw std::runtime_error( "Error, expected exponential atmosphere settings for body " + body );
-            }
-            else
-            {
-                // Create and initialize exponential atmosphere model.
-                std::shared_ptr< ExponentialAtmosphere > exponentialAtmosphereModel;
-                if( exponentialAtmosphereSettings->getBodyName( ) == undefined_body )
-                {
-                    exponentialAtmosphereModel =
-                            std::make_shared< ExponentialAtmosphere >( exponentialAtmosphereSettings->getDensityScaleHeight( ),
-                                                                       exponentialAtmosphereSettings->getConstantTemperature( ),
-                                                                       exponentialAtmosphereSettings->getDensityAtZeroAltitude( ),
-                                                                       exponentialAtmosphereSettings->getSpecificGasConstant( ),
-                                                                       exponentialAtmosphereSettings->getRatioOfSpecificHeats( ) );
-                }
-                else
-                {
-                    exponentialAtmosphereModel = std::make_shared< ExponentialAtmosphere >( exponentialAtmosphereSettings->getBodyName( ) );
-                }
-                atmosphereModel = exponentialAtmosphereModel;
-            }
-            break;
-        }
-        case custom_constant_temperature_atmosphere: {
-            // Check whether settings for atmosphere are consistent with its type.
-            std::shared_ptr< CustomConstantTemperatureAtmosphereSettings > customConstantTemperatureAtmosphereSettings =
-                    std::dynamic_pointer_cast< CustomConstantTemperatureAtmosphereSettings >( atmosphereSettings );
-            if( customConstantTemperatureAtmosphereSettings == nullptr )
-            {
-                throw std::runtime_error( "Error, expected exponential atmosphere settings for body " + body );
-            }
-            else
-            {
-                // Create and initialize exponential atmosphere model.
-                std::shared_ptr< CustomConstantTemperatureAtmosphere > customConstantTemperatureAtmosphereModel;
-                if( customConstantTemperatureAtmosphereSettings->getModelSpecificParameters( ).empty( ) )
-                {
-                    customConstantTemperatureAtmosphereModel = std::make_shared< CustomConstantTemperatureAtmosphere >(
-                            customConstantTemperatureAtmosphereSettings->getDensityFunction( ),
-                            customConstantTemperatureAtmosphereSettings->getConstantTemperature( ),
-                            customConstantTemperatureAtmosphereSettings->getSpecificGasConstant( ),
-                            customConstantTemperatureAtmosphereSettings->getRatioOfSpecificHeats( ) );
-                }
-                else
-                {
-                    customConstantTemperatureAtmosphereModel = std::make_shared< CustomConstantTemperatureAtmosphere >(
-                            customConstantTemperatureAtmosphereSettings->getDensityFunctionType( ),
-                            customConstantTemperatureAtmosphereSettings->getConstantTemperature( ),
-                            customConstantTemperatureAtmosphereSettings->getSpecificGasConstant( ),
-                            customConstantTemperatureAtmosphereSettings->getRatioOfSpecificHeats( ),
-                            customConstantTemperatureAtmosphereSettings->getModelSpecificParameters( ) );
-                }
-                atmosphereModel = customConstantTemperatureAtmosphereModel;
-            }
-            break;
-        }
-        case tabulated_atmosphere: {
-            // Check whether settings for atmosphere are consistent with its type
-            std::shared_ptr< TabulatedAtmosphereSettings > tabulatedAtmosphereSettings =
-                    std::dynamic_pointer_cast< TabulatedAtmosphereSettings >( atmosphereSettings );
-            if( tabulatedAtmosphereSettings == nullptr )
-            {
-                throw std::runtime_error( "Error, expected tabulated atmosphere settings for body " + body );
-            }
-            else
-            {
-                // Create and initialize tabulated atmosphere model.
-                atmosphereModel = std::make_shared< TabulatedAtmosphere >( tabulatedAtmosphereSettings->getAtmosphereFile( ),
-                                                                           tabulatedAtmosphereSettings->getIndependentVariables( ),
-                                                                           tabulatedAtmosphereSettings->getDependentVariables( ),
-                                                                           tabulatedAtmosphereSettings->getSpecificGasConstant( ),
-                                                                           tabulatedAtmosphereSettings->getRatioOfSpecificHeats( ),
-                                                                           tabulatedAtmosphereSettings->getBoundaryHandling( ),
-                                                                           tabulatedAtmosphereSettings->getDefaultExtrapolationValue( ) );
-            }
-            break;
-        }
-#if TUDAT_BUILD_WITH_NRLMSISE
-        case nrlmsise00: {
-            std::string spaceWeatherFilePath;
-            std::shared_ptr< NRLMSISE00AtmosphereSettings > nrlmsise00AtmosphereSettings =
-                    std::dynamic_pointer_cast< NRLMSISE00AtmosphereSettings >( atmosphereSettings );
-
-            if( nrlmsise00AtmosphereSettings == nullptr )
-            {
-                // Use default space weather file stored in tudatBundle.
-                spaceWeatherFilePath = paths::getSpaceWeatherDataPath( ) + "/sw19571001.txt";
-            }
-            else
-            {
-                // Use space weather file specified by user.
-                spaceWeatherFilePath = nrlmsise00AtmosphereSettings->getSpaceWeatherFile( );
-            }
-
-            tudat::input_output::solar_activity::SolarActivityDataMap solarActivityData =
-                    tudat::input_output::solar_activity::readSolarActivityData( spaceWeatherFilePath );
-
-            // Create atmosphere model using NRLMISE00 input function
-            atmosphereModel = std::make_shared< aerodynamics::NRLMSISE00Atmosphere >( solarActivityData, true );
-            break;
-        }
-#endif
-        case scaled_atmosphere: {
-            // Check consistency of type and class.
-            std::shared_ptr< ScaledAtmosphereSettings > scaledAtmosphereSettings =
-                    std::dynamic_pointer_cast< ScaledAtmosphereSettings >( atmosphereSettings );
-            if( scaledAtmosphereSettings == nullptr )
-            {
-                throw std::runtime_error( "Error, expected scaled atmosphere settings for body " + body );
-            }
-            else
-            {
-                std::shared_ptr< AtmosphereModel > baseAtmosphere =
-                        createAtmosphereModel( scaledAtmosphereSettings->getBaseSettings( ), body );
-                atmosphereModel = std::make_shared< ScaledAtmosphereModel >(
-                        baseAtmosphere, scaledAtmosphereSettings->getScaling( ), scaledAtmosphereSettings->getIsScalingAbsolute( ) );
-            }
-            break;
-        }
-        default:
-            throw std::runtime_error( "Error, did not recognize atmosphere model settings type " +
-                                      std::to_string( atmosphereSettings->getAtmosphereType( ) ) );
-    }
-
-    if( atmosphereSettings->getWindSettings( ) != nullptr )
-    {
-        atmosphereModel->setWindModel( createWindModel( atmosphereSettings->getWindSettings( ), body ) );
-    }
-
-    return atmosphereModel;
-}
-
-}  // namespace simulation_setup
-
-}  // namespace tudat
+ #include "tudat/astro/aerodynamics/exponentialAtmosphere.h"
+ #include "tudat/astro/aerodynamics/tabulatedAtmosphere.h"
+ #if TUDAT_BUILD_WITH_NRLMSISE
+ #include "tudat/astro/aerodynamics/nrlmsise00Atmosphere.h"
+ #include "tudat/astro/aerodynamics/nrlmsise00InputFunctions.h"
+ #endif
+ #include "tudat/io/basicInputOutput.h"
+ #include "tudat/io/solarActivityData.h"
+ #include "tudat/simulation/environment_setup/createAtmosphereModel.h"
+ 
+ namespace tudat
+ {
+ 
+ namespace simulation_setup
+ {
+ 
+ //! Function to create a wind model.
+ std::shared_ptr< aerodynamics::WindModel > createWindModel( const std::shared_ptr< WindModelSettings > windSettings,
+                                                             const std::string& body )
+ {
+     std::shared_ptr< aerodynamics::WindModel > windModel;
+ 
+     // Check wind model type and create requested model
+     switch( windSettings->getWindModelType( ) )
+     {
+         case constant_wind_model: {
+             // Check input consistency
+             std::shared_ptr< ConstantWindModelSettings > customWindModelSettings =
+                     std::dynamic_pointer_cast< ConstantWindModelSettings >( windSettings );
+ 
+             if( customWindModelSettings == nullptr )
+             {
+                 throw std::runtime_error( "Error when making constant wind model for body " + body + ", input is incompatible" );
+             }
+             windModel = std::make_shared< aerodynamics::ConstantWindModel >( customWindModelSettings->getConstantWindVelocity( ),
+                                                                              customWindModelSettings->getAssociatedFrame( ) );
+             break;
+         }
+         case custom_wind_model: {
+             // Check input consistency
+             std::shared_ptr< CustomWindModelSettings > customWindModelSettings =
+                     std::dynamic_pointer_cast< CustomWindModelSettings >( windSettings );
+ 
+             if( customWindModelSettings == nullptr )
+             {
+                 throw std::runtime_error( "Error when making custom wind model for body " + body + ", input is incompatible" );
+             }
+             windModel = std::make_shared< aerodynamics::CustomWindModel >( customWindModelSettings->getWindFunction( ),
+                                                                            customWindModelSettings->getAssociatedFrame( ) );
+ 
+             break;
+         }
+         default:
+             throw std::runtime_error( "Error when making wind model for body " + body + ", input type not recognized" );
+     }
+ 
+     return windModel;
+ }
+ 
+ //! Function to create an atmosphere model.
+ std::shared_ptr< aerodynamics::AtmosphereModel > createAtmosphereModel( const std::shared_ptr< AtmosphereSettings > atmosphereSettings,
+                                                                         const std::string& body )
+ {
+     using namespace tudat::aerodynamics;
+ 
+     // Declare return object.
+     std::shared_ptr< AtmosphereModel > atmosphereModel;
+ 
+     // Check which type of atmosphere model is to be created.
+     switch( atmosphereSettings->getAtmosphereType( ) )
+     {
+         case exponential_atmosphere: {
+             // Check whether settings for atmosphere are consistent with its type.
+             std::shared_ptr< ExponentialAtmosphereSettings > exponentialAtmosphereSettings =
+                     std::dynamic_pointer_cast< ExponentialAtmosphereSettings >( atmosphereSettings );
+ 
+             if( exponentialAtmosphereSettings == nullptr )
+             {
+                 throw std::runtime_error( "Error, expected exponential atmosphere settings for body " + body );
+             }
+             else
+             {
+                 // Create and initialize exponential atmosphere model.
+                 std::shared_ptr< ExponentialAtmosphere > exponentialAtmosphereModel;
+                 if( exponentialAtmosphereSettings->getBodyName( ) == undefined_body )
+                 {
+                     exponentialAtmosphereModel =
+                             std::make_shared< ExponentialAtmosphere >( exponentialAtmosphereSettings->getDensityScaleHeight( ),
+                                                                        exponentialAtmosphereSettings->getConstantTemperature( ),
+                                                                        exponentialAtmosphereSettings->getDensityAtZeroAltitude( ),
+                                                                        exponentialAtmosphereSettings->getSpecificGasConstant( ),
+                                                                        exponentialAtmosphereSettings->getRatioOfSpecificHeats( ) );
+                 }
+                 else
+                 {
+                     exponentialAtmosphereModel = std::make_shared< ExponentialAtmosphere >( exponentialAtmosphereSettings->getBodyName( ) );
+                 }
+                 atmosphereModel = exponentialAtmosphereModel;
+             }
+             break;
+         }
+         case custom_constant_temperature_atmosphere: {
+             // Check whether settings for atmosphere are consistent with its type.
+             std::shared_ptr< CustomConstantTemperatureAtmosphereSettings > customConstantTemperatureAtmosphereSettings =
+                     std::dynamic_pointer_cast< CustomConstantTemperatureAtmosphereSettings >( atmosphereSettings );
+             if( customConstantTemperatureAtmosphereSettings == nullptr )
+             {
+                 throw std::runtime_error( "Error, expected exponential atmosphere settings for body " + body );
+             }
+             else
+             {
+                 // Create and initialize exponential atmosphere model.
+                 std::shared_ptr< CustomConstantTemperatureAtmosphere > customConstantTemperatureAtmosphereModel;
+                 if( customConstantTemperatureAtmosphereSettings->getModelSpecificParameters( ).empty( ) )
+                 {
+                     customConstantTemperatureAtmosphereModel = std::make_shared< CustomConstantTemperatureAtmosphere >(
+                             customConstantTemperatureAtmosphereSettings->getDensityFunction( ),
+                             customConstantTemperatureAtmosphereSettings->getConstantTemperature( ),
+                             customConstantTemperatureAtmosphereSettings->getSpecificGasConstant( ),
+                             customConstantTemperatureAtmosphereSettings->getRatioOfSpecificHeats( ) );
+                 }
+                 else
+                 {
+                     customConstantTemperatureAtmosphereModel = std::make_shared< CustomConstantTemperatureAtmosphere >(
+                             customConstantTemperatureAtmosphereSettings->getDensityFunctionType( ),
+                             customConstantTemperatureAtmosphereSettings->getConstantTemperature( ),
+                             customConstantTemperatureAtmosphereSettings->getSpecificGasConstant( ),
+                             customConstantTemperatureAtmosphereSettings->getRatioOfSpecificHeats( ),
+                             customConstantTemperatureAtmosphereSettings->getModelSpecificParameters( ) );
+                 }
+                 atmosphereModel = customConstantTemperatureAtmosphereModel;
+             }
+             break;
+         }
+         case tabulated_atmosphere: {
+             // Check whether settings for atmosphere are consistent with its type
+             std::shared_ptr< TabulatedAtmosphereSettings > tabulatedAtmosphereSettings =
+                     std::dynamic_pointer_cast< TabulatedAtmosphereSettings >( atmosphereSettings );
+             if( tabulatedAtmosphereSettings == nullptr )
+             {
+                 throw std::runtime_error( "Error, expected tabulated atmosphere settings for body " + body );
+             }
+             else
+             {
+                 // Create and initialize tabulated atmosphere model.
+                 atmosphereModel = std::make_shared< TabulatedAtmosphere >( tabulatedAtmosphereSettings->getAtmosphereFile( ),
+                                                                            tabulatedAtmosphereSettings->getIndependentVariables( ),
+                                                                            tabulatedAtmosphereSettings->getDependentVariables( ),
+                                                                            tabulatedAtmosphereSettings->getSpecificGasConstant( ),
+                                                                            tabulatedAtmosphereSettings->getRatioOfSpecificHeats( ),
+                                                                            tabulatedAtmosphereSettings->getBoundaryHandling( ),
+                                                                            tabulatedAtmosphereSettings->getDefaultExtrapolationValue( ) );
+             }
+             break;
+         }
+ #if TUDAT_BUILD_WITH_NRLMSISE
+         case nrlmsise00: {
+             std::string spaceWeatherFilePath;
+             int geomagneticActivity;
+     
+             // Attempt to cast the atmosphereSettings to NRLMSISE00AtmosphereSettings
+             std::shared_ptr< NRLMSISE00AtmosphereSettings > nrlmsise00AtmosphereSettings =
+                     std::dynamic_pointer_cast< NRLMSISE00AtmosphereSettings >( atmosphereSettings );
+     
+             if( nrlmsise00AtmosphereSettings == nullptr )
+             {
+                 // Use default space weather file stored in tudatBundle and geomagnetic storm conditions when no settings provided
+                 spaceWeatherFilePath = paths::getSpaceWeatherDataPath( ) + "/sw19571001.txt";
+                 geomagneticActivity = -1;  // Default geomagnetic activity when no settings provided
+             }
+             else if (nrlmsise00AtmosphereSettings->getSpaceWeatherFile().empty())
+             {
+                 // Use default space weather file stored in tudatBundle when the file is not provided
+                 spaceWeatherFilePath = paths::getSpaceWeatherDataPath() + "/sw19571001.txt";
+                 geomagneticActivity = nrlmsise00AtmosphereSettings->getGeomagneticActivity();
+             }
+             else
+             {
+                 // Use space weather file specified by user and the geomagnetic activity specified by user
+                 spaceWeatherFilePath = nrlmsise00AtmosphereSettings->getSpaceWeatherFile();
+                 geomagneticActivity = nrlmsise00AtmosphereSettings->getGeomagneticActivity();
+             }
+     
+             // Read the solar activity data from the specified file
+             tudat::input_output::solar_activity::SolarActivityDataMap solarActivityData =
+                     tudat::input_output::solar_activity::readSolarActivityData( spaceWeatherFilePath );
+     
+             // Create the atmosphere model using the NRLMSISE00 input function
+             atmosphereModel = std::make_shared< aerodynamics::NRLMSISE00Atmosphere >( solarActivityData, true, geomagneticActivity );
+             break;
+         }
+ #endif
+         case scaled_atmosphere: {
+             // Check consistency of type and class.
+             std::shared_ptr< ScaledAtmosphereSettings > scaledAtmosphereSettings =
+                     std::dynamic_pointer_cast< ScaledAtmosphereSettings >( atmosphereSettings );
+             if( scaledAtmosphereSettings == nullptr )
+             {
+                 throw std::runtime_error( "Error, expected scaled atmosphere settings for body " + body );
+             }
+             else
+             {
+                 std::shared_ptr< AtmosphereModel > baseAtmosphere =
+                         createAtmosphereModel( scaledAtmosphereSettings->getBaseSettings( ), body );
+                 atmosphereModel = std::make_shared< ScaledAtmosphereModel >(
+                         baseAtmosphere, scaledAtmosphereSettings->getScaling( ), scaledAtmosphereSettings->getIsScalingAbsolute( ) );
+             }
+             break;
+         }
+         default:
+             throw std::runtime_error( "Error, did not recognize atmosphere model settings type " +
+                                       std::to_string( atmosphereSettings->getAtmosphereType( ) ) );
+     }
+ 
+     if( atmosphereSettings->getWindSettings( ) != nullptr )
+     {
+         atmosphereModel->setWindModel( createWindModel( atmosphereSettings->getWindSettings( ), body ) );
+     }
+ 
+     return atmosphereModel;
+ }
+ 
+ }  // namespace simulation_setup
+ 
+ }  // namespace tudat

--- a/src/simulation/environment_setup/createAtmosphereModel.cpp
+++ b/src/simulation/environment_setup/createAtmosphereModel.cpp
@@ -176,7 +176,7 @@
              {
                  // Use default space weather file stored in tudatBundle and geomagnetic storm conditions when no settings provided
                  spaceWeatherFilePath = paths::getSpaceWeatherDataPath( ) + "/sw19571001.txt";
-                 geomagneticActivity = -1;  // Default geomagnetic activity when no settings provided
+                 geomagneticActivity = 1;  // Default geomagnetic activity when no settings provided
              }
              else if (nrlmsise00AtmosphereSettings->getSpaceWeatherFile().empty())
              {

--- a/tests/src/astro/aerodynamics/unitTestNRLMSISE00Atmosphere.cpp
+++ b/tests/src/astro/aerodynamics/unitTestNRLMSISE00Atmosphere.cpp
@@ -14,1336 +14,1597 @@
  *
  */
 
-#define BOOST_TEST_DYN_LINK
-#define BOOST_TEST_MAIN
-
-#include <algorithm>
-#include <vector>
-#include <utility>
-
-#include <boost/test/unit_test.hpp>
-
-#include "tudat/astro/aerodynamics/nrlmsise00Atmosphere.h"
-#include "tudat/astro/aerodynamics/tabulatedAtmosphere.h"
-#include "tudat/io/basicInputOutput.h"
-
-#include "tudat/astro/aerodynamics/nrlmsise00InputFunctions.h"
-
-#include "tudat/math/basic/mathematicalConstants.h"
-#include "tudat/simulation/simulation.h"
-
-namespace tudat
-{
-
-namespace unit_tests
-{
-
-//! Test NRLMSISE00 atmosphere model.
-BOOST_AUTO_TEST_SUITE( test_nrlmsise00_atmosphere )
-
-using namespace tudat;
-using tudat::aerodynamics::NRLMSISE00Atmosphere;
-using tudat::aerodynamics::NRLMSISE00Input;
-using tudat::mathematical_constants::PI;
-
-// Global variable to be changed by tests and function.
-NRLMSISE00Input data;
-
-// Define input data generic (or almost completely) for all tests.
-NRLMSISE00Input gen_data( 0, 172, 29000.0, 16.0, 150.0, 150.0, 4.0 );
-std::vector< double > gen_input = { 400.0E3, -70.0 * PI / 180.0, 60.0 * PI / 180.0, 0.0 };
-
-//! Test function to update the NRLMSISE00 iunput data as a function of time and geometry.
-NRLMSISE00Input nrlmsiseTestFunction( double altitude,
-                                      double longitude,
-                                      double latitude,
-                                      double time,
-                                      bool computeLocalSolarTime,
-                                      bool invariableLower )
-{
-    // Functionality encountered in the original wrapper class, these
-    // have been moved out of the Tudat space and now into the
-    // application space. This is given here as an example of how to
-    // solve these problems and to keep the code for future generations :).
-    // NOTE: both these functions are switched of for testing.
-    if( computeLocalSolarTime )
-    {
-        data.localSolarTime = data.secondOfTheDay / 3600.0 + longitude / 15.0;
-    }
-
-    if( invariableLower && altitude < 80000.0 )
-    {
-        data.f107 = 150.0;
-        data.f107a = 150.0;
-        data.apDaily = 4.0;
-        data.switches[ 9 ] = 1;
-    }
-
-    return data;
-}
-
-//! Perform NRLMSISE-00 test of get functions.
-//  Check the consistency between full output and get parameter output functions.
-BOOST_AUTO_TEST_CASE( testNRLMSISE00AtmosphereTestFunctions )
-{
-    // Manual reset of switch
-    gen_data.switches[ 9 ] = 1;
-
-    // Define tolerance for equality
-    double tolerance = 1.0E-18;
-
-    // Create the model
-    NRLMSISE00Atmosphere model( std::bind( &nrlmsiseTestFunction,
-                                           std::placeholders::_1,
-                                           std::placeholders::_2,
-                                           std::placeholders::_3,
-                                           std::placeholders::_4,
-                                           false,
-                                           false ) );
-
-    // Create local copy of input and define variations
-    data = gen_data;
-    std::vector< double > input = gen_input;
-
-    // Define variations from the standard case
-    // First case is the default case
-
-    // Get full output and extract density and temperature
-    std::pair< std::vector< double >, std::vector< double > > output =
-            model.getFullOutput( input[ 0 ], input[ 1 ], input[ 2 ], input[ 3 ] );
-    double density1 = output.first[ 5 ] * 1000.0;
-    double temperature1 = output.second[ 1 ];
-
-    // Get density and temperature from functions
-    double density2 = model.getDensity( input[ 0 ], input[ 1 ], input[ 2 ], input[ 3 ] );
-    double temperature2 = model.getTemperature( input[ 0 ], input[ 1 ], input[ 2 ], input[ 3 ] );
-
-    // Check densities and temperatures.
-    BOOST_CHECK_CLOSE_FRACTION( density1, density2, tolerance );
-    BOOST_CHECK_CLOSE_FRACTION( temperature1, temperature2, tolerance );
-}
-
-//! Perform test of hashing function.
-//  Hashing is important to speed up the model and prevent double
-//  calculations, however it can be tricky too, so make sure to reset the hash when in doubt.
-BOOST_AUTO_TEST_CASE( testNRLMSISE00AtmosphereTestHashing )
-{
-    // Create the model
-    NRLMSISE00Atmosphere model( std::bind( &nrlmsiseTestFunction,
-                                           std::placeholders::_1,
-                                           std::placeholders::_2,
-                                           std::placeholders::_3,
-                                           std::placeholders::_4,
-                                           false,
-                                           false ) );
-
-    // Create local copy of input and define variations
-    data = gen_data;
-    std::vector< double > input = gen_input;
-    // Define variations from the standard case
-    // First case is the default case
-
-    double density1 = model.getDensity( input[ 0 ], input[ 1 ], input[ 2 ], input[ 3 ] );
-
-    // Increase the daily F10.7 average (from 140.0)
-    data.f107 = 180.0;
-    double density2 = model.getDensity( input[ 0 ], input[ 1 ], input[ 2 ], input[ 3 ] );
-
-    // See that although the F10.7 has changed, no recalculation was
-    // triggered. The densities remain the same!
-    BOOST_CHECK_EQUAL( density1, density2 );
-
-    // In order to trigger a recalculation we can
-    // (A) reset the hash
-    model.resetHashKey( );
-    double density3 = model.getDensity( input[ 0 ], input[ 1 ], input[ 2 ], input[ 3 ] );
-
-    // And indeed observe a new density is calculated and is not equal
-    // anymore to the old one.
-    BOOST_CHECK_PREDICATE( std::not_equal_to< double >( ), (density1)( density3 ) );
-
-    // Recalculate density1, to "reset" the internal state of the
-    // model , for the next demo
-    data.f107 = 150.0;
-    model.resetHashKey( );
-    double density1new = model.getDensity( input[ 0 ], input[ 1 ], input[ 2 ], input[ 3 ] );
-    BOOST_CHECK_EQUAL( density1new, density1 );
-    data.f107 = 180.0;
-
-    // (B) change any of the four indepedent parameters, namely
-    // altitude, latitude, longitude, and/or time. Since time is not
-    // used in our current NRLMSISE00InputFunction of this test, we
-    // can change time without changing anything.
-    double density4 = model.getDensity( input[ 0 ], input[ 1 ], input[ 2 ], input[ 3 ] + 42.0 );
-
-    // The densities are not equal (ergo recalculated). Furthermore
-    // the density using method (B) is exactly equal to the density
-    // obtained using solution (A), this shows that both are equal in
-    // triggering recalculations.
-    BOOST_CHECK_PREDICATE( std::not_equal_to< double >( ), (density1)( density4 ) );
-    BOOST_CHECK_EQUAL( density3, density4 );
-}
-
-//! Perform NRLMSISE-00 test 1
-//  Check values for 11 output parameters on against (hardcoded) values
-//  obtained from the similar nrlmsise-test.c program.
-BOOST_AUTO_TEST_CASE( testNRLMSISE00AtmosphereTest1 )
-{
-
-    // Define verification data for specific test and tolerance
-    double tolerance = 1.0E-12;
-    std::vector< double > verificationData = { 6.665176904952E+05, 1.138805559752E+08, 1.998210925573E+07, 4.022763585713E+05,
-                                               3.557464994516E+03, 4.074713532757E-15, 3.475312399717E+04, 4.095913268293E+06,
-                                               2.667273209336E+04, 1.250539943561E+03, 1.241416130019E+03 };
-
-    // Create the model
-    NRLMSISE00Atmosphere model( std::bind( &nrlmsiseTestFunction,
-                                           std::placeholders::_1,
-                                           std::placeholders::_2,
-                                           std::placeholders::_3,
-                                           std::placeholders::_4,
-                                           false,
-                                           false ) );
-
-    // Create local copy of input and define variations
-    data = gen_data;
-    std::vector< double > input = gen_input;
-    // Define variations from the standard case
-    // First case is the default case
-
-    // Get full output for current test case
-    std::pair< std::vector< double >, std::vector< double > > output =
-            model.getFullOutput( input[ 0 ], input[ 1 ], input[ 2 ], input[ 3 ] );
-
-    // Loop through output and perform tests
-    for( unsigned i = 0; i < 9; i++ )
-    {
-        BOOST_CHECK_CLOSE_FRACTION( verificationData[ i ], output.first[ i ], tolerance );
-    }
-    for( unsigned i = 0; i < 2; i++ )
-    {
-        BOOST_CHECK_CLOSE_FRACTION( verificationData[ i + 9 ], output.second[ i ], tolerance );
-    }
-}
-
-//! Perform NRLMSISE-00 test 2
-// Check values for 11 output parameters on against (hardcoded) values
-// obtained from the similar nrlmsise-test.c program.
-BOOST_AUTO_TEST_CASE( testNRLMSISE00AtmosphereTest2 )
-{
-    // Define verification data for specific test and tolerance
-    double tolerance = 1.0E-12;
-    std::vector< double > verificationData = { 3.407293223161E+06, 1.586333369569E+08, 1.391117365461E+07, 3.262559509596E+05,
-                                               1.559618150501E+03, 5.001845729072E-15, 4.854208463340E+04, 4.380966712899E+06,
-                                               6.956681955942E+03, 1.166754383757E+03, 1.161710451887E+03 };
-
-    // Create the model
-    NRLMSISE00Atmosphere model( std::bind( &nrlmsiseTestFunction,
-                                           std::placeholders::_1,
-                                           std::placeholders::_2,
-                                           std::placeholders::_3,
-                                           std::placeholders::_4,
-                                           false,
-                                           false ) );
-
-    // Create local copy of input and define variations
-    data = gen_data;
-    std::vector< double > input = gen_input;
-    // Define variations from the standard case
-    data.dayOfTheYear = 81;
-
-    // We change parameters other than alt, lat, long, and/or time,
-    // so it's best to reset the hash.
-    model.resetHashKey( );
-
-    // Get full output for current test case
-    std::pair< std::vector< double >, std::vector< double > > output =
-            model.getFullOutput( input[ 0 ], input[ 1 ], input[ 2 ], input[ 3 ] );
-
-    // Loop through output and perform tests
-    for( unsigned i = 0; i < 9; i++ )
-    {
-        BOOST_CHECK_CLOSE_FRACTION( verificationData[ i ], output.first[ i ], tolerance );
-    }
-    for( unsigned i = 0; i < 2; i++ )
-    {
-        BOOST_CHECK_CLOSE_FRACTION( verificationData[ i + 9 ], output.second[ i ], tolerance );
-    }
-}
-
-//! Perform NRLMSISE-00 test 3
-// Check values for 11 output parameters on against (hardcoded) values
-// obtained from the similar nrlmsise-test.c program.
-BOOST_AUTO_TEST_CASE( testNRLMSISE00AtmosphereTest3 )
-{
-    // Define verification data for specific test and tolerance
-    double tolerance = 1.0E-12;
-    std::vector< double > verificationData = { 1.123767244038E+05, 6.934130086761E+04, 4.247105217477E+01, 1.322750141475E-01,
-                                               2.618848418232E-05, 2.756772319269E-18, 2.016749854321E+04, 5.741255934147E+03,
-                                               2.374394151990E+04, 1.239892111717E+03, 1.239890640133E+03 };
-
-    // Create the model
-    NRLMSISE00Atmosphere model( std::bind( &nrlmsiseTestFunction,
-                                           std::placeholders::_1,
-                                           std::placeholders::_2,
-                                           std::placeholders::_3,
-                                           std::placeholders::_4,
-                                           false,
-                                           false ) );
-
-    // Create local copy of input and define variations
-    data = gen_data;
-    std::vector< double > input = gen_input;
-    // Define variations from the standard case
-    data.secondOfTheDay = 75000.0;
-    input[ 0 ] = 1000.0E3;
-
-    // We change parameters other than alt, lat, long, and/or time,
-    // so it's best to reset the hash.
-    model.resetHashKey( );
-
-    // Get full output for current test case
-    std::pair< std::vector< double >, std::vector< double > > output =
-            model.getFullOutput( input[ 0 ], input[ 1 ], input[ 2 ], input[ 3 ] );
-
-    // Loop through output and perform tests
-    for( unsigned i = 0; i < 9; i++ )
-    {
-        BOOST_CHECK_CLOSE_FRACTION( verificationData[ i ], output.first[ i ], tolerance );
-    }
-    for( unsigned i = 0; i < 2; i++ )
-    {
-        BOOST_CHECK_CLOSE_FRACTION( verificationData[ i + 9 ], output.second[ i ], tolerance );
-    }
-}
-
-//! Perform NRLMSISE-00 test 4
-// Check values for 11 output parameters on against (hardcoded) values
-// obtained from the similar nrlmsise-test.c program.
-BOOST_AUTO_TEST_CASE( testNRLMSISE00AtmosphereTest4 )
-{
-    // Define verification data for specific test and tolerance
-    double tolerance = 1.0E-12;
-    std::vector< double > verificationData = { 5.411554379937E+07, 1.918893443939E+11, 6.115825598225E+12, 1.225201051740E+12,
-                                               6.023211973085E+10, 3.584426304113E-10, 1.059879697741E+07, 2.615736693705E+05,
-                                               2.819879355928E-42, 1.027318464900E+03, 2.068877764036E+02 };
-
-    // Create the model
-    NRLMSISE00Atmosphere model( std::bind( &nrlmsiseTestFunction,
-                                           std::placeholders::_1,
-                                           std::placeholders::_2,
-                                           std::placeholders::_3,
-                                           std::placeholders::_4,
-                                           false,
-                                           false ) );
-
-    // Create local copy of input and define variations
-    data = gen_data;
-    std::vector< double > input = gen_input;
-
-    // Define variations from the standard case
-    input[ 0 ] = 100.0E3;
-
-    // We change parameters other than alt, lat, long, and/or time,
-    // so it's best to reset the hash.
-    model.resetHashKey( );
-
-    // Get full output for current test case
-    std::pair< std::vector< double >, std::vector< double > > output =
-            model.getFullOutput( input[ 0 ], input[ 1 ], input[ 2 ], input[ 3 ] );
-
-    // Loop through output and perform tests
-    for( unsigned i = 0; i < 9; i++ )
-    {
-        BOOST_CHECK_CLOSE_FRACTION( verificationData[ i ], output.first[ i ], tolerance );
-    }
-    for( unsigned i = 0; i < 2; i++ )
-    {
-        BOOST_CHECK_CLOSE_FRACTION( verificationData[ i + 9 ], output.second[ i ], tolerance );
-    }
-}
-
-//! Perform NRLMSISE-00 test 5
-// Check values for 11 output parameters on against (hardcoded) values
-// obtained from the similar nrlmsise-test.c program.
-BOOST_AUTO_TEST_CASE( testNRLMSISE00AtmosphereTest5 )
-{
-    // Define verification data for specific test and tolerance
-    double tolerance = 1.0E-12;
-    std::vector< double > verificationData = { 1.851122486193E+06, 1.476554837927E+08, 1.579356228264E+07, 2.633794977312E+05,
-                                               1.588781398384E+03, 4.809630239407E-15, 5.816166780787E+04, 5.478984479069E+06,
-                                               1.264445941761E+03, 1.212396152121E+03, 1.208135425212E+03 };
-
-    // Create the model
-    NRLMSISE00Atmosphere model( std::bind( &nrlmsiseTestFunction,
-                                           std::placeholders::_1,
-                                           std::placeholders::_2,
-                                           std::placeholders::_3,
-                                           std::placeholders::_4,
-                                           false,
-                                           false ) );
-
-    // Create local copy of input and define variations
-    data = gen_data;
-    std::vector< double > input = gen_input;
-
-    // Define variations from the standard case
-    input[ 2 ] = 0.0;
-
-    // We change parameters other than alt, lat, long, and/or time,
-    // so it's best to reset the hash.
-    model.resetHashKey( );
-
-    // Get full output for current test case
-    std::pair< std::vector< double >, std::vector< double > > output =
-            model.getFullOutput( input[ 0 ], input[ 1 ], input[ 2 ], input[ 3 ] );
-
-    // Loop through output and perform tests
-    for( unsigned i = 0; i < 9; i++ )
-    {
-        BOOST_CHECK_CLOSE_FRACTION( verificationData[ i ], output.first[ i ], tolerance );
-    }
-    for( unsigned i = 0; i < 2; i++ )
-    {
-        BOOST_CHECK_CLOSE_FRACTION( verificationData[ i + 9 ], output.second[ i ], tolerance );
-    }
-}
-
-//! Perform NRLMSISE-00 test 6
-// Check values for 11 output parameters on against (hardcoded) values
-// obtained from the similar nrlmsise-test.c program.
-BOOST_AUTO_TEST_CASE( testNRLMSISE00AtmosphereTest6 )
-{
-    // Define verification data for specific test and tolerance
-    double tolerance = 1.0E-12;
-    std::vector< double > verificationData = { 8.673095233906E+05, 1.278861768014E+08, 1.822576627172E+07, 2.922214190618E+05,
-                                               2.402962436424E+03, 4.355865642645E-15, 3.686389243751E+04, 3.897275503727E+06,
-                                               2.667273209336E+04, 1.220146417915E+03, 1.212712083212E+03 };
-
-    // Create the model
-    NRLMSISE00Atmosphere model( std::bind( &nrlmsiseTestFunction,
-                                           std::placeholders::_1,
-                                           std::placeholders::_2,
-                                           std::placeholders::_3,
-                                           std::placeholders::_4,
-                                           false,
-                                           false ) );
-
-    // Create local copy of input and define variations
-    data = gen_data;
-    std::vector< double > input = gen_input;
-
-    // Define variations from the standard case
-    input[ 1 ] = 0.0;
-
-    // We change parameters other than alt, lat, long, and/or time,
-    // so it's best to reset the hash.
-    model.resetHashKey( );
-
-    // Get full output for current test case
-    std::pair< std::vector< double >, std::vector< double > > output =
-            model.getFullOutput( input[ 0 ], input[ 1 ], input[ 2 ], input[ 3 ] );
-
-    // Loop through output and perform tests
-    for( unsigned i = 0; i < 9; i++ )
-    {
-        BOOST_CHECK_CLOSE_FRACTION( verificationData[ i ], output.first[ i ], tolerance );
-    }
-    for( unsigned i = 0; i < 2; i++ )
-    {
-        BOOST_CHECK_CLOSE_FRACTION( verificationData[ i + 9 ], output.second[ i ], tolerance );
-    }
-}
-
-//! Perform NRLMSISE-00 test 7
-// Check values for 11 output parameters on against (hardcoded) values
-// obtained from the similar nrlmsise-test.c program.
-BOOST_AUTO_TEST_CASE( testNRLMSISE00AtmosphereTest7 )
-{
-    // Define verification data for specific test and tolerance
-    double tolerance = 1.0E-12;
-    std::vector< double > verificationData = { 5.776251216023E+05, 6.979138693660E+07, 1.236813559822E+07, 2.492867715429E+05,
-                                               1.405738674178E+03, 2.470651391663E-15, 5.291985567067E+04, 1.069814109367E+06,
-                                               2.667273209336E+04, 1.116385376043E+03, 1.112998568217E+03 };
-
-    // Create the model
-    NRLMSISE00Atmosphere model( std::bind( &nrlmsiseTestFunction,
-                                           std::placeholders::_1,
-                                           std::placeholders::_2,
-                                           std::placeholders::_3,
-                                           std::placeholders::_4,
-                                           false,
-                                           false ) );
-
-    // Create local copy of input and define variations
-    data = gen_data;
-    std::vector< double > input = gen_input;
-
-    // Define variations from the standard case
-    data.localSolarTime = 4.0;
-
-    // We change parameters other than alt, lat, long, and/or time,
-    // so it's best to reset the hash.
-    model.resetHashKey( );
-
-    // Get full output for current test case
-    std::pair< std::vector< double >, std::vector< double > > output =
-            model.getFullOutput( input[ 0 ], input[ 1 ], input[ 2 ], input[ 3 ] );
-
-    // Loop through output and perform tests
-    for( unsigned i = 0; i < 9; i++ )
-    {
-        BOOST_CHECK_CLOSE_FRACTION( verificationData[ i ], output.first[ i ], tolerance );
-    }
-    for( unsigned i = 0; i < 2; i++ )
-    {
-        BOOST_CHECK_CLOSE_FRACTION( verificationData[ i + 9 ], output.second[ i ], tolerance );
-    }
-}
-
-//! Perform NRLMSISE-00 test 8
-// Check values for 11 output parameters on against (hardcoded) values
-// obtained from the similar nrlmsise-test.c program.
-BOOST_AUTO_TEST_CASE( testNRLMSISE00AtmosphereTest8 )
-{
-    // Define verification data for specific test and tolerance
-    double tolerance = 1.0E-12;
-    std::vector< double > verificationData = { 3.740304105508E+05, 4.782720123611E+07, 5.240380033324E+06, 1.759874640391E+05,
-                                               5.501648779570E+02, 1.571888739255E-15, 8.896775722935E+04, 1.979740836233E+06,
-                                               9.121814875991E+03, 1.031247440715E+03, 1.024848492213E+03 };
-
-    // Create the model
-    NRLMSISE00Atmosphere model( std::bind( &nrlmsiseTestFunction,
-                                           std::placeholders::_1,
-                                           std::placeholders::_2,
-                                           std::placeholders::_3,
-                                           std::placeholders::_4,
-                                           false,
-                                           false ) );
-
-    // Create local copy of input and define variations
-    data = gen_data;
-    std::vector< double > input = gen_input;
-
-    // Define variations from the standard case
-    data.f107a = 70.0;
-
-    // We change parameters other than alt, lat, long, and/or time,
-    // so it's best to reset the hash.
-    model.resetHashKey( );
-
-    // Get full output for current test case
-    std::pair< std::vector< double >, std::vector< double > > output =
-            model.getFullOutput( input[ 0 ], input[ 1 ], input[ 2 ], input[ 3 ] );
-
-    // Loop through output and perform tests
-    for( unsigned i = 0; i < 9; i++ )
-    {
-        BOOST_CHECK_CLOSE_FRACTION( verificationData[ i ], output.first[ i ], tolerance );
-    }
-    for( unsigned i = 0; i < 2; i++ )
-    {
-        BOOST_CHECK_CLOSE_FRACTION( verificationData[ i + 9 ], output.second[ i ], tolerance );
-    }
-}
-
-//! Perform NRLMSISE-00 test 9
-// Check values for 11 output parameters on against (hardcoded) values
-// obtained from the similar nrlmsise-test.c program.
-BOOST_AUTO_TEST_CASE( testNRLMSISE00AtmosphereTest9 )
-{
-    // Define verification data for specific test and tolerance
-    double tolerance = 1.0E-12;
-    std::vector< double > verificationData = { 6.748338766624E+05, 1.245315260444E+08, 2.369009541053E+07, 4.911583154750E+05,
-                                               4.578781099054E+03, 4.564420245361E-15, 3.244594775161E+04, 5.370833087086E+06,
-                                               2.667273209336E+04, 1.306052042027E+03, 1.293374040390E+03 };
-
-    // Create the model
-    NRLMSISE00Atmosphere model( std::bind( &nrlmsiseTestFunction,
-                                           std::placeholders::_1,
-                                           std::placeholders::_2,
-                                           std::placeholders::_3,
-                                           std::placeholders::_4,
-                                           false,
-                                           false ) );
-
-    // Create local copy of input and define variations
-    data = gen_data;
-    std::vector< double > input = gen_input;
-
-    // Define variations from the standard case
-    data.f107 = 180.0;
-
-    // We change parameters other than alt, lat, long, and/or time,
-    // so it's best to reset the hash.
-    model.resetHashKey( );
-
-    // Get full output for current test case
-    std::pair< std::vector< double >, std::vector< double > > output =
-            model.getFullOutput( input[ 0 ], input[ 1 ], input[ 2 ], input[ 3 ] );
-
-    // Loop through output and perform tests
-    for( unsigned i = 0; i < 9; i++ )
-    {
-        BOOST_CHECK_CLOSE_FRACTION( verificationData[ i ], output.first[ i ], tolerance );
-    }
-    for( unsigned i = 0; i < 2; i++ )
-    {
-        BOOST_CHECK_CLOSE_FRACTION( verificationData[ i + 9 ], output.second[ i ], tolerance );
-    }
-}
-
-//! Perform NRLMSISE-00 test 10
-// Check values for 11 output parameters on against (hardcoded) values
-// obtained from the similar nrlmsise-test.c program.
-BOOST_AUTO_TEST_CASE( testNRLMSISE00AtmosphereTest10 )
-{
-    // Define verification data for specific test and tolerance
-    double tolerance = 1.0E-12;
-    std::vector< double > verificationData = { 5.528600841645E+05, 1.198041324041E+08, 3.495797764558E+07, 9.339618355028E+05,
-                                               1.096254765493E+04, 4.974543110322E-15, 2.686427856260E+04, 4.889974232971E+06,
-                                               2.805444837126E+04, 1.361868020785E+03, 1.347389183730E+03 };
-
-    // Create the model
-    NRLMSISE00Atmosphere model( std::bind( &nrlmsiseTestFunction,
-                                           std::placeholders::_1,
-                                           std::placeholders::_2,
-                                           std::placeholders::_3,
-                                           std::placeholders::_4,
-                                           false,
-                                           false ) );
-
-    // Create local copy of input and define variations
-    data = gen_data;
-    std::vector< double > input = gen_input;
-
-    // Define variations from the standard case
-    data.apDaily = 40.0;
-
-    // We change parameters other than alt, lat, long, and/or time,
-    // so it's best to reset the hash.
-    model.resetHashKey( );
-
-    // Get full output for current test case
-    std::pair< std::vector< double >, std::vector< double > > output =
-            model.getFullOutput( input[ 0 ], input[ 1 ], input[ 2 ], input[ 3 ] );
-
-    // Loop through output and perform tests
-    for( unsigned i = 0; i < 9; i++ )
-    {
-        BOOST_CHECK_CLOSE_FRACTION( verificationData[ i ], output.first[ i ], tolerance );
-    }
-    for( unsigned i = 0; i < 2; i++ )
-    {
-        BOOST_CHECK_CLOSE_FRACTION( verificationData[ i + 9 ], output.second[ i ], tolerance );
-    }
-}
-
-//! Perform NRLMSISE-00 test 11
-// Check values for 11 output parameters on against (hardcoded) values
-// obtained from the similar nrlmsise-test.c program.
-BOOST_AUTO_TEST_CASE( testNRLMSISE00AtmosphereTest11 )
-{
-    // Define verification data for specific test and tolerance
-    double tolerance = 1.0E-12;
-    std::vector< double > verificationData = { 1.375487584186E+14, 0.000000000000E+00, 2.049687044291E+19, 5.498695433719E+18,
-                                               2.451733158028E+17, 1.261065661119E-03, 0.000000000000E+00, 0.000000000000E+00,
-                                               0.000000000000E+00, 1.027318464900E+03, 2.814647576632E+02 };
-
-    // Create the model
-    NRLMSISE00Atmosphere model( std::bind( &nrlmsiseTestFunction,
-                                           std::placeholders::_1,
-                                           std::placeholders::_2,
-                                           std::placeholders::_3,
-                                           std::placeholders::_4,
-                                           false,
-                                           false ) );
-
-    // Create local copy of input and define variations
-    data = gen_data;
-    std::vector< double > input = gen_input;
-
-    // Define variations from the standard case
-    input[ 0 ] = 0.0;
-
-    // We change parameters other than alt, lat, long, and/or time,
-    // so it's best to reset the hash.
-    model.resetHashKey( );
-
-    // Get full output for current test case
-    std::pair< std::vector< double >, std::vector< double > > output =
-            model.getFullOutput( input[ 0 ], input[ 1 ], input[ 2 ], input[ 3 ] );
-
-    // Loop through output and perform tests
-    for( unsigned i = 0; i < 9; i++ )
-    {
-        BOOST_CHECK_CLOSE_FRACTION( verificationData[ i ], output.first[ i ], tolerance );
-    }
-    for( unsigned i = 0; i < 2; i++ )
-    {
-        BOOST_CHECK_CLOSE_FRACTION( verificationData[ i + 9 ], output.second[ i ], tolerance );
-    }
-}
-
-//! Perform NRLMSISE-00 test 12
-// Check values for 11 output parameters on against (hardcoded) values
-// obtained from the similar nrlmsise-test.c program.
-BOOST_AUTO_TEST_CASE( testNRLMSISE00AtmosphereTest12 )
-{
-    // Define verification data for specific test and tolerance
-    double tolerance = 1.0E-12;
-    std::vector< double > verificationData = { 4.427442587677E+13, 0.000000000000E+00, 6.597567157737E+18, 1.769929341406E+18,
-                                               7.891679955727E+16, 4.059139375799E-04, 0.000000000000E+00, 0.000000000000E+00,
-                                               0.000000000000E+00, 1.027318464900E+03, 2.274179808273E+02 };
-
-    // Create the model
-    NRLMSISE00Atmosphere model( std::bind( &nrlmsiseTestFunction,
-                                           std::placeholders::_1,
-                                           std::placeholders::_2,
-                                           std::placeholders::_3,
-                                           std::placeholders::_4,
-                                           false,
-                                           false ) );
-
-    // Create local copy of input and define variations
-    data = gen_data;
-    std::vector< double > input = gen_input;
-
-    // Define variations from the standard case
-    input[ 0 ] = 10.0E3;
-
-    // We change parameters other than alt, lat, long, and/or time,
-    // so it's best to reset the hash.
-    model.resetHashKey( );
-
-    // Get full output for current test case
-    std::pair< std::vector< double >, std::vector< double > > output =
-            model.getFullOutput( input[ 0 ], input[ 1 ], input[ 2 ], input[ 3 ] );
-
-    // Loop through output and perform tests
-    for( unsigned i = 0; i < 9; i++ )
-    {
-        BOOST_CHECK_CLOSE_FRACTION( verificationData[ i ], output.first[ i ], tolerance );
-    }
-    for( unsigned i = 0; i < 2; i++ )
-    {
-        BOOST_CHECK_CLOSE_FRACTION( verificationData[ i + 9 ], output.second[ i ], tolerance );
-    }
-}
-
-//! Perform NRLMSISE-00 test 13
-// Check values for 11 output parameters on against (hardcoded) values
-// obtained from the similar nrlmsise-test.c program.
-BOOST_AUTO_TEST_CASE( testNRLMSISE00AtmosphereTest13 )
-{
-    // Define verification data for specific test and tolerance
-    double tolerance = 1.0E-12;
-    std::vector< double > verificationData = { 2.127828756207E+12, 0.000000000000E+00, 3.170790550354E+17, 8.506279809435E+16,
-                                               3.792741116806E+15, 1.950822245176E-05, 0.000000000000E+00, 0.000000000000E+00,
-                                               0.000000000000E+00, 1.027318464900E+03, 2.374389145877E+02 };
-
-    // Create the model
-    NRLMSISE00Atmosphere model( std::bind( &nrlmsiseTestFunction,
-                                           std::placeholders::_1,
-                                           std::placeholders::_2,
-                                           std::placeholders::_3,
-                                           std::placeholders::_4,
-                                           false,
-                                           false ) );
-
-    // Create local copy of input and define variations
-    data = gen_data;
-    std::vector< double > input = gen_input;
-
-    // Define variations from the standard case
-    input[ 0 ] = 30.0E3;
-
-    // We change parameters other than alt, lat, long, and/or time,
-    // so it's best to reset the hash.
-    model.resetHashKey( );
-
-    // Get full output for current test case
-    std::pair< std::vector< double >, std::vector< double > > output =
-            model.getFullOutput( input[ 0 ], input[ 1 ], input[ 2 ], input[ 3 ] );
-
-    // Loop through output and perform tests
-    for( unsigned i = 0; i < 9; i++ )
-    {
-        BOOST_CHECK_CLOSE_FRACTION( verificationData[ i ], output.first[ i ], tolerance );
-    }
-    for( unsigned i = 0; i < 2; i++ )
-    {
-        BOOST_CHECK_CLOSE_FRACTION( verificationData[ i + 9 ], output.second[ i ], tolerance );
-    }
-}
-
-//! Perform NRLMSISE-00 test 14
-// Check values for 11 output parameters on against (hardcoded) values
-// obtained from the similar nrlmsise-test.c program.
-BOOST_AUTO_TEST_CASE( testNRLMSISE00AtmosphereTest14 )
-{
-    // Define verification data for specific test and tolerance
-    double tolerance = 1.0E-12;
-    std::vector< double > verificationData = { 1.412183545593E+11, 0.000000000000E+00, 2.104369643783E+16, 5.645392443377E+15,
-                                               2.517141749411E+14, 1.294709015929E-06, 0.000000000000E+00, 0.000000000000E+00,
-                                               0.000000000000E+00, 1.027318464900E+03, 2.795551129541E+02 };
-
-    // Create the model
-    NRLMSISE00Atmosphere model( std::bind( &nrlmsiseTestFunction,
-                                           std::placeholders::_1,
-                                           std::placeholders::_2,
-                                           std::placeholders::_3,
-                                           std::placeholders::_4,
-                                           false,
-                                           false ) );
-
-    // Create local copy of input and define variations
-    data = gen_data;
-    std::vector< double > input = gen_input;
-
-    // Define variations from the standard case
-    input[ 0 ] = 50.0E3;
-
-    // We change parameters other than alt, lat, long, and/or time,
-    // so it's best to reset the hash.
-    model.resetHashKey( );
-
-    // Get full output for current test case
-    std::pair< std::vector< double >, std::vector< double > > output =
-            model.getFullOutput( input[ 0 ], input[ 1 ], input[ 2 ], input[ 3 ] );
-
-    // Loop through output and perform tests
-    for( unsigned i = 0; i < 9; i++ )
-    {
-        BOOST_CHECK_CLOSE_FRACTION( verificationData[ i ], output.first[ i ], tolerance );
-    }
-    for( unsigned i = 0; i < 2; i++ )
-    {
-        BOOST_CHECK_CLOSE_FRACTION( verificationData[ i + 9 ], output.second[ i ], tolerance );
-    }
-}
-
-//! Perform NRLMSISE-00 test 15
-// Check values for 11 output parameters on against (hardcoded) values
-// obtained from the similar nrlmsise-test.c program.
-BOOST_AUTO_TEST_CASE( testNRLMSISE00AtmosphereTest15 )
-{
-    // Define verification data for specific test and tolerance
-    double tolerance = 1.0E-12;
-    std::vector< double > verificationData = { 1.254884400273E+10, 0.000000000000E+00, 1.874532829219E+15, 4.923050980785E+14,
-                                               2.239685413856E+13, 1.147667671512E-07, 0.000000000000E+00, 0.000000000000E+00,
-                                               0.000000000000E+00, 1.027318464900E+03, 2.190732313642E+02 };
-
-    // Create the model
-    NRLMSISE00Atmosphere model( std::bind( &nrlmsiseTestFunction,
-                                           std::placeholders::_1,
-                                           std::placeholders::_2,
-                                           std::placeholders::_3,
-                                           std::placeholders::_4,
-                                           false,
-                                           false ) );
-
-    // Create local copy of input and define variations
-    data = gen_data;
-    std::vector< double > input = gen_input;
-
-    // Define variations from the standard case
-    input[ 0 ] = 70.0E3;
-
-    // We change parameters other than alt, lat, long, and/or time,
-    // so it's best to reset the hash.
-    model.resetHashKey( );
-
-    // Get full output for current test case
-    std::pair< std::vector< double >, std::vector< double > > output =
-            model.getFullOutput( input[ 0 ], input[ 1 ], input[ 2 ], input[ 3 ] );
-
-    // Loop through output and perform tests
-    for( unsigned i = 0; i < 9; i++ )
-    {
-        BOOST_CHECK_CLOSE_FRACTION( verificationData[ i ], output.first[ i ], tolerance );
-    }
-    for( unsigned i = 0; i < 2; i++ )
-    {
-        BOOST_CHECK_CLOSE_FRACTION( verificationData[ i + 9 ], output.second[ i ], tolerance );
-    }
-}
-
-//! Perform NRLMSISE-00 test 16
-// Check values for 11 output parameters on against (hardcoded) values
-// obtained from the similar nrlmsise-test.c program.
-BOOST_AUTO_TEST_CASE( testNRLMSISE00AtmosphereTest16 )
-{
-    // Define verification data for specific test and tolerance
-    double tolerance = 1.0E-12;
-    std::vector< double > verificationData = { 5.196477402973E+05, 1.274494072960E+08, 4.850449869853E+07, 1.720837982575E+06,
-                                               2.354486590544E+04, 5.881940448652E-15, 2.500078391081E+04, 6.279209825019E+06,
-                                               2.667273209336E+04, 1.426411662282E+03, 1.408607795553E+03 };
-
-    // Create the model
-    NRLMSISE00Atmosphere model( std::bind( &nrlmsiseTestFunction,
-                                           std::placeholders::_1,
-                                           std::placeholders::_2,
-                                           std::placeholders::_3,
-                                           std::placeholders::_4,
-                                           false,
-                                           false ) );
-
-    // Create local copy of input and define variations
-    data = gen_data;
-    std::vector< double > input = gen_input;
-
-    // Define variations from the standard case
-    data.apVector = std::vector< double >( 7, 100.0 );
-    data.switches[ 9 ] = -1;
-
-    // We change parameters other than alt, lat, long, and/or time,
-    // so it's best to reset the hash.
-    model.resetHashKey( );
-
-    // Get full output for current test case
-    std::pair< std::vector< double >, std::vector< double > > output =
-            model.getFullOutput( input[ 0 ], input[ 1 ], input[ 2 ], input[ 3 ] );
-
-    // Loop through output and perform tests
-    for( unsigned i = 0; i < 9; i++ )
-    {
-        BOOST_CHECK_CLOSE_FRACTION( verificationData[ i ], output.first[ i ], tolerance );
-    }
-    for( unsigned i = 0; i < 2; i++ )
-    {
-        BOOST_CHECK_CLOSE_FRACTION( verificationData[ i + 9 ], output.second[ i ], tolerance );
-    }
-}
-
-//! Perform NRLMSISE-00 test 17
-// Check values for 11 output parameters on against (hardcoded) values
-// obtained from the similar nrlmsise-test.c program.
-BOOST_AUTO_TEST_CASE( testNRLMSISE00AtmosphereTest17 )
-{
-    // Define verification data for specific test and tolerance
-    double tolerance = 1.0E-12;
-    std::vector< double > verificationData = { 4.260859748794E+07, 1.241342015549E+11, 4.929561542488E+12, 1.048406749093E+12,
-                                               4.993465083056E+10, 2.914303550309E-10, 8.831228592572E+06, 2.252515508626E+05,
-                                               2.415245929649E-42, 1.027318464900E+03, 1.934071062577E+02 };
-
-    // Create the model
-    NRLMSISE00Atmosphere model( std::bind( &nrlmsiseTestFunction,
-                                           std::placeholders::_1,
-                                           std::placeholders::_2,
-                                           std::placeholders::_3,
-                                           std::placeholders::_4,
-                                           false,
-                                           false ) );
-
-    // Create local copy of input and define variations
-    data = gen_data;
-    std::vector< double > input = gen_input;
-
-    // Define variations from the standard case
-    input[ 0 ] = 100.0E3;
-    data.apVector = std::vector< double >( 7, 100.0 );
-    data.switches[ 9 ] = -1;
-
-    // We change parameters other than alt, lat, long, and/or time,
-    // so it's best to reset the hash.
-    model.resetHashKey( );
-
-    // Get full output for current test case
-    std::pair< std::vector< double >, std::vector< double > > output =
-            model.getFullOutput( input[ 0 ], input[ 1 ], input[ 2 ], input[ 3 ] );
-
-    // Loop through output and perform tests
-    for( unsigned i = 0; i < 9; i++ )
-    {
-        BOOST_CHECK_CLOSE_FRACTION( verificationData[ i ], output.first[ i ], tolerance );
-    }
-    for( unsigned i = 0; i < 2; i++ )
-    {
-        BOOST_CHECK_CLOSE_FRACTION( verificationData[ i + 9 ], output.second[ i ], tolerance );
-    }
-}
-
-//! Perform NRLMSISE-00 test 18
-// Check computation of speed of sound
-BOOST_AUTO_TEST_CASE( testSpeedOfSound )
-{
-    // Construct model with default properties
-    NRLMSISE00Atmosphere model( std::bind( &nrlmsiseTestFunction,
-                                           std::placeholders::_1,
-                                           std::placeholders::_2,
-                                           std::placeholders::_3,
-                                           std::placeholders::_4,
-                                           false,
-                                           false ) );
-
-    double altitude = 0.0;
-    double longitude = 0.0;
-    double latitude = 0.0;
-    double time = 0.0;
-
-    // Check speed of sound : (https://en.wikipedia.org/wiki/Speed_of_sound  (at 20 deg celcius) )
-    // 340.9 at sealevel (anderson, fundamentals of aerodynamics)
-    BOOST_CHECK_CLOSE_FRACTION( model.getSpeedOfSound( altitude, longitude, latitude, time ), 343.21, 2E-2 );   // < 2%
-    BOOST_CHECK_CLOSE_FRACTION( model.getSpeedOfSound( altitude, longitude, latitude, time ), 340.9, 1.8E-2 );  // < 1.8%
-
-    // US Standard Atmosphere Model 1976
-    std::string atmosphereTableFile = tudat::paths::getAtmosphereTablesPath( ) + "/USSA1976Until100kmPer100mUntil1000kmPer1000m.dat";
-    tudat::aerodynamics::TabulatedAtmosphere US76model( atmosphereTableFile );
-
-    // Test wist US76 table (NRLMSISE should provide approximately the same results)
-    BOOST_CHECK_CLOSE_FRACTION(
-            model.getSpeedOfSound( altitude, longitude, latitude, time ), US76model.getSpeedOfSound( altitude ), 2E-2 );  // < 2%
-
-    altitude = 10.0E3;
-    BOOST_CHECK_CLOSE_FRACTION(
-            model.getSpeedOfSound( altitude, longitude, latitude, time ), US76model.getSpeedOfSound( altitude ), 3.5E-2 );  // < 3.5%
-
-    altitude = 40.0E3;
-    BOOST_CHECK_CLOSE_FRACTION(
-            model.getSpeedOfSound( altitude, longitude, latitude, time ), US76model.getSpeedOfSound( altitude ), 6.5E-2 );  // < 6.5%
-
-    altitude = 80.0E3;
-    BOOST_CHECK_CLOSE_FRACTION(
-            model.getSpeedOfSound( altitude, longitude, latitude, time ), US76model.getSpeedOfSound( altitude ), 5E-2 );  // < 5%
-
-    // Verify calculation
-    double speedOfSound = std::sqrt( 1.4 * 8.3144598 * model.getTemperature( altitude, longitude, latitude, time ) /
-                                     model.getMeanMolarMass( altitude, longitude, latitude, time ) );
-    BOOST_CHECK_CLOSE_FRACTION( speedOfSound, model.getSpeedOfSound( altitude, longitude, latitude, time ), 1E-15 );
-}
-
-//! Perform NRLMSISE-00 test 19
-// Check computation of molar mass
-BOOST_AUTO_TEST_CASE( testMolarMass )
-{
-    // Construct model with default properties
-    NRLMSISE00Atmosphere model( std::bind( &nrlmsiseTestFunction,
-                                           std::placeholders::_1,
-                                           std::placeholders::_2,
-                                           std::placeholders::_3,
-                                           std::placeholders::_4,
-                                           false,
-                                           false ) );
-
-    double altitude = 0.0;
-    double longitude = 0.0;
-    double latitude = 0.0;
-    double time = 0.0;
-
-    // Check using textbook example: Dynamics of atmospheric re-entry, Regan , 1993
-    BOOST_CHECK_CLOSE_FRACTION( model.getMeanMolarMass( altitude, longitude, latitude, time ), 28.96643E-3, 3E-4 );  // < 0.03%
-
-    altitude = 50.0E3;
-    BOOST_CHECK_CLOSE_FRACTION( model.getMeanMolarMass( altitude, longitude, latitude, time ), 28.96643E-3, 3E-4 );  // < 0.03%
-
-    altitude = 200.0E3;
-    BOOST_CHECK_CLOSE_FRACTION( model.getMeanMolarMass( altitude, longitude, latitude, time ), 21.0E-3, 3E-2 );  // < 3%
-
-    altitude = 300.0E3;
-    BOOST_CHECK_CLOSE_FRACTION( model.getMeanMolarMass( altitude, longitude, latitude, time ), 18.0E-3, 3E-2 );  // < 3%
-}
-
-//! Perform NRLMSISE-00 test 20
-// Check computation mean free path
-BOOST_AUTO_TEST_CASE( testMeanFreePath )
-{
-    // Construct model with default properties
-    NRLMSISE00Atmosphere model( std::bind( &nrlmsiseTestFunction,
-                                           std::placeholders::_1,
-                                           std::placeholders::_2,
-                                           std::placeholders::_3,
-                                           std::placeholders::_4,
-                                           false,
-                                           false ) );
-
-    double altitude = 20.0E3;
-    double longitude = 0.5;
-    double latitude = 0.2;
-    double time = 1.0E5;
-
-    // Verify calculation
-    double meanFreePath = std::sqrt( 2.0 ) * PI *
-            std::pow( model.getWeightedAverageCollisionDiameter( altitude, longitude, latitude, time ), 2.0 ) *
-            model.getAverageNumberDensity( altitude, longitude, latitude, time );
-    meanFreePath = std::pow( meanFreePath, ( -1.0 ) );
-
-    BOOST_CHECK_CLOSE_FRACTION( model.getMeanFreePath( altitude, longitude, latitude, time ), meanFreePath, 1.0E-15 );
-
-    // Verify using data - Logarithmic plot: physics of the Earth's space environment, Gerd W. Prolls (page 29)
-    // Test using approximate values obtained from figure
-    altitude = 0.0E3;
-    BOOST_CHECK_CLOSE_FRACTION( model.getMeanFreePath( altitude, longitude, latitude, time ), 1.0E-7, 10.0 );
-
-    altitude = 60.0E3;
-    BOOST_CHECK_CLOSE_FRACTION( model.getMeanFreePath( altitude, longitude, latitude, time ), 1.0E-3, 1.2 );
-
-    altitude = 300.0E3;
-    BOOST_CHECK_CLOSE_FRACTION( model.getMeanFreePath( altitude, longitude, latitude, time ), 1.0E4, 0.9 );
-}
-//
-////! Perform NRLMSISE-00 test 21 - Test input function
-//// Corresponds to NRLMSISE test 1 but space weather file is used to set solar activity data.
-//// No adjustment values in space weather file are used.
-//BOOST_AUTO_TEST_CASE( test_nrlmise_InputFunction_no_adjustment )
-//{
-//    //    NRLMSISE00Input gen_data(2030, 172, 29000.0, 16.0, 150.0, 150.0, 4.0);
-//    // DD-MM-YY = 21-06-2030 , Hrs-Min-Sec = 8-3-20
-//    double julianDate = tudat::basic_astrodynamics::convertCalendarDateToJulianDay< double >( 2030, 6, 21, 8, 3, 20.0 );
-//    double time =
-//            tudat::basic_astrodynamics::convertJulianDayToSecondsSinceEpoch( julianDate, tudat::basic_astrodynamics::JULIAN_DAY_ON_J2000 );
-//
-//    // std::vector< double > gen_input = { 400.0, -70.0, 60.0, 0.0 };
-//    double altitude = 400.0E3;  // km
-//    double longitude = -70.0 * PI / 180.0;
-//    double latitude = 60.0 * PI / 180.0;
-//
-//    // find space weather file
-//    std::string spaceWeatherFilePath = tudat::paths::getTudatTestDataPath( ) + "/swAtmosTestWithAdjust.txt";
-//
-//    tudat::input_output::solar_activity::SolarActivityDataMap solarActivityData =
-//            tudat::input_output::solar_activity::readSolarActivityData( spaceWeatherFilePath );
-//
-//    // Create atmosphere model using NRLMISE00 input function
-//    // Local solar time is set to 16.0 to correspond with testing data!
-//    std::function< tudat::aerodynamics::NRLMSISE00Input( double, double, double, double ) > inputFunction =
-//            std::bind( &tudat::aerodynamics::nrlmsiseInputFunction,
-//                       std::placeholders::_1,
-//                       std::placeholders::_2,
-//                       std::placeholders::_3,
-//                       std::placeholders::_4,
-//                       solarActivityData,
-//                       true,
-//                       16.0 );
-//
-//    // Create Pointer to NRLMSISE model
-//    tudat::aerodynamics::NRLMSISE00Atmosphere atmosphereModel( inputFunction );
-//
-//    // Verification data
-//    std::vector< double > verificationData = { 6.665176904952E+05, 1.138805559752E+08, 1.998210925573E+07, 4.022763585713E+05,
-//                                               3.557464994516E+03, 4.074713532757E-15, 3.475312399717E+04, 4.095913268293E+06,
-//                                               2.667273209336E+04, 1.250539943561E+03, 1.241416130019E+03 };
-//
-//    double computedDensity = atmosphereModel.getDensity( altitude, longitude, latitude, time );
-//
-//    BOOST_CHECK_CLOSE_FRACTION( verificationData[ 5 ] * 1000, computedDensity, 1E-11 );
-//}
-//
-////! Perform NRLMSISE-00 test 22 - Test input function
-//// Corresponds to NRLMSISE test 1 but space weather file is used to set solar activity data.
-//// Adjustment values (flux qualifier is 1) in space weather file are used.
-//BOOST_AUTO_TEST_CASE( test_nrlmise_InputFunction_with_adjustment )
-//{
-//    //    NRLMSISE00Input gen_data(2030, 172, 29000.0, 16.0, 150.0, 150.0, 4.0);
-//    // DD-MM-YY = 21-06-2030 , Hrs-Min-Sec = 8-3-20
-//    double julianDate = tudat::basic_astrodynamics::convertCalendarDateToJulianDay< double >( 2030, 6, 21, 8, 3, 20.0 );
-//    double time =
-//            tudat::basic_astrodynamics::convertJulianDayToSecondsSinceEpoch( julianDate, tudat::basic_astrodynamics::JULIAN_DAY_ON_J2000 );
-//
-//    // std::vector< double > gen_input = { 400.0, -70.0, 60.0, 0.0 };
-//    double altitude = 400.0E3;  // km
-//    double longitude = -70.0 * PI / 180.0;
-//    double latitude = 60.0 * PI / 180.0;
-//
-//    // find space weather file
-//    std::string spaceWeatherFilePath = tudat::paths::getTudatTestDataPath( ) + "/swAtmosTestWithAdjust.txt";
-//
-//    tudat::input_output::solar_activity::SolarActivityDataMap solarActivityData =
-//            tudat::input_output::solar_activity::readSolarActivityData( spaceWeatherFilePath );
-//
-//    // Create atmosphere model using NRLMISE00 input function
-//    // Local solar time is set to 16.0 to correspond with testing data!
-//    std::function< tudat::aerodynamics::NRLMSISE00Input( double, double, double, double ) > inputFunction =
-//            std::bind( &tudat::aerodynamics::nrlmsiseInputFunction,
-//                       std::placeholders::_1,
-//                       std::placeholders::_2,
-//                       std::placeholders::_3,
-//                       std::placeholders::_4,
-//                       solarActivityData,
-//                       true,
-//                       16.0 );
-//
-//    // Create Pointer to NRLMSISE model
-//    tudat::aerodynamics::NRLMSISE00Atmosphere atmosphereModel( inputFunction );
-//
-//    // Verification data
-//    std::vector< double > verificationData = { 6.665176904952E+05, 1.138805559752E+08, 1.998210925573E+07, 4.022763585713E+05,
-//                                               3.557464994516E+03, 4.074713532757E-15, 3.475312399717E+04, 4.095913268293E+06,
-//                                               2.667273209336E+04, 1.250539943561E+03, 1.241416130019E+03 };
-//
-//    double computedDensity = atmosphereModel.getDensity( altitude, longitude, latitude, time );
-//
-//    BOOST_CHECK_CLOSE_FRACTION( verificationData[ 5 ] * 1000, computedDensity, 1E-11 );
-//}
-
-
-BOOST_AUTO_TEST_CASE( testNRLMSISEInPropagation )
-// int main( )
-{
-    using namespace aerodynamics;
-    using namespace numerical_integrators;
-    using namespace simulation_setup;
-    using namespace propagators;
-    using namespace basic_mathematics;
-    using namespace basic_astrodynamics;
-    using namespace orbital_element_conversions;
-    using namespace spice_interface;
-
-    // Load Spice kernels.
-    loadStandardSpiceKernels( );
-
-    // Set simulation start epoch.
-    const double simulationStartEpoch = 0.0;
-    const double simulationEndEpoch = 300.0;
-    const double fixedStepSize = 1.0;
-
-    // Set Keplerian elements for Capsule.
-    Eigen::Vector6d apolloInitialStateInKeplerianElements;
-    apolloInitialStateInKeplerianElements( semiMajorAxisIndex ) = spice_interface::getAverageRadius( "Earth" ) + 120.0E3;
-    apolloInitialStateInKeplerianElements( eccentricityIndex ) = 0.005;
-    apolloInitialStateInKeplerianElements( inclinationIndex ) = unit_conversions::convertDegreesToRadians( 85.3 );
-    apolloInitialStateInKeplerianElements( argumentOfPeriapsisIndex ) = unit_conversions::convertDegreesToRadians( 235.7 );
-    apolloInitialStateInKeplerianElements( longitudeOfAscendingNodeIndex ) = unit_conversions::convertDegreesToRadians( 23.4 );
-    apolloInitialStateInKeplerianElements( trueAnomalyIndex ) = unit_conversions::convertDegreesToRadians( 139.87 );
-
-    // Convert apollo state from Keplerian elements to Cartesian elements.
-    const double earthGravitationalParameter = getBodyGravitationalParameter( "Earth" );
-    const Eigen::Vector6d apolloInitialState =
-            convertKeplerianToCartesianElements( apolloInitialStateInKeplerianElements, earthGravitationalParameter );
-
-    // Define simulation body settings.
-    BodyListSettings bodySettings = getDefaultBodySettings( { "Earth", "Moon" }, "Earth", "ECLIPJ2000" );
-    bodySettings.at( "Earth" )->gravityFieldSettings = std::make_shared< simulation_setup::GravityFieldSettings >( central_spice );
-    bodySettings.at( "Earth" )->atmosphereSettings = std::make_shared< simulation_setup::AtmosphereSettings >( nrlmsise00 );
-
-    // Create Earth object
-    simulation_setup::SystemOfBodies bodies = simulation_setup::createSystemOfBodies( bodySettings );
-
-    // Create vehicle objects.
-    bodies.createEmptyBody( "Apollo" );
-    bodies.at( "Apollo" )->setConstantBodyMass( 2000.0 );
-
-    // Create vehicle aerodynamic coefficients
-    double referenceArea = 4.0;
-    double aerodynamicCoefficient = 1.2;
-    std::shared_ptr< AerodynamicCoefficientSettings > aerodynamicCoefficientSettings =
-            std::make_shared< ConstantAerodynamicCoefficientSettings >(
-                    referenceArea, aerodynamicCoefficient * Eigen::Vector3d::UnitX( ), negative_aerodynamic_frame_coefficients );
-
-    // Create and set aerodynamic coefficients object
-    bodies.at( "Apollo" )
-            ->setAerodynamicCoefficientInterface(
-                    createAerodynamicCoefficientInterface( aerodynamicCoefficientSettings, "Apollo", bodies ) );
-
-    // Define propagator settings variables.
-    SelectedAccelerationMap accelerationMap;
-    std::vector< std::string > bodiesToPropagate;
-    std::vector< std::string > centralBodies;
-
-    // Define acceleration model settings.
-    std::map< std::string, std::vector< std::shared_ptr< AccelerationSettings > > > accelerationsOfApollo;
-    accelerationsOfApollo[ "Earth" ].push_back( std::make_shared< AccelerationSettings >( point_mass_gravity ) );
-    accelerationsOfApollo[ "Earth" ].push_back( std::make_shared< AccelerationSettings >( aerodynamic ) );
-    accelerationsOfApollo[ "Moon" ].push_back( std::make_shared< AccelerationSettings >( point_mass_gravity ) );
-    accelerationMap[ "Apollo" ] = accelerationsOfApollo;
-
-    bodiesToPropagate.push_back( "Apollo" );
-    centralBodies.push_back( "Earth" );
-
-    // Set initial state
-    Eigen::Vector6d systemInitialState = apolloInitialState;
-
-    // Define list of dependent variables to save.
-    std::vector< std::shared_ptr< SingleDependentVariableSaveSettings > > dependentVariables;
-    dependentVariables.push_back(
-            std::make_shared< SingleDependentVariableSaveSettings >( altitude_dependent_variable, "Apollo", "Earth" ) );
-    dependentVariables.push_back(
-            std::make_shared< SingleDependentVariableSaveSettings >( local_density_dependent_variable, "Apollo", "Earth" ) );
-    dependentVariables.push_back(
-            std::make_shared< SingleDependentVariableSaveSettings >( body_fixed_relative_spherical_position, "Apollo", "Earth" ) );
-    dependentVariables.push_back( std::make_shared< SingleDependentVariableSaveSettings >( nrlmsise_input_data, "Apollo", "Earth" ) );
-
-    // Create acceleration models and propagation settings.
-    basic_astrodynamics::AccelerationMap accelerationModelMap =
-            createAccelerationModelsMap( bodies, accelerationMap, bodiesToPropagate, centralBodies );
-
-    std::shared_ptr< IntegratorSettings<> > integratorSettings =
-            std::make_shared< IntegratorSettings<> >( rungeKutta4, simulationStartEpoch, fixedStepSize );
-
-    std::shared_ptr< TranslationalStatePropagatorSettings< double > > propagatorSettings =
-            std::make_shared< TranslationalStatePropagatorSettings< double > >(
-                    centralBodies,
-                    accelerationModelMap,
-                    bodiesToPropagate,
-                    systemInitialState,
-                    simulationStartEpoch,
-                    integratorSettings,
-                    std::make_shared< propagators::PropagationTimeTerminationSettings >( 3200.0 ),
-                    cowell,
-                    dependentVariables );
-
-    // Create simulation object and propagate dynamics.
-    SingleArcDynamicsSimulator<> dynamicsSimulator( bodies, propagatorSettings );
-
-    std::map< double, Eigen::Matrix< double, Eigen::Dynamic, 1 > > dependentVariableOutput =
-            dynamicsSimulator.getDependentVariableHistory( );
-
-    nrlmsise_flags flags;
-    nrlmsise_input input;
-    nrlmsise_output output;
-    auto nrlmsiseInputFunction =
-            std::dynamic_pointer_cast< NRLMSISE00Atmosphere >( bodies.at( "Earth" )->getAtmosphereModel( ) )->getNrlmsise00InputFunction( );
-
-    for( auto it: dependentVariableOutput )
-    {
-        double altitude = it.second( 0 );
-        double density = it.second( 1 );
-        Eigen::Vector3d sphericalPosition = it.second.segment( 2, 3 );
-        Eigen::VectorXd nrlmsiseInputVector = it.second.segment( 5, 17 );
-
-        NRLMSISE00Input inputData = nrlmsiseInputFunction( altitude, sphericalPosition( 2 ), sphericalPosition( 1 ), it.first );
-
-        BOOST_CHECK_EQUAL( nrlmsiseInputVector( 0 ), inputData.year );
-        BOOST_CHECK_EQUAL( nrlmsiseInputVector( 1 ), inputData.dayOfTheYear );
-        BOOST_CHECK_CLOSE_FRACTION( nrlmsiseInputVector( 2 ), inputData.secondOfTheDay, 1.0E-14 );
-        BOOST_CHECK_CLOSE_FRACTION( nrlmsiseInputVector( 3 ) * 1000.0, altitude, 1.0E-14 );
-        BOOST_CHECK_CLOSE_FRACTION( nrlmsiseInputVector( 4 ), sphericalPosition( 1 ) * 180.0 / mathematical_constants::PI, 1.0E-14 );
-        BOOST_CHECK_CLOSE_FRACTION( nrlmsiseInputVector( 5 ), sphericalPosition( 2 ) * 180.0 / mathematical_constants::PI, 1.0E-14 );
-        BOOST_CHECK_CLOSE_FRACTION( nrlmsiseInputVector( 6 ), inputData.localSolarTime, 1.0E-14 );
-        BOOST_CHECK_CLOSE_FRACTION( nrlmsiseInputVector( 7 ), inputData.f107, 1.0E-14 );
-        BOOST_CHECK_CLOSE_FRACTION( nrlmsiseInputVector( 8 ), inputData.f107a, 1.0E-14 );
-        BOOST_CHECK_CLOSE_FRACTION( nrlmsiseInputVector( 9 ), inputData.apDaily, 1.0E-14 );
-        for( int i = 0; i < 6; i++ )
+ #define BOOST_TEST_DYN_LINK
+ #define BOOST_TEST_MAIN
+ 
+ #include <algorithm>
+ #include <vector>
+ #include <utility>
+ 
+ #include <boost/test/unit_test.hpp>
+ 
+ #include "tudat/astro/aerodynamics/nrlmsise00Atmosphere.h"
+ #include "tudat/astro/aerodynamics/tabulatedAtmosphere.h"
+ #include "tudat/io/basicInputOutput.h"
+ 
+ #include "tudat/astro/aerodynamics/nrlmsise00InputFunctions.h"
+ 
+ #include "tudat/math/basic/mathematicalConstants.h"
+ #include "tudat/simulation/simulation.h"
+ 
+ namespace tudat
+ {
+ 
+ namespace unit_tests
+ {
+ 
+ //! Test NRLMSISE00 atmosphere model.
+ BOOST_AUTO_TEST_SUITE( test_nrlmsise00_atmosphere )
+ 
+ using namespace tudat;
+ using tudat::aerodynamics::NRLMSISE00Atmosphere;
+ using tudat::aerodynamics::NRLMSISE00Input;
+ using tudat::mathematical_constants::PI;
+ 
+ // Global variable to be changed by tests and function.
+ NRLMSISE00Input data;
+ 
+ // Define input data generic (or almost completely) for all tests.
+ NRLMSISE00Input gen_data( 0, 172, 29000.0, 16.0, 150.0, 150.0, 4.0 );
+ std::vector< double > gen_input = { 400.0E3, -70.0 * PI / 180.0, 60.0 * PI / 180.0, 0.0 };
+ 
+ //! Test function to update the NRLMSISE00 iunput data as a function of time and geometry.
+ NRLMSISE00Input nrlmsiseTestFunction( double altitude,
+                                       double longitude,
+                                       double latitude,
+                                       double time,
+                                       bool computeLocalSolarTime,
+                                       bool invariableLower )
+ {
+     // Functionality encountered in the original wrapper class, these
+     // have been moved out of the Tudat space and now into the
+     // application space. This is given here as an example of how to
+     // solve these problems and to keep the code for future generations :).
+     // NOTE: both these functions are switched of for testing.
+     if( computeLocalSolarTime )
+     {
+         data.localSolarTime = data.secondOfTheDay / 3600.0 + longitude / 15.0;
+     }
+ 
+     if( invariableLower && altitude < 80000.0 )
+     {
+         data.f107 = 150.0;
+         data.f107a = 150.0;
+         data.apDaily = 4.0;
+         data.switches[ 9 ] = 1;
+     }
+ 
+     return data;
+ }
+
+ //! Perform NRLMSISE-00 test of get functions.
+ //  Check the consistency between full output and get parameter output functions.
+ BOOST_AUTO_TEST_CASE( testNRLMSISE00AtmosphereTestFunctions )
+ {
+     // Manual reset of switch
+     gen_data.switches[ 9 ] = 1;
+ 
+     // Define tolerance for equality
+     double tolerance = 1.0E-18;
+ 
+     // Create the model
+     NRLMSISE00Atmosphere model( std::bind( &nrlmsiseTestFunction,
+                                            std::placeholders::_1,
+                                            std::placeholders::_2,
+                                            std::placeholders::_3,
+                                            std::placeholders::_4,
+                                            false,
+                                            false ) );
+ 
+     // Create local copy of input and define variations
+     data = gen_data;
+     std::vector< double > input = gen_input;
+ 
+     // Define variations from the standard case
+     // First case is the default case
+ 
+     // Get full output and extract density and temperature
+     std::pair< std::vector< double >, std::vector< double > > output =
+             model.getFullOutput( input[ 0 ], input[ 1 ], input[ 2 ], input[ 3 ] );
+     double density1 = output.first[ 5 ] * 1000.0;
+     double temperature1 = output.second[ 1 ];
+ 
+     // Get density and temperature from functions
+     double density2 = model.getDensity( input[ 0 ], input[ 1 ], input[ 2 ], input[ 3 ] );
+     double temperature2 = model.getTemperature( input[ 0 ], input[ 1 ], input[ 2 ], input[ 3 ] );
+ 
+     // Check densities and temperatures.
+     BOOST_CHECK_CLOSE_FRACTION( density1, density2, tolerance );
+     BOOST_CHECK_CLOSE_FRACTION( temperature1, temperature2, tolerance );
+ }
+ 
+ //! Perform test of hashing function.
+ //  Hashing is important to speed up the model and prevent double
+ //  calculations, however it can be tricky too, so make sure to reset the hash when in doubt.
+ BOOST_AUTO_TEST_CASE( testNRLMSISE00AtmosphereTestHashing )
+ {
+     // Create the model
+     NRLMSISE00Atmosphere model( std::bind( &nrlmsiseTestFunction,
+                                            std::placeholders::_1,
+                                            std::placeholders::_2,
+                                            std::placeholders::_3,
+                                            std::placeholders::_4,
+                                            false,
+                                            false ) );
+ 
+     // Create local copy of input and define variations
+     data = gen_data;
+     std::vector< double > input = gen_input;
+     // Define variations from the standard case
+     // First case is the default case
+
+     double density1 = model.getDensity( input[ 0 ], input[ 1 ], input[ 2 ], input[ 3 ] );
+ 
+     // Increase the daily F10.7 average (from 140.0)
+     data.f107 = 180.0;
+     double density2 = model.getDensity( input[ 0 ], input[ 1 ], input[ 2 ], input[ 3 ] );
+ 
+     // See that although the F10.7 has changed, no recalculation was
+     // triggered. The densities remain the same!
+     BOOST_CHECK_EQUAL( density1, density2 );
+ 
+     // In order to trigger a recalculation we can
+     // (A) reset the hash
+     model.resetHashKey( );
+     double density3 = model.getDensity( input[ 0 ], input[ 1 ], input[ 2 ], input[ 3 ] );
+ 
+     // And indeed observe a new density is calculated and is not equal
+     // anymore to the old one.
+     BOOST_CHECK_PREDICATE( std::not_equal_to< double >( ), (density1)( density3 ) );
+ 
+     // Recalculate density1, to "reset" the internal state of the
+     // model , for the next demo
+     data.f107 = 150.0;
+     model.resetHashKey( );
+     double density1new = model.getDensity( input[ 0 ], input[ 1 ], input[ 2 ], input[ 3 ] );
+     BOOST_CHECK_EQUAL( density1new, density1 );
+     data.f107 = 180.0;
+ 
+     // (B) change any of the four indepedent parameters, namely
+     // altitude, latitude, longitude, and/or time. Since time is not
+     // used in our current NRLMSISE00InputFunction of this test, we
+     // can change time without changing anything.
+     double density4 = model.getDensity( input[ 0 ], input[ 1 ], input[ 2 ], input[ 3 ] + 42.0 );
+ 
+     // The densities are not equal (ergo recalculated). Furthermore
+     // the density using method (B) is exactly equal to the density
+     // obtained using solution (A), this shows that both are equal in
+     // triggering recalculations.
+     BOOST_CHECK_PREDICATE( std::not_equal_to< double >( ), (density1)( density4 ) );
+     BOOST_CHECK_EQUAL( density3, density4 );
+ }
+
+ //! Perform NRLMSISE-00 test 1
+ //  Check values for 11 output parameters on against (hardcoded) values
+ //  obtained from the similar nrlmsise-test.c program.
+ BOOST_AUTO_TEST_CASE( testNRLMSISE00AtmosphereTest1 )
+ {
+ 
+     // Define verification data for specific test and tolerance
+     double tolerance = 1.0E-12;
+     std::vector< double > verificationData = { 6.665176904952E+05, 1.138805559752E+08, 1.998210925573E+07, 4.022763585713E+05,
+                                                3.557464994516E+03, 4.074713532757E-15, 3.475312399717E+04, 4.095913268293E+06,
+                                                2.667273209336E+04, 1.250539943561E+03, 1.241416130019E+03 };
+ 
+     // Create the model
+     NRLMSISE00Atmosphere model( std::bind( &nrlmsiseTestFunction,
+                                            std::placeholders::_1,
+                                            std::placeholders::_2,
+                                            std::placeholders::_3,
+                                            std::placeholders::_4,
+                                            false,
+                                            false ) );
+ 
+     // Create local copy of input and define variations
+     data = gen_data;
+     std::vector< double > input = gen_input;
+     // Define variations from the standard case
+     // First case is the default case
+ 
+     // Get full output for current test case
+     std::pair< std::vector< double >, std::vector< double > > output =
+             model.getFullOutput( input[ 0 ], input[ 1 ], input[ 2 ], input[ 3 ] );
+ 
+     // Loop through output and perform tests
+     for( unsigned i = 0; i < 9; i++ )
+     {
+         BOOST_CHECK_CLOSE_FRACTION( verificationData[ i ], output.first[ i ], tolerance );
+     }
+     for( unsigned i = 0; i < 2; i++ )
+     {
+         BOOST_CHECK_CLOSE_FRACTION( verificationData[ i + 9 ], output.second[ i ], tolerance );
+     }
+ }
+
+ //! Perform NRLMSISE-00 test 2
+ // Check values for 11 output parameters on against (hardcoded) values
+ // obtained from the similar nrlmsise-test.c program.
+ BOOST_AUTO_TEST_CASE( testNRLMSISE00AtmosphereTest2 )
+ {
+     // Define verification data for specific test and tolerance
+     double tolerance = 1.0E-12;
+     std::vector< double > verificationData = { 3.407293223161E+06, 1.586333369569E+08, 1.391117365461E+07, 3.262559509596E+05,
+                                                1.559618150501E+03, 5.001845729072E-15, 4.854208463340E+04, 4.380966712899E+06,
+                                                6.956681955942E+03, 1.166754383757E+03, 1.161710451887E+03 };
+ 
+     // Create the model
+     NRLMSISE00Atmosphere model( std::bind( &nrlmsiseTestFunction,
+                                            std::placeholders::_1,
+                                            std::placeholders::_2,
+                                            std::placeholders::_3,
+                                            std::placeholders::_4,
+                                            false,
+                                            false ) );
+ 
+     // Create local copy of input and define variations
+     data = gen_data;
+     std::vector< double > input = gen_input;
+     // Define variations from the standard case
+     data.dayOfTheYear = 81;
+ 
+     // We change parameters other than alt, lat, long, and/or time,
+     // so it's best to reset the hash.
+     model.resetHashKey( );
+ 
+     // Get full output for current test case
+     std::pair< std::vector< double >, std::vector< double > > output =
+             model.getFullOutput( input[ 0 ], input[ 1 ], input[ 2 ], input[ 3 ] );
+ 
+     // Loop through output and perform tests
+     for( unsigned i = 0; i < 9; i++ )
+     {
+         BOOST_CHECK_CLOSE_FRACTION( verificationData[ i ], output.first[ i ], tolerance );
+     }
+     for( unsigned i = 0; i < 2; i++ )
+     {
+         BOOST_CHECK_CLOSE_FRACTION( verificationData[ i + 9 ], output.second[ i ], tolerance );
+     }
+ }
+ 
+ //! Perform NRLMSISE-00 test 3
+ // Check values for 11 output parameters on against (hardcoded) values
+ // obtained from the similar nrlmsise-test.c program.
+ BOOST_AUTO_TEST_CASE( testNRLMSISE00AtmosphereTest3 )
+ {
+     // Define verification data for specific test and tolerance
+     double tolerance = 1.0E-12;
+     std::vector< double > verificationData = { 1.123767244038E+05, 6.934130086761E+04, 4.247105217477E+01, 1.322750141475E-01,
+                                                2.618848418232E-05, 2.756772319269E-18, 2.016749854321E+04, 5.741255934147E+03,
+                                                2.374394151990E+04, 1.239892111717E+03, 1.239890640133E+03 };
+ 
+     // Create the model
+     NRLMSISE00Atmosphere model( std::bind( &nrlmsiseTestFunction,
+                                            std::placeholders::_1,
+                                            std::placeholders::_2,
+                                            std::placeholders::_3,
+                                            std::placeholders::_4,
+                                            false,
+                                            false ) );
+ 
+     // Create local copy of input and define variations
+     data = gen_data;
+     std::vector< double > input = gen_input;
+     // Define variations from the standard case
+     data.secondOfTheDay = 75000.0;
+     input[ 0 ] = 1000.0E3;
+ 
+     // We change parameters other than alt, lat, long, and/or time,
+     // so it's best to reset the hash.
+     model.resetHashKey( );
+ 
+     // Get full output for current test case
+     std::pair< std::vector< double >, std::vector< double > > output =
+             model.getFullOutput( input[ 0 ], input[ 1 ], input[ 2 ], input[ 3 ] );
+ 
+     // Loop through output and perform tests
+     for( unsigned i = 0; i < 9; i++ )
+     {
+         BOOST_CHECK_CLOSE_FRACTION( verificationData[ i ], output.first[ i ], tolerance );
+     }
+     for( unsigned i = 0; i < 2; i++ )
+     {
+         BOOST_CHECK_CLOSE_FRACTION( verificationData[ i + 9 ], output.second[ i ], tolerance );
+     }
+ }
+ 
+ //! Perform NRLMSISE-00 test 4
+ // Check values for 11 output parameters on against (hardcoded) values
+ // obtained from the similar nrlmsise-test.c program.
+ BOOST_AUTO_TEST_CASE( testNRLMSISE00AtmosphereTest4 )
+ {
+     // Define verification data for specific test and tolerance
+     double tolerance = 1.0E-12;
+     std::vector< double > verificationData = { 5.411554379937E+07, 1.918893443939E+11, 6.115825598225E+12, 1.225201051740E+12,
+                                                6.023211973085E+10, 3.584426304113E-10, 1.059879697741E+07, 2.615736693705E+05,
+                                                2.819879355928E-42, 1.027318464900E+03, 2.068877764036E+02 };
+ 
+     // Create the model
+     NRLMSISE00Atmosphere model( std::bind( &nrlmsiseTestFunction,
+                                            std::placeholders::_1,
+                                            std::placeholders::_2,
+                                            std::placeholders::_3,
+                                            std::placeholders::_4,
+                                            false,
+                                            false ) );
+ 
+     // Create local copy of input and define variations
+     data = gen_data;
+     std::vector< double > input = gen_input;
+ 
+     // Define variations from the standard case
+     input[ 0 ] = 100.0E3;
+ 
+     // We change parameters other than alt, lat, long, and/or time,
+     // so it's best to reset the hash.
+     model.resetHashKey( );
+ 
+     // Get full output for current test case
+     std::pair< std::vector< double >, std::vector< double > > output =
+             model.getFullOutput( input[ 0 ], input[ 1 ], input[ 2 ], input[ 3 ] );
+ 
+     // Loop through output and perform tests
+     for( unsigned i = 0; i < 9; i++ )
+     {
+         BOOST_CHECK_CLOSE_FRACTION( verificationData[ i ], output.first[ i ], tolerance );
+     }
+     for( unsigned i = 0; i < 2; i++ )
+     {
+         BOOST_CHECK_CLOSE_FRACTION( verificationData[ i + 9 ], output.second[ i ], tolerance );
+     }
+ }
+ 
+ //! Perform NRLMSISE-00 test 5
+ // Check values for 11 output parameters on against (hardcoded) values
+ // obtained from the similar nrlmsise-test.c program.
+ BOOST_AUTO_TEST_CASE( testNRLMSISE00AtmosphereTest5 )
+ {
+     // Define verification data for specific test and tolerance
+     double tolerance = 1.0E-12;
+     std::vector< double > verificationData = { 1.851122486193E+06, 1.476554837927E+08, 1.579356228264E+07, 2.633794977312E+05,
+                                                1.588781398384E+03, 4.809630239407E-15, 5.816166780787E+04, 5.478984479069E+06,
+                                                1.264445941761E+03, 1.212396152121E+03, 1.208135425212E+03 };
+ 
+     // Create the model
+     NRLMSISE00Atmosphere model( std::bind( &nrlmsiseTestFunction,
+                                            std::placeholders::_1,
+                                            std::placeholders::_2,
+                                            std::placeholders::_3,
+                                            std::placeholders::_4,
+                                            false,
+                                            false ) );
+ 
+     // Create local copy of input and define variations
+     data = gen_data;
+     std::vector< double > input = gen_input;
+ 
+     // Define variations from the standard case
+     input[ 2 ] = 0.0;
+ 
+     // We change parameters other than alt, lat, long, and/or time,
+     // so it's best to reset the hash.
+     model.resetHashKey( );
+ 
+     // Get full output for current test case
+     std::pair< std::vector< double >, std::vector< double > > output =
+             model.getFullOutput( input[ 0 ], input[ 1 ], input[ 2 ], input[ 3 ] );
+ 
+     // Loop through output and perform tests
+     for( unsigned i = 0; i < 9; i++ )
+     {
+         BOOST_CHECK_CLOSE_FRACTION( verificationData[ i ], output.first[ i ], tolerance );
+     }
+     for( unsigned i = 0; i < 2; i++ )
+     {
+         BOOST_CHECK_CLOSE_FRACTION( verificationData[ i + 9 ], output.second[ i ], tolerance );
+     }
+ }
+ 
+ //! Perform NRLMSISE-00 test 6
+ // Check values for 11 output parameters on against (hardcoded) values
+ // obtained from the similar nrlmsise-test.c program.
+ BOOST_AUTO_TEST_CASE( testNRLMSISE00AtmosphereTest6 )
+ {
+     // Define verification data for specific test and tolerance
+     double tolerance = 1.0E-12;
+     std::vector< double > verificationData = { 8.673095233906E+05, 1.278861768014E+08, 1.822576627172E+07, 2.922214190618E+05,
+                                                2.402962436424E+03, 4.355865642645E-15, 3.686389243751E+04, 3.897275503727E+06,
+                                                2.667273209336E+04, 1.220146417915E+03, 1.212712083212E+03 };
+ 
+     // Create the model
+     NRLMSISE00Atmosphere model( std::bind( &nrlmsiseTestFunction,
+                                            std::placeholders::_1,
+                                            std::placeholders::_2,
+                                            std::placeholders::_3,
+                                            std::placeholders::_4,
+                                            false,
+                                            false ) );
+ 
+     // Create local copy of input and define variations
+     data = gen_data;
+     std::vector< double > input = gen_input;
+ 
+     // Define variations from the standard case
+     input[ 1 ] = 0.0;
+ 
+     // We change parameters other than alt, lat, long, and/or time,
+     // so it's best to reset the hash.
+     model.resetHashKey( );
+ 
+     // Get full output for current test case
+     std::pair< std::vector< double >, std::vector< double > > output =
+             model.getFullOutput( input[ 0 ], input[ 1 ], input[ 2 ], input[ 3 ] );
+ 
+     // Loop through output and perform tests
+     for( unsigned i = 0; i < 9; i++ )
+     {
+         BOOST_CHECK_CLOSE_FRACTION( verificationData[ i ], output.first[ i ], tolerance );
+     }
+     for( unsigned i = 0; i < 2; i++ )
+     {
+         BOOST_CHECK_CLOSE_FRACTION( verificationData[ i + 9 ], output.second[ i ], tolerance );
+     }
+ }
+ 
+ //! Perform NRLMSISE-00 test 7
+ // Check values for 11 output parameters on against (hardcoded) values
+ // obtained from the similar nrlmsise-test.c program.
+ BOOST_AUTO_TEST_CASE( testNRLMSISE00AtmosphereTest7 )
+ {
+     // Define verification data for specific test and tolerance
+     double tolerance = 1.0E-12;
+     std::vector< double > verificationData = { 5.776251216023E+05, 6.979138693660E+07, 1.236813559822E+07, 2.492867715429E+05,
+                                                1.405738674178E+03, 2.470651391663E-15, 5.291985567067E+04, 1.069814109367E+06,
+                                                2.667273209336E+04, 1.116385376043E+03, 1.112998568217E+03 };
+ 
+     // Create the model
+     NRLMSISE00Atmosphere model( std::bind( &nrlmsiseTestFunction,
+                                            std::placeholders::_1,
+                                            std::placeholders::_2,
+                                            std::placeholders::_3,
+                                            std::placeholders::_4,
+                                            false,
+                                            false ) );
+ 
+     // Create local copy of input and define variations
+     data = gen_data;
+     std::vector< double > input = gen_input;
+ 
+     // Define variations from the standard case
+     data.localSolarTime = 4.0;
+ 
+     // We change parameters other than alt, lat, long, and/or time,
+     // so it's best to reset the hash.
+     model.resetHashKey( );
+ 
+     // Get full output for current test case
+     std::pair< std::vector< double >, std::vector< double > > output =
+             model.getFullOutput( input[ 0 ], input[ 1 ], input[ 2 ], input[ 3 ] );
+ 
+     // Loop through output and perform tests
+     for( unsigned i = 0; i < 9; i++ )
+     {
+         BOOST_CHECK_CLOSE_FRACTION( verificationData[ i ], output.first[ i ], tolerance );
+     }
+     for( unsigned i = 0; i < 2; i++ )
+     {
+         BOOST_CHECK_CLOSE_FRACTION( verificationData[ i + 9 ], output.second[ i ], tolerance );
+     }
+ }
+ 
+ //! Perform NRLMSISE-00 test 8
+ // Check values for 11 output parameters on against (hardcoded) values
+ // obtained from the similar nrlmsise-test.c program.
+ BOOST_AUTO_TEST_CASE( testNRLMSISE00AtmosphereTest8 )
+ {
+     // Define verification data for specific test and tolerance
+     double tolerance = 1.0E-12;
+     std::vector< double > verificationData = { 3.740304105508E+05, 4.782720123611E+07, 5.240380033324E+06, 1.759874640391E+05,
+                                                5.501648779570E+02, 1.571888739255E-15, 8.896775722935E+04, 1.979740836233E+06,
+                                                9.121814875991E+03, 1.031247440715E+03, 1.024848492213E+03 };
+ 
+     // Create the model
+     NRLMSISE00Atmosphere model( std::bind( &nrlmsiseTestFunction,
+                                            std::placeholders::_1,
+                                            std::placeholders::_2,
+                                            std::placeholders::_3,
+                                            std::placeholders::_4,
+                                            false,
+                                            false ) );
+ 
+     // Create local copy of input and define variations
+     data = gen_data;
+     std::vector< double > input = gen_input;
+ 
+     // Define variations from the standard case
+     data.f107a = 70.0;
+ 
+     // We change parameters other than alt, lat, long, and/or time,
+     // so it's best to reset the hash.
+     model.resetHashKey( );
+ 
+     // Get full output for current test case
+     std::pair< std::vector< double >, std::vector< double > > output =
+             model.getFullOutput( input[ 0 ], input[ 1 ], input[ 2 ], input[ 3 ] );
+ 
+     // Loop through output and perform tests
+     for( unsigned i = 0; i < 9; i++ )
+     {
+         BOOST_CHECK_CLOSE_FRACTION( verificationData[ i ], output.first[ i ], tolerance );
+     }
+     for( unsigned i = 0; i < 2; i++ )
+     {
+         BOOST_CHECK_CLOSE_FRACTION( verificationData[ i + 9 ], output.second[ i ], tolerance );
+     }
+ }
+ 
+ //! Perform NRLMSISE-00 test 9
+ // Check values for 11 output parameters on against (hardcoded) values
+ // obtained from the similar nrlmsise-test.c program.
+ BOOST_AUTO_TEST_CASE( testNRLMSISE00AtmosphereTest9 )
+ {
+     // Define verification data for specific test and tolerance
+     double tolerance = 1.0E-12;
+     std::vector< double > verificationData = { 6.748338766624E+05, 1.245315260444E+08, 2.369009541053E+07, 4.911583154750E+05,
+                                                4.578781099054E+03, 4.564420245361E-15, 3.244594775161E+04, 5.370833087086E+06,
+                                                2.667273209336E+04, 1.306052042027E+03, 1.293374040390E+03 };
+ 
+     // Create the model
+     NRLMSISE00Atmosphere model( std::bind( &nrlmsiseTestFunction,
+                                            std::placeholders::_1,
+                                            std::placeholders::_2,
+                                            std::placeholders::_3,
+                                            std::placeholders::_4,
+                                            false,
+                                            false ) );
+ 
+     // Create local copy of input and define variations
+     data = gen_data;
+     std::vector< double > input = gen_input;
+ 
+     // Define variations from the standard case
+     data.f107 = 180.0;
+ 
+     // We change parameters other than alt, lat, long, and/or time,
+     // so it's best to reset the hash.
+     model.resetHashKey( );
+ 
+     // Get full output for current test case
+     std::pair< std::vector< double >, std::vector< double > > output =
+             model.getFullOutput( input[ 0 ], input[ 1 ], input[ 2 ], input[ 3 ] );
+ 
+     // Loop through output and perform tests
+     for( unsigned i = 0; i < 9; i++ )
+     {
+         BOOST_CHECK_CLOSE_FRACTION( verificationData[ i ], output.first[ i ], tolerance );
+     }
+     for( unsigned i = 0; i < 2; i++ )
+     {
+         BOOST_CHECK_CLOSE_FRACTION( verificationData[ i + 9 ], output.second[ i ], tolerance );
+     }
+ }
+ 
+ //! Perform NRLMSISE-00 test 10
+ // Check values for 11 output parameters on against (hardcoded) values
+ // obtained from the similar nrlmsise-test.c program.
+ BOOST_AUTO_TEST_CASE( testNRLMSISE00AtmosphereTest10 )
+ {
+     // Define verification data for specific test and tolerance
+     double tolerance = 1.0E-12;
+     std::vector< double > verificationData = { 5.528600841645E+05, 1.198041324041E+08, 3.495797764558E+07, 9.339618355028E+05,
+                                                1.096254765493E+04, 4.974543110322E-15, 2.686427856260E+04, 4.889974232971E+06,
+                                                2.805444837126E+04, 1.361868020785E+03, 1.347389183730E+03 };
+ 
+     // Create the model
+     NRLMSISE00Atmosphere model( std::bind( &nrlmsiseTestFunction,
+                                            std::placeholders::_1,
+                                            std::placeholders::_2,
+                                            std::placeholders::_3,
+                                            std::placeholders::_4,
+                                            false,
+                                            false ) );
+ 
+     // Create local copy of input and define variations
+     data = gen_data;
+     std::vector< double > input = gen_input;
+ 
+     // Define variations from the standard case
+     data.apDaily = 40.0;
+ 
+     // We change parameters other than alt, lat, long, and/or time,
+     // so it's best to reset the hash.
+     model.resetHashKey( );
+ 
+     // Get full output for current test case
+     std::pair< std::vector< double >, std::vector< double > > output =
+             model.getFullOutput( input[ 0 ], input[ 1 ], input[ 2 ], input[ 3 ] );
+ 
+     // Loop through output and perform tests
+     for( unsigned i = 0; i < 9; i++ )
+     {
+         BOOST_CHECK_CLOSE_FRACTION( verificationData[ i ], output.first[ i ], tolerance );
+     }
+     for( unsigned i = 0; i < 2; i++ )
+     {
+         BOOST_CHECK_CLOSE_FRACTION( verificationData[ i + 9 ], output.second[ i ], tolerance );
+     }
+ }
+ 
+ //! Perform NRLMSISE-00 test 11
+ // Check values for 11 output parameters on against (hardcoded) values
+ // obtained from the similar nrlmsise-test.c program.
+ BOOST_AUTO_TEST_CASE( testNRLMSISE00AtmosphereTest11 )
+ {
+     // Define verification data for specific test and tolerance
+     double tolerance = 1.0E-12;
+     std::vector< double > verificationData = { 1.375487584186E+14, 0.000000000000E+00, 2.049687044291E+19, 5.498695433719E+18,
+                                                2.451733158028E+17, 1.261065661119E-03, 0.000000000000E+00, 0.000000000000E+00,
+                                                0.000000000000E+00, 1.027318464900E+03, 2.814647576632E+02 };
+ 
+     // Create the model
+     NRLMSISE00Atmosphere model( std::bind( &nrlmsiseTestFunction,
+                                            std::placeholders::_1,
+                                            std::placeholders::_2,
+                                            std::placeholders::_3,
+                                            std::placeholders::_4,
+                                            false,
+                                            false ) );
+ 
+     // Create local copy of input and define variations
+     data = gen_data;
+     std::vector< double > input = gen_input;
+ 
+     // Define variations from the standard case
+     input[ 0 ] = 0.0;
+ 
+     // We change parameters other than alt, lat, long, and/or time,
+     // so it's best to reset the hash.
+     model.resetHashKey( );
+ 
+     // Get full output for current test case
+     std::pair< std::vector< double >, std::vector< double > > output =
+             model.getFullOutput( input[ 0 ], input[ 1 ], input[ 2 ], input[ 3 ] );
+ 
+     // Loop through output and perform tests
+     for( unsigned i = 0; i < 9; i++ )
+     {
+         BOOST_CHECK_CLOSE_FRACTION( verificationData[ i ], output.first[ i ], tolerance );
+     }
+     for( unsigned i = 0; i < 2; i++ )
+     {
+         BOOST_CHECK_CLOSE_FRACTION( verificationData[ i + 9 ], output.second[ i ], tolerance );
+     }
+ }
+ 
+ //! Perform NRLMSISE-00 test 12
+ // Check values for 11 output parameters on against (hardcoded) values
+ // obtained from the similar nrlmsise-test.c program.
+ BOOST_AUTO_TEST_CASE( testNRLMSISE00AtmosphereTest12 )
+ {
+     // Define verification data for specific test and tolerance
+     double tolerance = 1.0E-12;
+     std::vector< double > verificationData = { 4.427442587677E+13, 0.000000000000E+00, 6.597567157737E+18, 1.769929341406E+18,
+                                                7.891679955727E+16, 4.059139375799E-04, 0.000000000000E+00, 0.000000000000E+00,
+                                                0.000000000000E+00, 1.027318464900E+03, 2.274179808273E+02 };
+ 
+     // Create the model
+     NRLMSISE00Atmosphere model( std::bind( &nrlmsiseTestFunction,
+                                            std::placeholders::_1,
+                                            std::placeholders::_2,
+                                            std::placeholders::_3,
+                                            std::placeholders::_4,
+                                            false,
+                                            false ) );
+ 
+     // Create local copy of input and define variations
+     data = gen_data;
+     std::vector< double > input = gen_input;
+ 
+     // Define variations from the standard case
+     input[ 0 ] = 10.0E3;
+ 
+     // We change parameters other than alt, lat, long, and/or time,
+     // so it's best to reset the hash.
+     model.resetHashKey( );
+ 
+     // Get full output for current test case
+     std::pair< std::vector< double >, std::vector< double > > output =
+             model.getFullOutput( input[ 0 ], input[ 1 ], input[ 2 ], input[ 3 ] );
+ 
+     // Loop through output and perform tests
+     for( unsigned i = 0; i < 9; i++ )
+     {
+         BOOST_CHECK_CLOSE_FRACTION( verificationData[ i ], output.first[ i ], tolerance );
+     }
+     for( unsigned i = 0; i < 2; i++ )
+     {
+         BOOST_CHECK_CLOSE_FRACTION( verificationData[ i + 9 ], output.second[ i ], tolerance );
+     }
+ }
+ 
+ //! Perform NRLMSISE-00 test 13
+ // Check values for 11 output parameters on against (hardcoded) values
+ // obtained from the similar nrlmsise-test.c program.
+ BOOST_AUTO_TEST_CASE( testNRLMSISE00AtmosphereTest13 )
+ {
+     // Define verification data for specific test and tolerance
+     double tolerance = 1.0E-12;
+     std::vector< double > verificationData = { 2.127828756207E+12, 0.000000000000E+00, 3.170790550354E+17, 8.506279809435E+16,
+                                                3.792741116806E+15, 1.950822245176E-05, 0.000000000000E+00, 0.000000000000E+00,
+                                                0.000000000000E+00, 1.027318464900E+03, 2.374389145877E+02 };
+ 
+     // Create the model
+     NRLMSISE00Atmosphere model( std::bind( &nrlmsiseTestFunction,
+                                            std::placeholders::_1,
+                                            std::placeholders::_2,
+                                            std::placeholders::_3,
+                                            std::placeholders::_4,
+                                            false,
+                                            false ) );
+ 
+     // Create local copy of input and define variations
+     data = gen_data;
+     std::vector< double > input = gen_input;
+ 
+     // Define variations from the standard case
+     input[ 0 ] = 30.0E3;
+ 
+     // We change parameters other than alt, lat, long, and/or time,
+     // so it's best to reset the hash.
+     model.resetHashKey( );
+ 
+     // Get full output for current test case
+     std::pair< std::vector< double >, std::vector< double > > output =
+             model.getFullOutput( input[ 0 ], input[ 1 ], input[ 2 ], input[ 3 ] );
+ 
+     // Loop through output and perform tests
+     for( unsigned i = 0; i < 9; i++ )
+     {
+         BOOST_CHECK_CLOSE_FRACTION( verificationData[ i ], output.first[ i ], tolerance );
+     }
+     for( unsigned i = 0; i < 2; i++ )
+     {
+         BOOST_CHECK_CLOSE_FRACTION( verificationData[ i + 9 ], output.second[ i ], tolerance );
+     }
+ }
+ 
+ //! Perform NRLMSISE-00 test 14
+ // Check values for 11 output parameters on against (hardcoded) values
+ // obtained from the similar nrlmsise-test.c program.
+ BOOST_AUTO_TEST_CASE( testNRLMSISE00AtmosphereTest14 )
+ {
+     // Define verification data for specific test and tolerance
+     double tolerance = 1.0E-12;
+     std::vector< double > verificationData = { 1.412183545593E+11, 0.000000000000E+00, 2.104369643783E+16, 5.645392443377E+15,
+                                                2.517141749411E+14, 1.294709015929E-06, 0.000000000000E+00, 0.000000000000E+00,
+                                                0.000000000000E+00, 1.027318464900E+03, 2.795551129541E+02 };
+ 
+     // Create the model
+     NRLMSISE00Atmosphere model( std::bind( &nrlmsiseTestFunction,
+                                            std::placeholders::_1,
+                                            std::placeholders::_2,
+                                            std::placeholders::_3,
+                                            std::placeholders::_4,
+                                            false,
+                                            false ) );
+ 
+     // Create local copy of input and define variations
+     data = gen_data;
+     std::vector< double > input = gen_input;
+ 
+     // Define variations from the standard case
+     input[ 0 ] = 50.0E3;
+ 
+     // We change parameters other than alt, lat, long, and/or time,
+     // so it's best to reset the hash.
+     model.resetHashKey( );
+ 
+     // Get full output for current test case
+     std::pair< std::vector< double >, std::vector< double > > output =
+             model.getFullOutput( input[ 0 ], input[ 1 ], input[ 2 ], input[ 3 ] );
+ 
+     // Loop through output and perform tests
+     for( unsigned i = 0; i < 9; i++ )
+     {
+         BOOST_CHECK_CLOSE_FRACTION( verificationData[ i ], output.first[ i ], tolerance );
+     }
+     for( unsigned i = 0; i < 2; i++ )
+     {
+         BOOST_CHECK_CLOSE_FRACTION( verificationData[ i + 9 ], output.second[ i ], tolerance );
+     }
+ }
+ 
+ //! Perform NRLMSISE-00 test 15
+ // Check values for 11 output parameters on against (hardcoded) values
+ // obtained from the similar nrlmsise-test.c program.
+ BOOST_AUTO_TEST_CASE( testNRLMSISE00AtmosphereTest15 )
+ {
+     // Define verification data for specific test and tolerance
+     double tolerance = 1.0E-12;
+     std::vector< double > verificationData = { 1.254884400273E+10, 0.000000000000E+00, 1.874532829219E+15, 4.923050980785E+14,
+                                                2.239685413856E+13, 1.147667671512E-07, 0.000000000000E+00, 0.000000000000E+00,
+                                                0.000000000000E+00, 1.027318464900E+03, 2.190732313642E+02 };
+ 
+     // Create the model
+     NRLMSISE00Atmosphere model( std::bind( &nrlmsiseTestFunction,
+                                            std::placeholders::_1,
+                                            std::placeholders::_2,
+                                            std::placeholders::_3,
+                                            std::placeholders::_4,
+                                            false,
+                                            false ) );
+ 
+     // Create local copy of input and define variations
+     data = gen_data;
+     std::vector< double > input = gen_input;
+ 
+     // Define variations from the standard case
+     input[ 0 ] = 70.0E3;
+ 
+     // We change parameters other than alt, lat, long, and/or time,
+     // so it's best to reset the hash.
+     model.resetHashKey( );
+ 
+     // Get full output for current test case
+     std::pair< std::vector< double >, std::vector< double > > output =
+             model.getFullOutput( input[ 0 ], input[ 1 ], input[ 2 ], input[ 3 ] );
+ 
+     // Loop through output and perform tests
+     for( unsigned i = 0; i < 9; i++ )
+     {
+         BOOST_CHECK_CLOSE_FRACTION( verificationData[ i ], output.first[ i ], tolerance );
+     }
+     for( unsigned i = 0; i < 2; i++ )
+     {
+         BOOST_CHECK_CLOSE_FRACTION( verificationData[ i + 9 ], output.second[ i ], tolerance );
+     }
+ }
+ 
+ //! Perform NRLMSISE-00 test 16
+ // Check values for 11 output parameters on against (hardcoded) values
+ // obtained from the similar nrlmsise-test.c program.
+ BOOST_AUTO_TEST_CASE( testNRLMSISE00AtmosphereTest16 )
+ {
+     // Define verification data for specific test and tolerance
+     double tolerance = 1.0E-12;
+     std::vector< double > verificationData = { 5.196477402973E+05, 1.274494072960E+08, 4.850449869853E+07, 1.720837982575E+06,
+                                                2.354486590544E+04, 5.881940448652E-15, 2.500078391081E+04, 6.279209825019E+06,
+                                                2.667273209336E+04, 1.426411662282E+03, 1.408607795553E+03 };
+ 
+     // Create the model
+     NRLMSISE00Atmosphere model( std::bind( &nrlmsiseTestFunction,
+                                            std::placeholders::_1,
+                                            std::placeholders::_2,
+                                            std::placeholders::_3,
+                                            std::placeholders::_4,
+                                            false,
+                                            false ) );
+ 
+     // Create local copy of input and define variations
+     data = gen_data;
+     std::vector< double > input = gen_input;
+ 
+     // Define variations from the standard case
+     data.apVector = std::vector< double >( 7, 100.0 );
+     data.switches[ 9 ] = -1;
+ 
+     // We change parameters other than alt, lat, long, and/or time,
+     // so it's best to reset the hash.
+     model.resetHashKey( );
+ 
+     // Get full output for current test case
+     std::pair< std::vector< double >, std::vector< double > > output =
+             model.getFullOutput( input[ 0 ], input[ 1 ], input[ 2 ], input[ 3 ] );
+ 
+     // Loop through output and perform tests
+     for( unsigned i = 0; i < 9; i++ )
+     {
+         BOOST_CHECK_CLOSE_FRACTION( verificationData[ i ], output.first[ i ], tolerance );
+     }
+     for( unsigned i = 0; i < 2; i++ )
+     {
+         BOOST_CHECK_CLOSE_FRACTION( verificationData[ i + 9 ], output.second[ i ], tolerance );
+     }
+ }
+ 
+ //! Perform NRLMSISE-00 test 17
+ // Check values for 11 output parameters on against (hardcoded) values
+ // obtained from the similar nrlmsise-test.c program.
+ BOOST_AUTO_TEST_CASE( testNRLMSISE00AtmosphereTest17 )
+ {
+     // Define verification data for specific test and tolerance
+     double tolerance = 1.0E-12;
+     std::vector< double > verificationData = { 4.260859748794E+07, 1.241342015549E+11, 4.929561542488E+12, 1.048406749093E+12,
+                                                4.993465083056E+10, 2.914303550309E-10, 8.831228592572E+06, 2.252515508626E+05,
+                                                2.415245929649E-42, 1.027318464900E+03, 1.934071062577E+02 };
+ 
+     // Create the model
+     NRLMSISE00Atmosphere model( std::bind( &nrlmsiseTestFunction,
+                                            std::placeholders::_1,
+                                            std::placeholders::_2,
+                                            std::placeholders::_3,
+                                            std::placeholders::_4,
+                                            false,
+                                            false ) );
+ 
+     // Create local copy of input and define variations
+     data = gen_data;
+     std::vector< double > input = gen_input;
+ 
+     // Define variations from the standard case
+     input[ 0 ] = 100.0E3;
+     data.apVector = std::vector< double >( 7, 100.0 );
+     data.switches[ 9 ] = -1;
+ 
+     // We change parameters other than alt, lat, long, and/or time,
+     // so it's best to reset the hash.
+     model.resetHashKey( );
+ 
+     // Get full output for current test case
+     std::pair< std::vector< double >, std::vector< double > > output =
+             model.getFullOutput( input[ 0 ], input[ 1 ], input[ 2 ], input[ 3 ] );
+ 
+     // Loop through output and perform tests
+     for( unsigned i = 0; i < 9; i++ )
+     {
+         BOOST_CHECK_CLOSE_FRACTION( verificationData[ i ], output.first[ i ], tolerance );
+     }
+     for( unsigned i = 0; i < 2; i++ )
+     {
+         BOOST_CHECK_CLOSE_FRACTION( verificationData[ i + 9 ], output.second[ i ], tolerance );
+     }
+ }
+ 
+ //! Perform NRLMSISE-00 test 18
+ // Check computation of speed of sound
+ BOOST_AUTO_TEST_CASE( testSpeedOfSound )
+ {
+     // Construct model with default properties
+     NRLMSISE00Atmosphere model( std::bind( &nrlmsiseTestFunction,
+                                            std::placeholders::_1,
+                                            std::placeholders::_2,
+                                            std::placeholders::_3,
+                                            std::placeholders::_4,
+                                            false,
+                                            false ) );
+ 
+     double altitude = 0.0;
+     double longitude = 0.0;
+     double latitude = 0.0;
+     double time = 0.0;
+ 
+     // Check speed of sound : (https://en.wikipedia.org/wiki/Speed_of_sound  (at 20 deg celcius) )
+     // 340.9 at sealevel (anderson, fundamentals of aerodynamics)
+     BOOST_CHECK_CLOSE_FRACTION( model.getSpeedOfSound( altitude, longitude, latitude, time ), 343.21, 2E-2 );   // < 2%
+     BOOST_CHECK_CLOSE_FRACTION( model.getSpeedOfSound( altitude, longitude, latitude, time ), 340.9, 1.8E-2 );  // < 1.8%
+ 
+     // US Standard Atmosphere Model 1976
+     std::string atmosphereTableFile = tudat::paths::getAtmosphereTablesPath( ) + "/USSA1976Until100kmPer100mUntil1000kmPer1000m.dat";
+     tudat::aerodynamics::TabulatedAtmosphere US76model( atmosphereTableFile );
+ 
+     // Test wist US76 table (NRLMSISE should provide approximately the same results)
+     BOOST_CHECK_CLOSE_FRACTION(
+             model.getSpeedOfSound( altitude, longitude, latitude, time ), US76model.getSpeedOfSound( altitude ), 2E-2 );  // < 2%
+ 
+     altitude = 10.0E3;
+     BOOST_CHECK_CLOSE_FRACTION(
+             model.getSpeedOfSound( altitude, longitude, latitude, time ), US76model.getSpeedOfSound( altitude ), 3.5E-2 );  // < 3.5%
+ 
+     altitude = 40.0E3;
+     BOOST_CHECK_CLOSE_FRACTION(
+             model.getSpeedOfSound( altitude, longitude, latitude, time ), US76model.getSpeedOfSound( altitude ), 6.5E-2 );  // < 6.5%
+ 
+     altitude = 80.0E3;
+     BOOST_CHECK_CLOSE_FRACTION(
+             model.getSpeedOfSound( altitude, longitude, latitude, time ), US76model.getSpeedOfSound( altitude ), 5E-2 );  // < 5%
+ 
+     // Verify calculation
+     double speedOfSound = std::sqrt( 1.4 * 8.3144598 * model.getTemperature( altitude, longitude, latitude, time ) /
+                                      model.getMeanMolarMass( altitude, longitude, latitude, time ) );
+     BOOST_CHECK_CLOSE_FRACTION( speedOfSound, model.getSpeedOfSound( altitude, longitude, latitude, time ), 1E-15 );
+ }
+ 
+ //! Perform NRLMSISE-00 test 19
+ // Check computation of molar mass
+ BOOST_AUTO_TEST_CASE( testMolarMass )
+ {
+     // Construct model with default properties
+     NRLMSISE00Atmosphere model( std::bind( &nrlmsiseTestFunction,
+                                            std::placeholders::_1,
+                                            std::placeholders::_2,
+                                            std::placeholders::_3,
+                                            std::placeholders::_4,
+                                            false,
+                                            false ) );
+ 
+     double altitude = 0.0;
+     double longitude = 0.0;
+     double latitude = 0.0;
+     double time = 0.0;
+ 
+     // Check using textbook example: Dynamics of atmospheric re-entry, Regan , 1993
+     BOOST_CHECK_CLOSE_FRACTION( model.getMeanMolarMass( altitude, longitude, latitude, time ), 28.96643E-3, 3E-4 );  // < 0.03%
+ 
+     altitude = 50.0E3;
+     BOOST_CHECK_CLOSE_FRACTION( model.getMeanMolarMass( altitude, longitude, latitude, time ), 28.96643E-3, 3E-4 );  // < 0.03%
+ 
+     altitude = 200.0E3;
+     BOOST_CHECK_CLOSE_FRACTION( model.getMeanMolarMass( altitude, longitude, latitude, time ), 21.0E-3, 3E-2 );  // < 3%
+ 
+     altitude = 300.0E3;
+     BOOST_CHECK_CLOSE_FRACTION( model.getMeanMolarMass( altitude, longitude, latitude, time ), 18.0E-3, 3E-2 );  // < 3%
+ }
+ 
+ //! Perform NRLMSISE-00 test 20
+ // Check computation mean free path
+ BOOST_AUTO_TEST_CASE( testMeanFreePath )
+ {
+     // Construct model with default properties
+     NRLMSISE00Atmosphere model( std::bind( &nrlmsiseTestFunction,
+                                            std::placeholders::_1,
+                                            std::placeholders::_2,
+                                            std::placeholders::_3,
+                                            std::placeholders::_4,
+                                            false,
+                                            false ) );
+ 
+     double altitude = 20.0E3;
+     double longitude = 0.5;
+     double latitude = 0.2;
+     double time = 1.0E5;
+ 
+     // Verify calculation
+     double meanFreePath = std::sqrt( 2.0 ) * PI *
+             std::pow( model.getWeightedAverageCollisionDiameter( altitude, longitude, latitude, time ), 2.0 ) *
+             model.getAverageNumberDensity( altitude, longitude, latitude, time );
+     meanFreePath = std::pow( meanFreePath, ( -1.0 ) );
+ 
+     BOOST_CHECK_CLOSE_FRACTION( model.getMeanFreePath( altitude, longitude, latitude, time ), meanFreePath, 1.0E-15 );
+ 
+     // Verify using data - Logarithmic plot: physics of the Earth's space environment, Gerd W. Prolls (page 29)
+     // Test using approximate values obtained from figure
+     altitude = 0.0E3;
+     BOOST_CHECK_CLOSE_FRACTION( model.getMeanFreePath( altitude, longitude, latitude, time ), 1.0E-7, 10.0 );
+ 
+     altitude = 60.0E3;
+     BOOST_CHECK_CLOSE_FRACTION( model.getMeanFreePath( altitude, longitude, latitude, time ), 1.0E-3, 1.2 );
+ 
+     altitude = 300.0E3;
+     BOOST_CHECK_CLOSE_FRACTION( model.getMeanFreePath( altitude, longitude, latitude, time ), 1.0E4, 0.9 );
+ }
+ //
+ ////! Perform NRLMSISE-00 test 21 - Test input function
+ //// Corresponds to NRLMSISE test 1 but space weather file is used to set solar activity data.
+ //// No adjustment values in space weather file are used.
+ //BOOST_AUTO_TEST_CASE( test_nrlmise_InputFunction_no_adjustment )
+ //{
+ //    //    NRLMSISE00Input gen_data(2030, 172, 29000.0, 16.0, 150.0, 150.0, 4.0);
+ //    // DD-MM-YY = 21-06-2030 , Hrs-Min-Sec = 8-3-20
+ //    double julianDate = tudat::basic_astrodynamics::convertCalendarDateToJulianDay< double >( 2030, 6, 21, 8, 3, 20.0 );
+ //    double time =
+ //            tudat::basic_astrodynamics::convertJulianDayToSecondsSinceEpoch( julianDate, tudat::basic_astrodynamics::JULIAN_DAY_ON_J2000 );
+ //
+ //    // std::vector< double > gen_input = { 400.0, -70.0, 60.0, 0.0 };
+ //    double altitude = 400.0E3;  // km
+ //    double longitude = -70.0 * PI / 180.0;
+ //    double latitude = 60.0 * PI / 180.0;
+ //
+ //    // find space weather file
+ //    std::string spaceWeatherFilePath = tudat::paths::getTudatTestDataPath( ) + "/swAtmosTestWithAdjust.txt";
+ //
+ //    tudat::input_output::solar_activity::SolarActivityDataMap solarActivityData =
+ //            tudat::input_output::solar_activity::readSolarActivityData( spaceWeatherFilePath );
+ //
+ //    // Create atmosphere model using NRLMISE00 input function
+ //    // Local solar time is set to 16.0 to correspond with testing data!
+ //    std::function< tudat::aerodynamics::NRLMSISE00Input( double, double, double, double ) > inputFunction =
+ //            std::bind( &tudat::aerodynamics::nrlmsiseInputFunction,
+ //                       std::placeholders::_1,
+ //                       std::placeholders::_2,
+ //                       std::placeholders::_3,
+ //                       std::placeholders::_4,
+ //                       solarActivityData,
+ //                       true,
+ //                       16.0 );
+ //
+ //    // Create Pointer to NRLMSISE model
+ //    tudat::aerodynamics::NRLMSISE00Atmosphere atmosphereModel( inputFunction );
+ //
+ //    // Verification data
+ //    std::vector< double > verificationData = { 6.665176904952E+05, 1.138805559752E+08, 1.998210925573E+07, 4.022763585713E+05,
+ //                                               3.557464994516E+03, 4.074713532757E-15, 3.475312399717E+04, 4.095913268293E+06,
+ //                                               2.667273209336E+04, 1.250539943561E+03, 1.241416130019E+03 };
+ //
+ //    double computedDensity = atmosphereModel.getDensity( altitude, longitude, latitude, time );
+ //
+ //    BOOST_CHECK_CLOSE_FRACTION( verificationData[ 5 ] * 1000, computedDensity, 1E-11 );
+ //}
+ //
+ ////! Perform NRLMSISE-00 test 22 - Test input function
+ //// Corresponds to NRLMSISE test 1 but space weather file is used to set solar activity data.
+ //// Adjustment values (flux qualifier is 1) in space weather file are used.
+ //BOOST_AUTO_TEST_CASE( test_nrlmise_InputFunction_with_adjustment )
+ //{
+ //    //    NRLMSISE00Input gen_data(2030, 172, 29000.0, 16.0, 150.0, 150.0, 4.0);
+ //    // DD-MM-YY = 21-06-2030 , Hrs-Min-Sec = 8-3-20
+ //    double julianDate = tudat::basic_astrodynamics::convertCalendarDateToJulianDay< double >( 2030, 6, 21, 8, 3, 20.0 );
+ //    double time =
+ //            tudat::basic_astrodynamics::convertJulianDayToSecondsSinceEpoch( julianDate, tudat::basic_astrodynamics::JULIAN_DAY_ON_J2000 );
+ //
+ //    // std::vector< double > gen_input = { 400.0, -70.0, 60.0, 0.0 };
+ //    double altitude = 400.0E3;  // km
+ //    double longitude = -70.0 * PI / 180.0;
+ //    double latitude = 60.0 * PI / 180.0;
+ //
+ //    // find space weather file
+ //    std::string spaceWeatherFilePath = tudat::paths::getTudatTestDataPath( ) + "/swAtmosTestWithAdjust.txt";
+ //
+ //    tudat::input_output::solar_activity::SolarActivityDataMap solarActivityData =
+ //            tudat::input_output::solar_activity::readSolarActivityData( spaceWeatherFilePath );
+ //
+ //    // Create atmosphere model using NRLMISE00 input function
+ //    // Local solar time is set to 16.0 to correspond with testing data!
+ //    std::function< tudat::aerodynamics::NRLMSISE00Input( double, double, double, double ) > inputFunction =
+ //            std::bind( &tudat::aerodynamics::nrlmsiseInputFunction,
+ //                       std::placeholders::_1,
+ //                       std::placeholders::_2,
+ //                       std::placeholders::_3,
+ //                       std::placeholders::_4,
+ //                       solarActivityData,
+ //                       true,
+ //                       16.0 );
+ //
+ //    // Create Pointer to NRLMSISE model
+ //    tudat::aerodynamics::NRLMSISE00Atmosphere atmosphereModel( inputFunction );
+ //
+ //    // Verification data
+ //    std::vector< double > verificationData = { 6.665176904952E+05, 1.138805559752E+08, 1.998210925573E+07, 4.022763585713E+05,
+ //                                               3.557464994516E+03, 4.074713532757E-15, 3.475312399717E+04, 4.095913268293E+06,
+ //                                               2.667273209336E+04, 1.250539943561E+03, 1.241416130019E+03 };
+ //
+ //    double computedDensity = atmosphereModel.getDensity( altitude, longitude, latitude, time );
+ //
+ //    BOOST_CHECK_CLOSE_FRACTION( verificationData[ 5 ] * 1000, computedDensity, 1E-11 );
+ //}
+
+ 
+ BOOST_AUTO_TEST_CASE( testNRLMSISEInPropagation )
+ // int main( )
+ {
+     using namespace aerodynamics;
+     using namespace numerical_integrators;
+     using namespace simulation_setup;
+     using namespace propagators;
+     using namespace basic_mathematics;
+     using namespace basic_astrodynamics;
+     using namespace orbital_element_conversions;
+     using namespace spice_interface;
+ 
+     // Load Spice kernels.
+     loadStandardSpiceKernels( );
+ 
+     // Set simulation start epoch.
+     const double simulationStartEpoch = 0.0;
+     const double simulationEndEpoch = 300.0;
+     const double fixedStepSize = 1.0;
+ 
+     // Set Keplerian elements for Capsule.
+     Eigen::Vector6d apolloInitialStateInKeplerianElements;
+     apolloInitialStateInKeplerianElements( semiMajorAxisIndex ) = spice_interface::getAverageRadius( "Earth" ) + 120.0E3;
+     apolloInitialStateInKeplerianElements( eccentricityIndex ) = 0.005;
+     apolloInitialStateInKeplerianElements( inclinationIndex ) = unit_conversions::convertDegreesToRadians( 85.3 );
+     apolloInitialStateInKeplerianElements( argumentOfPeriapsisIndex ) = unit_conversions::convertDegreesToRadians( 235.7 );
+     apolloInitialStateInKeplerianElements( longitudeOfAscendingNodeIndex ) = unit_conversions::convertDegreesToRadians( 23.4 );
+     apolloInitialStateInKeplerianElements( trueAnomalyIndex ) = unit_conversions::convertDegreesToRadians( 139.87 );
+ 
+     // Convert apollo state from Keplerian elements to Cartesian elements.
+     const double earthGravitationalParameter = getBodyGravitationalParameter( "Earth" );
+     const Eigen::Vector6d apolloInitialState =
+             convertKeplerianToCartesianElements( apolloInitialStateInKeplerianElements, earthGravitationalParameter );
+ 
+     // Define simulation body settings.
+     BodyListSettings bodySettings = getDefaultBodySettings( { "Earth", "Moon" }, "Earth", "ECLIPJ2000" );
+     bodySettings.at( "Earth" )->gravityFieldSettings = std::make_shared< simulation_setup::GravityFieldSettings >( central_spice );
+     bodySettings.at( "Earth" )->atmosphereSettings = std::make_shared< simulation_setup::AtmosphereSettings >( nrlmsise00 );
+ 
+     // Create Earth object
+     simulation_setup::SystemOfBodies bodies = simulation_setup::createSystemOfBodies( bodySettings );
+ 
+     // Create vehicle objects.
+     bodies.createEmptyBody( "Apollo" );
+     bodies.at( "Apollo" )->setConstantBodyMass( 2000.0 );
+ 
+     // Create vehicle aerodynamic coefficients
+     double referenceArea = 4.0;
+     double aerodynamicCoefficient = 1.2;
+     std::shared_ptr< AerodynamicCoefficientSettings > aerodynamicCoefficientSettings =
+             std::make_shared< ConstantAerodynamicCoefficientSettings >(
+                     referenceArea, aerodynamicCoefficient * Eigen::Vector3d::UnitX( ), negative_aerodynamic_frame_coefficients );
+ 
+     // Create and set aerodynamic coefficients object
+     bodies.at( "Apollo" )
+             ->setAerodynamicCoefficientInterface(
+                     createAerodynamicCoefficientInterface( aerodynamicCoefficientSettings, "Apollo", bodies ) );
+ 
+     // Define propagator settings variables.
+     SelectedAccelerationMap accelerationMap;
+     std::vector< std::string > bodiesToPropagate;
+     std::vector< std::string > centralBodies;
+ 
+     // Define acceleration model settings.
+     std::map< std::string, std::vector< std::shared_ptr< AccelerationSettings > > > accelerationsOfApollo;
+     accelerationsOfApollo[ "Earth" ].push_back( std::make_shared< AccelerationSettings >( point_mass_gravity ) );
+     accelerationsOfApollo[ "Earth" ].push_back( std::make_shared< AccelerationSettings >( aerodynamic ) );
+     accelerationsOfApollo[ "Moon" ].push_back( std::make_shared< AccelerationSettings >( point_mass_gravity ) );
+     accelerationMap[ "Apollo" ] = accelerationsOfApollo;
+ 
+     bodiesToPropagate.push_back( "Apollo" );
+     centralBodies.push_back( "Earth" );
+ 
+     // Set initial state
+     Eigen::Vector6d systemInitialState = apolloInitialState;
+ 
+     // Define list of dependent variables to save.
+     std::vector< std::shared_ptr< SingleDependentVariableSaveSettings > > dependentVariables;
+     dependentVariables.push_back(
+             std::make_shared< SingleDependentVariableSaveSettings >( altitude_dependent_variable, "Apollo", "Earth" ) );
+     dependentVariables.push_back(
+             std::make_shared< SingleDependentVariableSaveSettings >( local_density_dependent_variable, "Apollo", "Earth" ) );
+     dependentVariables.push_back(
+             std::make_shared< SingleDependentVariableSaveSettings >( body_fixed_relative_spherical_position, "Apollo", "Earth" ) );
+     dependentVariables.push_back( std::make_shared< SingleDependentVariableSaveSettings >( nrlmsise_input_data, "Apollo", "Earth" ) );
+ 
+     // Create acceleration models and propagation settings.
+     basic_astrodynamics::AccelerationMap accelerationModelMap =
+             createAccelerationModelsMap( bodies, accelerationMap, bodiesToPropagate, centralBodies );
+ 
+     std::shared_ptr< IntegratorSettings<> > integratorSettings =
+             std::make_shared< IntegratorSettings<> >( rungeKutta4, simulationStartEpoch, fixedStepSize );
+ 
+     std::shared_ptr< TranslationalStatePropagatorSettings< double > > propagatorSettings =
+             std::make_shared< TranslationalStatePropagatorSettings< double > >(
+                     centralBodies,
+                     accelerationModelMap,
+                     bodiesToPropagate,
+                     systemInitialState,
+                     simulationStartEpoch,
+                     integratorSettings,
+                     std::make_shared< propagators::PropagationTimeTerminationSettings >( 3200.0 ),
+                     cowell,
+                     dependentVariables );
+ 
+     // Create simulation object and propagate dynamics.
+     SingleArcDynamicsSimulator<> dynamicsSimulator( bodies, propagatorSettings );
+ 
+     std::map< double, Eigen::Matrix< double, Eigen::Dynamic, 1 > > dependentVariableOutput =
+             dynamicsSimulator.getDependentVariableHistory( );
+ 
+     nrlmsise_flags flags;
+     nrlmsise_input input;
+     nrlmsise_output output;
+     auto nrlmsiseInputFunction =
+             std::dynamic_pointer_cast< NRLMSISE00Atmosphere >( bodies.at( "Earth" )->getAtmosphereModel( ) )->getNrlmsise00InputFunction( );
+ 
+     for( auto it: dependentVariableOutput )
+     {
+         double altitude = it.second( 0 );
+         double density = it.second( 1 );
+         Eigen::Vector3d sphericalPosition = it.second.segment( 2, 3 );
+         Eigen::VectorXd nrlmsiseInputVector = it.second.segment( 5, 17 );
+ 
+         NRLMSISE00Input inputData = nrlmsiseInputFunction( altitude, sphericalPosition( 2 ), sphericalPosition( 1 ), it.first );
+ 
+         BOOST_CHECK_EQUAL( nrlmsiseInputVector( 0 ), inputData.year );
+         BOOST_CHECK_EQUAL( nrlmsiseInputVector( 1 ), inputData.dayOfTheYear );
+         BOOST_CHECK_CLOSE_FRACTION( nrlmsiseInputVector( 2 ), inputData.secondOfTheDay, 1.0E-14 );
+         BOOST_CHECK_CLOSE_FRACTION( nrlmsiseInputVector( 3 ) * 1000.0, altitude, 1.0E-14 );
+         BOOST_CHECK_CLOSE_FRACTION( nrlmsiseInputVector( 4 ), sphericalPosition( 1 ) * 180.0 / mathematical_constants::PI, 1.0E-14 );
+         BOOST_CHECK_CLOSE_FRACTION( nrlmsiseInputVector( 5 ), sphericalPosition( 2 ) * 180.0 / mathematical_constants::PI, 1.0E-14 );
+         BOOST_CHECK_CLOSE_FRACTION( nrlmsiseInputVector( 6 ), inputData.localSolarTime, 1.0E-14 );
+         BOOST_CHECK_CLOSE_FRACTION( nrlmsiseInputVector( 7 ), inputData.f107, 1.0E-14 );
+         BOOST_CHECK_CLOSE_FRACTION( nrlmsiseInputVector( 8 ), inputData.f107a, 1.0E-14 );
+         BOOST_CHECK_CLOSE_FRACTION( nrlmsiseInputVector( 9 ), inputData.apDaily, 1.0E-14 );
+         for( int i = 0; i < 6; i++ )
+         {
+             BOOST_CHECK_CLOSE_FRACTION( nrlmsiseInputVector( 10 + i ), inputData.apVector.at( i ), 1.0E-14 );
+         }
+
+    
+         // Print input data with full precision
+         if( it.first == dependentVariableOutput.rbegin( )->first )
         {
-            BOOST_CHECK_CLOSE_FRACTION( nrlmsiseInputVector( 10 + i ), inputData.apVector.at( i ), 1.0E-14 );
+            std::cout << std::fixed << std::setprecision(16) << "Year: " << nrlmsiseInputVector( 0 ) << std::endl;
+            std::cout << std::fixed << std::setprecision(16) << "Day of the year: " << nrlmsiseInputVector( 1 ) << std::endl;
+            std::cout << std::fixed << std::setprecision(16) << "Second of the day: " << nrlmsiseInputVector( 2 ) << std::endl;
+            std::cout << std::fixed << std::setprecision(16) << "Altitude: " << nrlmsiseInputVector( 3 ) << std::endl;
+            std::cout << std::fixed << std::setprecision(16) << "Latitude: " << nrlmsiseInputVector( 4 ) << std::endl;
+            std::cout << std::fixed << std::setprecision(16) << "Longitude: " << nrlmsiseInputVector( 5 ) << std::endl;
+            std::cout << std::fixed << std::setprecision(16) << "Local solar time: " << nrlmsiseInputVector( 6 ) << std::endl;
+            std::cout << std::fixed << std::setprecision(16) << "F107: " << nrlmsiseInputVector( 7 ) << std::endl;
+            std::cout << std::fixed << std::setprecision(16) << "F107a: " << nrlmsiseInputVector( 8 ) << std::endl;
+            std::cout << std::fixed << std::setprecision(16) << "Ap daily: " << nrlmsiseInputVector( 9 ) << std::endl;
+            std::cout << std::fixed << std::setprecision(16) << "Ap vector: " << inputData.apVector.at( 0 ) << std::endl;
+            std::cout << std::fixed << std::setprecision(16) << "Ap vector: " << inputData.apVector.at( 1 ) << std::endl;
+            std::cout << std::fixed << std::setprecision(16) << "Ap vector: " << inputData.apVector.at( 2 ) << std::endl;
+            std::cout << std::fixed << std::setprecision(16) << "Ap vector: " << inputData.apVector.at( 3 ) << std::endl;
+            std::cout << std::fixed << std::setprecision(16) << "Ap vector: " << inputData.apVector.at( 4 ) << std::endl;
+            std::cout << std::fixed << std::setprecision(16) << "Ap vector: " << inputData.apVector.at( 5 ) << std::endl;
+            std::cout << std::fixed << std::setprecision(16) << "Switches: " << inputData.switches.at( 0 ) << std::endl;
+            std::cout << std::fixed << std::setprecision(16) << "Switches: " << inputData.switches.at( 1 ) << std::endl;
+            std::cout << std::fixed << std::setprecision(16) << "Switches: " << inputData.switches.at( 2 ) << std::endl;
+            std::cout << std::fixed << std::setprecision(16) << "Switches: " << inputData.switches.at( 3 ) << std::endl;
+            std::cout << std::fixed << std::setprecision(16) << "Switches: " << inputData.switches.at( 4 ) << std::endl;
+            std::cout << std::fixed << std::setprecision(16) << "Switches: " << inputData.switches.at( 5 ) << std::endl;
+            std::cout << std::fixed << std::setprecision(16) << "Switches: " << inputData.switches.at( 6 ) << std::endl;
+            std::cout << std::fixed << std::setprecision(16) << "Switches: " << inputData.switches.at( 7 ) << std::endl;
+            std::cout << std::fixed << std::setprecision(16) << "Switches: " << inputData.switches.at( 8 ) << std::endl;
+            std::cout << std::fixed << std::setprecision(16) << "Switches: " << inputData.switches.at( 9 ) << std::endl;
+            std::cout << std::fixed << std::setprecision(16) << "Switches: " << inputData.switches.at( 10 ) << std::endl;
+            std::cout << std::fixed << std::setprecision(16) << "Switches: " << inputData.switches.at( 11 ) << std::endl;
+            std::cout << std::fixed << std::setprecision(16) << "Switches: " << inputData.switches.at( 12 ) << std::endl;
+            std::cout << std::fixed << std::setprecision(16) << "Switches: " << inputData.switches.at( 13 ) << std::endl;
+            std::cout << std::fixed << std::setprecision(16) << "Switches: " << inputData.switches.at( 14 ) << std::endl;
+            std::cout << std::fixed << std::setprecision(16) << "Switches: " << inputData.switches.at( 15 ) << std::endl;
+            std::cout << std::fixed << std::setprecision(16) << "Switches: " << inputData.switches.at( 16 ) << std::endl;
+            std::cout << std::fixed << std::setprecision(16) << "Switches: " << inputData.switches.at( 17 ) << std::endl;
+            std::cout << std::fixed << std::setprecision(16) << "Switches: " << inputData.switches.at( 18 ) << std::endl;
+            std::cout << std::fixed << std::setprecision(16) << "Switches: " << inputData.switches.at( 19 ) << std::endl;
+            std::cout << std::fixed << std::setprecision(16) << "Switches: " << inputData.switches.at( 20 ) << std::endl;
+            std::cout << std::fixed << std::setprecision(16) << "Switches: " << inputData.switches.at( 21 ) << std::endl;
+            std::cout << std::fixed << std::setprecision(16) << "Switches: " << inputData.switches.at( 22 ) << std::endl;
+            std::cout << std::fixed << std::setprecision(16) << "Switches: " << inputData.switches.at( 23 ) << std::endl;
+            std::cout << std::fixed << std::setprecision(16) << "Density: " << density << std::endl;
+        }
+ 
+         BOOST_CHECK_EQUAL( inputData.f107, 130.1 );
+         BOOST_CHECK_EQUAL( inputData.f107a, 166.2 );
+         BOOST_CHECK_EQUAL( inputData.apDaily, 30 );
+         BOOST_CHECK_EQUAL( inputData.apVector.at( 0 ), 32 );
+         BOOST_CHECK_EQUAL( inputData.apVector.at( 1 ), 18 );
+         BOOST_CHECK_EQUAL( inputData.apVector.at( 2 ), 27 );
+         BOOST_CHECK_EQUAL( inputData.apVector.at( 3 ), 39 );
+         BOOST_CHECK_EQUAL( inputData.apVector.at( 4 ), 34.5 );
+         BOOST_CHECK_EQUAL( inputData.apVector.at( 5 ), 19.25 );
+ 
+         double manualDensity = std::dynamic_pointer_cast< NRLMSISE00Atmosphere >( bodies.at( "Earth" )->getAtmosphereModel( ) )
+                                        ->getDensity( altitude, sphericalPosition( 2 ), sphericalPosition( 1 ), it.first );
+         BOOST_CHECK_CLOSE_FRACTION( density, manualDensity, 1.0E-14 );
+ 
+         //        std::copy( inputData_.switches.begin( ), inputData_.switches.end( ), flags_.switches );
+         //
+         //
+         //        gtd7(&input_, &flags, &output );
+         //
+         //        // Retrieve density and temperature
+         //        double reconstructeDensity_ = output_.d[ 5 ] * 1000.0;
+     }
+ }
+
+ BOOST_AUTO_TEST_CASE( testNRLMSISEInPropagation_no_geomagnetic_activity )
+ // int main( )
+ {
+     using namespace aerodynamics;
+     using namespace numerical_integrators;
+     using namespace simulation_setup;
+     using namespace propagators;
+     using namespace basic_mathematics;
+     using namespace basic_astrodynamics;
+     using namespace orbital_element_conversions;
+     using namespace spice_interface;
+ 
+     // Load Spice kernels.
+     loadStandardSpiceKernels( );
+ 
+     // Set simulation start epoch.
+     const double simulationStartEpoch = 0.0;
+     const double simulationEndEpoch = 300.0;
+     const double fixedStepSize = 1.0;
+ 
+     // Set Keplerian elements for Capsule.
+     Eigen::Vector6d apolloInitialStateInKeplerianElements;
+     apolloInitialStateInKeplerianElements( semiMajorAxisIndex ) = spice_interface::getAverageRadius( "Earth" ) + 120.0E3;
+     apolloInitialStateInKeplerianElements( eccentricityIndex ) = 0.005;
+     apolloInitialStateInKeplerianElements( inclinationIndex ) = unit_conversions::convertDegreesToRadians( 85.3 );
+     apolloInitialStateInKeplerianElements( argumentOfPeriapsisIndex ) = unit_conversions::convertDegreesToRadians( 235.7 );
+     apolloInitialStateInKeplerianElements( longitudeOfAscendingNodeIndex ) = unit_conversions::convertDegreesToRadians( 23.4 );
+     apolloInitialStateInKeplerianElements( trueAnomalyIndex ) = unit_conversions::convertDegreesToRadians( 139.87 );
+ 
+     // Convert apollo state from Keplerian elements to Cartesian elements.
+     const double earthGravitationalParameter = getBodyGravitationalParameter( "Earth" );
+     const Eigen::Vector6d apolloInitialState =
+             convertKeplerianToCartesianElements( apolloInitialStateInKeplerianElements, earthGravitationalParameter );
+ 
+     // Define simulation body settings.
+     BodyListSettings bodySettings = getDefaultBodySettings( { "Earth", "Moon" }, "Earth", "ECLIPJ2000" );
+     bodySettings.at( "Earth" )->gravityFieldSettings = std::make_shared< simulation_setup::GravityFieldSettings >( central_spice );
+     bodySettings.at( "Earth" )->atmosphereSettings = std::make_shared< simulation_setup::NRLMSISE00AtmosphereSettings >(
+        paths::getSpaceWeatherDataPath() + "/sw19571001.txt", 1 );
+ 
+     // Create Earth object
+     simulation_setup::SystemOfBodies bodies = simulation_setup::createSystemOfBodies( bodySettings );
+ 
+     // Create vehicle objects.
+     bodies.createEmptyBody( "Apollo" );
+     bodies.at( "Apollo" )->setConstantBodyMass( 2000.0 );
+ 
+     // Create vehicle aerodynamic coefficients
+     double referenceArea = 4.0;
+     double aerodynamicCoefficient = 1.2;
+     std::shared_ptr< AerodynamicCoefficientSettings > aerodynamicCoefficientSettings =
+             std::make_shared< ConstantAerodynamicCoefficientSettings >(
+                     referenceArea, aerodynamicCoefficient * Eigen::Vector3d::UnitX( ), negative_aerodynamic_frame_coefficients );
+ 
+     // Create and set aerodynamic coefficients object
+     bodies.at( "Apollo" )
+             ->setAerodynamicCoefficientInterface(
+                     createAerodynamicCoefficientInterface( aerodynamicCoefficientSettings, "Apollo", bodies ) );
+ 
+     // Define propagator settings variables.
+     SelectedAccelerationMap accelerationMap;
+     std::vector< std::string > bodiesToPropagate;
+     std::vector< std::string > centralBodies;
+ 
+     // Define acceleration model settings.
+     std::map< std::string, std::vector< std::shared_ptr< AccelerationSettings > > > accelerationsOfApollo;
+     accelerationsOfApollo[ "Earth" ].push_back( std::make_shared< AccelerationSettings >( point_mass_gravity ) );
+     accelerationsOfApollo[ "Earth" ].push_back( std::make_shared< AccelerationSettings >( aerodynamic ) );
+     accelerationsOfApollo[ "Moon" ].push_back( std::make_shared< AccelerationSettings >( point_mass_gravity ) );
+     accelerationMap[ "Apollo" ] = accelerationsOfApollo;
+ 
+     bodiesToPropagate.push_back( "Apollo" );
+     centralBodies.push_back( "Earth" );
+ 
+     // Set initial state
+     Eigen::Vector6d systemInitialState = apolloInitialState;
+ 
+     // Define list of dependent variables to save.
+     std::vector< std::shared_ptr< SingleDependentVariableSaveSettings > > dependentVariables;
+     dependentVariables.push_back(
+             std::make_shared< SingleDependentVariableSaveSettings >( altitude_dependent_variable, "Apollo", "Earth" ) );
+     dependentVariables.push_back(
+             std::make_shared< SingleDependentVariableSaveSettings >( local_density_dependent_variable, "Apollo", "Earth" ) );
+     dependentVariables.push_back(
+             std::make_shared< SingleDependentVariableSaveSettings >( body_fixed_relative_spherical_position, "Apollo", "Earth" ) );
+     dependentVariables.push_back( std::make_shared< SingleDependentVariableSaveSettings >( nrlmsise_input_data, "Apollo", "Earth" ) );
+ 
+     // Create acceleration models and propagation settings.
+     basic_astrodynamics::AccelerationMap accelerationModelMap =
+             createAccelerationModelsMap( bodies, accelerationMap, bodiesToPropagate, centralBodies );
+ 
+     std::shared_ptr< IntegratorSettings<> > integratorSettings =
+             std::make_shared< IntegratorSettings<> >( rungeKutta4, simulationStartEpoch, fixedStepSize );
+ 
+     std::shared_ptr< TranslationalStatePropagatorSettings< double > > propagatorSettings =
+             std::make_shared< TranslationalStatePropagatorSettings< double > >(
+                     centralBodies,
+                     accelerationModelMap,
+                     bodiesToPropagate,
+                     systemInitialState,
+                     simulationStartEpoch,
+                     integratorSettings,
+                     std::make_shared< propagators::PropagationTimeTerminationSettings >( 3200.0 ),
+                     cowell,
+                     dependentVariables );
+ 
+     // Create simulation object and propagate dynamics.
+     SingleArcDynamicsSimulator<> dynamicsSimulator( bodies, propagatorSettings );
+ 
+     std::map< double, Eigen::Matrix< double, Eigen::Dynamic, 1 > > dependentVariableOutput =
+             dynamicsSimulator.getDependentVariableHistory( );
+ 
+     nrlmsise_flags flags;
+     nrlmsise_input input;
+     nrlmsise_output output;
+     auto nrlmsiseInputFunction =
+             std::dynamic_pointer_cast< NRLMSISE00Atmosphere >( bodies.at( "Earth" )->getAtmosphereModel( ) )->getNrlmsise00InputFunction( );
+ 
+     for( auto it: dependentVariableOutput )
+     {
+         double altitude = it.second( 0 );
+         double density = it.second( 1 );
+         Eigen::Vector3d sphericalPosition = it.second.segment( 2, 3 );
+         Eigen::VectorXd nrlmsiseInputVector = it.second.segment( 5, 17 );
+ 
+         NRLMSISE00Input inputData = nrlmsiseInputFunction( altitude, sphericalPosition( 2 ), sphericalPosition( 1 ), it.first );
+ 
+         BOOST_CHECK_EQUAL( nrlmsiseInputVector( 0 ), inputData.year );
+         BOOST_CHECK_EQUAL( nrlmsiseInputVector( 1 ), inputData.dayOfTheYear );
+         BOOST_CHECK_CLOSE_FRACTION( nrlmsiseInputVector( 2 ), inputData.secondOfTheDay, 1.0E-14 );
+         BOOST_CHECK_CLOSE_FRACTION( nrlmsiseInputVector( 3 ) * 1000.0, altitude, 1.0E-14 );
+         BOOST_CHECK_CLOSE_FRACTION( nrlmsiseInputVector( 4 ), sphericalPosition( 1 ) * 180.0 / mathematical_constants::PI, 1.0E-14 );
+         BOOST_CHECK_CLOSE_FRACTION( nrlmsiseInputVector( 5 ), sphericalPosition( 2 ) * 180.0 / mathematical_constants::PI, 1.0E-14 );
+         BOOST_CHECK_CLOSE_FRACTION( nrlmsiseInputVector( 6 ), inputData.localSolarTime, 1.0E-14 );
+         BOOST_CHECK_CLOSE_FRACTION( nrlmsiseInputVector( 7 ), inputData.f107, 1.0E-14 );
+         BOOST_CHECK_CLOSE_FRACTION( nrlmsiseInputVector( 8 ), inputData.f107a, 1.0E-14 );
+         BOOST_CHECK_CLOSE_FRACTION( nrlmsiseInputVector( 9 ), inputData.apDaily, 1.0E-14 );
+         for( int i = 0; i < 6; i++ )
+         {
+             BOOST_CHECK_CLOSE_FRACTION( nrlmsiseInputVector( 10 + i ), inputData.apVector.at( i ), 1.0E-14 );
+         }
+
+        
+         // Print input data with full precision for only the last iteration
+        if( it.first == dependentVariableOutput.rbegin( )->first )
+        {
+            std::cout << std::fixed << std::setprecision(16) << "Year: " << nrlmsiseInputVector( 0 ) << std::endl;
+            std::cout << std::fixed << std::setprecision(16) << "Day of the year: " << nrlmsiseInputVector( 1 ) << std::endl;
+            std::cout << std::fixed << std::setprecision(16) << "Second of the day: " << nrlmsiseInputVector( 2 ) << std::endl;
+            std::cout << std::fixed << std::setprecision(16) << "Altitude: " << nrlmsiseInputVector( 3 ) << std::endl;
+            std::cout << std::fixed << std::setprecision(16) << "Latitude: " << nrlmsiseInputVector( 4 ) << std::endl;
+            std::cout << std::fixed << std::setprecision(16) << "Longitude: " << nrlmsiseInputVector( 5 ) << std::endl;
+            std::cout << std::fixed << std::setprecision(16) << "Local solar time: " << nrlmsiseInputVector( 6 ) << std::endl;
+            std::cout << std::fixed << std::setprecision(16) << "F107: " << nrlmsiseInputVector( 7 ) << std::endl;
+            std::cout << std::fixed << std::setprecision(16) << "F107a: " << nrlmsiseInputVector( 8 ) << std::endl;
+            std::cout << std::fixed << std::setprecision(16) << "Ap daily: " << nrlmsiseInputVector( 9 ) << std::endl;
+            std::cout << std::fixed << std::setprecision(16) << "Ap vector: " << inputData.apVector.at( 0 ) << std::endl;
+            std::cout << std::fixed << std::setprecision(16) << "Ap vector: " << inputData.apVector.at( 1 ) << std::endl;
+            std::cout << std::fixed << std::setprecision(16) << "Ap vector: " << inputData.apVector.at( 2 ) << std::endl;
+            std::cout << std::fixed << std::setprecision(16) << "Ap vector: " << inputData.apVector.at( 3 ) << std::endl;
+            std::cout << std::fixed << std::setprecision(16) << "Ap vector: " << inputData.apVector.at( 4 ) << std::endl;
+            std::cout << std::fixed << std::setprecision(16) << "Ap vector: " << inputData.apVector.at( 5 ) << std::endl;
+            std::cout << std::fixed << std::setprecision(16) << "Switches: " << inputData.switches.at( 0 ) << std::endl;
+            std::cout << std::fixed << std::setprecision(16) << "Switches: " << inputData.switches.at( 1 ) << std::endl;
+            std::cout << std::fixed << std::setprecision(16) << "Switches: " << inputData.switches.at( 2 ) << std::endl;
+            std::cout << std::fixed << std::setprecision(16) << "Switches: " << inputData.switches.at( 3 ) << std::endl;
+            std::cout << std::fixed << std::setprecision(16) << "Switches: " << inputData.switches.at( 4 ) << std::endl;
+            std::cout << std::fixed << std::setprecision(16) << "Switches: " << inputData.switches.at( 5 ) << std::endl;
+            std::cout << std::fixed << std::setprecision(16) << "Switches: " << inputData.switches.at( 6 ) << std::endl;
+            std::cout << std::fixed << std::setprecision(16) << "Switches: " << inputData.switches.at( 7 ) << std::endl;
+            std::cout << std::fixed << std::setprecision(16) << "Switches: " << inputData.switches.at( 8 ) << std::endl;
+            std::cout << std::fixed << std::setprecision(16) << "Switches: " << inputData.switches.at( 9 ) << std::endl;
+            std::cout << std::fixed << std::setprecision(16) << "Switches: " << inputData.switches.at( 10 ) << std::endl;
+            std::cout << std::fixed << std::setprecision(16) << "Switches: " << inputData.switches.at( 11 ) << std::endl;
+            std::cout << std::fixed << std::setprecision(16) << "Switches: " << inputData.switches.at( 12 ) << std::endl;
+            std::cout << std::fixed << std::setprecision(16) << "Switches: " << inputData.switches.at( 13 ) << std::endl;
+            std::cout << std::fixed << std::setprecision(16) << "Switches: " << inputData.switches.at( 14 ) << std::endl;
+            std::cout << std::fixed << std::setprecision(16) << "Switches: " << inputData.switches.at( 15 ) << std::endl;
+            std::cout << std::fixed << std::setprecision(16) << "Switches: " << inputData.switches.at( 16 ) << std::endl;
+            std::cout << std::fixed << std::setprecision(16) << "Switches: " << inputData.switches.at( 17 ) << std::endl;
+            std::cout << std::fixed << std::setprecision(16) << "Switches: " << inputData.switches.at( 18 ) << std::endl;
+            std::cout << std::fixed << std::setprecision(16) << "Switches: " << inputData.switches.at( 19 ) << std::endl;
+            std::cout << std::fixed << std::setprecision(16) << "Switches: " << inputData.switches.at( 20 ) << std::endl;
+            std::cout << std::fixed << std::setprecision(16) << "Switches: " << inputData.switches.at( 21 ) << std::endl;
+            std::cout << std::fixed << std::setprecision(16) << "Switches: " << inputData.switches.at( 22 ) << std::endl;
+            std::cout << std::fixed << std::setprecision(16) << "Switches: " << inputData.switches.at( 23 ) << std::endl;
+            std::cout << std::fixed << std::setprecision(16) << "Density: " << density << std::endl;
         }
 
-        BOOST_CHECK_EQUAL( inputData.f107, 130.1 );
-        BOOST_CHECK_EQUAL( inputData.f107a, 166.2 );
-        BOOST_CHECK_EQUAL( inputData.apDaily, 30 );
-        BOOST_CHECK_EQUAL( inputData.apVector.at( 0 ), 32 );
-        BOOST_CHECK_EQUAL( inputData.apVector.at( 1 ), 18 );
-        BOOST_CHECK_EQUAL( inputData.apVector.at( 2 ), 27 );
-        BOOST_CHECK_EQUAL( inputData.apVector.at( 3 ), 39 );
-        BOOST_CHECK_EQUAL( inputData.apVector.at( 4 ), 34.5 );
-        BOOST_CHECK_EQUAL( inputData.apVector.at( 5 ), 19.25 );
+ 
+         BOOST_CHECK_EQUAL( inputData.f107, 130.1 );
+         BOOST_CHECK_EQUAL( inputData.f107a, 166.2 );
+         BOOST_CHECK_EQUAL( inputData.apDaily, 30 );
+         BOOST_CHECK_EQUAL( inputData.apVector.at( 0 ), 0 );
+         BOOST_CHECK_EQUAL( inputData.apVector.at( 1 ), 0 );
+         BOOST_CHECK_EQUAL( inputData.apVector.at( 2 ), 0 );
+         BOOST_CHECK_EQUAL( inputData.apVector.at( 3 ), 0 );
+         BOOST_CHECK_EQUAL( inputData.apVector.at( 4 ), 0 );
+         BOOST_CHECK_EQUAL( inputData.apVector.at( 5 ), 0 );
+ 
+         double manualDensity = std::dynamic_pointer_cast< NRLMSISE00Atmosphere >( bodies.at( "Earth" )->getAtmosphereModel( ) )
+                                        ->getDensity( altitude, sphericalPosition( 2 ), sphericalPosition( 1 ), it.first );
+         BOOST_CHECK_CLOSE_FRACTION( density, manualDensity, 1.0E-14 );
+ 
+         //        std::copy( inputData_.switches.begin( ), inputData_.switches.end( ), flags_.switches );
+         //
+         //
+         //        gtd7(&input_, &flags, &output );
+         //
+         //        // Retrieve density and temperature
+         //        double reconstructeDensity_ = output_.d[ 5 ] * 1000.0;
+     }
+ }
 
-        double manualDensity = std::dynamic_pointer_cast< NRLMSISE00Atmosphere >( bodies.at( "Earth" )->getAtmosphereModel( ) )
-                                       ->getDensity( altitude, sphericalPosition( 2 ), sphericalPosition( 1 ), it.first );
-        BOOST_CHECK_CLOSE_FRACTION( density, manualDensity, 1.0E-14 );
-
-        //        std::copy( inputData_.switches.begin( ), inputData_.switches.end( ), flags_.switches );
-        //
-        //
-        //        gtd7(&input_, &flags, &output );
-        //
-        //        // Retrieve density and temperature
-        //        double reconstructeDensity_ = output_.d[ 5 ] * 1000.0;
-    }
-}
-
-BOOST_AUTO_TEST_SUITE_END( )
-
-}  // namespace unit_tests
-
-}  // namespace tudat
+ BOOST_AUTO_TEST_SUITE_END( )
+ 
+ }  // namespace unit_tests
+ 
+ }  // namespace tudat


### PR DESCRIPTION
This pull request extends the NRLMSISE00 atmospheric model to allow users to specify geomagnetic activity conditions when creating the model.

Changes
- Added a geomagnetic_activity argument to nrlmsise00AtmosphereSettings (C++ and Python).
- The flag modifies how apVector and switches[9] are set in the NRLMSISE00Input.
- Default behaviour remains unchanged (storm-time conditions).
- Replaced the thrown error for missing date weather data with a one-time warning per simulation.
- Added a unit test to verify behaviour when setting quiet geomagnetic conditions.