### PR TITLE
Add YAML-based templates for issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-bug.yml
+++ b/.github/ISSUE_TEMPLATE/01-bug.yml
@@ -1,0 +1,58 @@
+name: Bug report
+description: Something is not working as expected
+title: "[BUG]: <Short and descriptive title>"
+labels: "type: bug"
+
+body:
+- type: markdown
+  attributes:
+    value: >
+      Thank you for taking the time to file a bug report!
+
+- type: textarea
+  attributes:
+    label: "Describe the issue:"
+    description: >
+      A clear and concise description of what the bug is.
+  validations:
+    required: true
+
+- type: textarea
+  attributes:
+    label: "How to reproduce the issue:"
+    description: >
+      Help us reproduce the issue by listing steps, and including code snippets, error messages, screenshots, or links to the relevant files in our Github repository.
+  validations:
+    required: true
+
+- type: textarea
+  attributes:
+    label: "OS:"
+    placeholder: |
+      OS: << macOS Intel/ARM, Linux, Windows >>
+  validations:
+    required: true
+
+- type: textarea
+  attributes:
+    label: "Expected behavior:"
+    description: >
+      Describe what you expected to happen.
+  validations:
+    required: false
+
+- type: textarea
+  attributes:
+    label: "Current behavior:"
+    description: >
+      Describe what happened instead.
+  validations:
+    required: false
+
+- type: textarea
+  attributes:
+    label: "Additional context:"
+    description: >
+      Include any other relevant context, or attach screenshots.
+  validations:
+    required: false

--- a/.github/ISSUE_TEMPLATE/02-feature.yml
+++ b/.github/ISSUE_TEMPLATE/02-feature.yml
@@ -1,0 +1,34 @@
+name: Features and Enhancements
+description: Something that `tudat` should have
+title: "[F&E]: <Short and descriptive title>"
+labels: "type: feature"
+
+body:
+- type: markdown
+  attributes:
+    value: >
+      Thank you for taking the time to suggest a feature!
+
+- type: textarea
+  attributes:
+    label: "Description:"
+    description: >
+      Provide a concise description of the feature, and explan why it is important.
+  validations:
+    required: true
+
+- type: textarea
+  attributes:
+    label: "Suggestions for implementation:"
+    description: >
+      If you want, you can suggest a high-level approach to implementing this feature. Feel free to open a Pull Request if you want to implement it yourself!
+  validations:
+    required: false
+
+- type: textarea
+  attributes:
+    label: "Additional context:"
+    placeholder: |
+      << your explanation here >>
+  validations:
+    required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Tudat Team
+    url: https://github.com/orgs/tudat-team/discussions
+    about: Please ask and answer questions here.


### PR DESCRIPTION
Make it easier for users to follow new developing guidelines by setting up templates for pull requests.

The templates are based on the development guidelines suggested by @valeriof7 