### PR TITLE
Check if reflection law has been defined before creating panels

### DIFF
--- a/include/tudat/simulation/environment_setup/createSystemModel.h
+++ b/include/tudat/simulation/environment_setup/createSystemModel.h
@@ -180,7 +180,7 @@ public:
 
 inline std::shared_ptr< BodyPanelSettings > bodyPanelSettings(
         const std::shared_ptr< BodyPanelGeometrySettings > panelGeometry,
-        const std::shared_ptr< BodyPanelReflectionLawSettings > reflectionLawSettings = nullptr,
+        const std::shared_ptr< BodyPanelReflectionLawSettings > reflectionLawSettings,
         const std::string panelTypeId = "" )
 {
     return std::make_shared< BodyPanelSettings >( panelGeometry, reflectionLawSettings, panelTypeId );

--- a/src/simulation/environment_setup/createSystemModel.cpp
+++ b/src/simulation/environment_setup/createSystemModel.cpp
@@ -67,6 +67,11 @@ std::pair< std::shared_ptr< system_models::VehicleExteriorPanel >, std::string >
         throw std::runtime_error( "Error when creating body exterior panel settings, no panel geometry settings provided" );
     }
 
+    if( panelSettings->reflectionLawSettings_ == nullptr )
+    {
+        throw std::runtime_error( "Error when creating body exterior panel settings, no reflection law settings provided" );
+    }
+
     double panelArea = TUDAT_NAN;
     double panelTemperature = TUDAT_NAN;
     std::function< Eigen::Vector3d( ) > localFrameSurfaceNormal = nullptr;


### PR DESCRIPTION
Remove the default nullptr argument from the `bodyPanelSettings` function and check if the `reflectionLawSettings_` have been defined before creating the vehicle panel.

See https://github.com/tudat-team/tudatpy/pull/263 for tudatpy companion PR.