### PR TITLE
Fix missing useAnomalousOxygen_ flag in NRLMSISE00AtmosphereSettings

### DIFF
--- a/include/tudat/astro/aerodynamics/nrlmsise00Atmosphere.h
+++ b/include/tudat/astro/aerodynamics/nrlmsise00Atmosphere.h
@@ -72,7 +72,7 @@ public:
 
     NRLMSISE00Atmosphere( const tudat::input_output::solar_activity::SolarActivityDataMap solarActivityData,
                           const bool useIdealGasLaw = true,
-                          const bool useStormConditions = true,
+                          const bool useStormConditions = false,
                           const bool useAnomalousOxygen = true ):
         AtmosphereModel( true, true ), solarActivityContainer_( solarActivityData ), useIdealGasLaw_( useIdealGasLaw ),
         useAnomalousOxygen_( useAnomalousOxygen )

--- a/include/tudat/simulation/environment_setup/createAtmosphereModel.h
+++ b/include/tudat/simulation/environment_setup/createAtmosphereModel.h
@@ -510,7 +510,7 @@ public:
     NRLMSISE00AtmosphereSettings( const std::string& spaceWeatherFile,
                                   const bool useStormConditions = false,
                                   const bool useAnomalousOxygen = true ):
-        AtmosphereSettings( nrlmsise00 ), spaceWeatherFile_( spaceWeatherFile ), useStormConditions_( useStormConditions )
+        AtmosphereSettings( nrlmsise00 ), spaceWeatherFile_( spaceWeatherFile ), useStormConditions_( useStormConditions ), useAnomalousOxygen_( useAnomalousOxygen )
     { }
 
     //  Function to return file containing space weather data.


### PR DESCRIPTION
## Description

Fixes an inconsistency in the use of the `useAnomalousOxygen_` flag when constructing `NRLMSISE00AtmosphereSettings` via the propagation interface. Previously, the flag was ignored in this context, always resulting in anomalous oxygen being disabled regardless of the intended configuration. The fix ensures the flag is correctly passed to the internal model.

Also updates the default `useStormConditions_` to `false` in the `NRLMSISE00Atmosphere` class to match expected behaviour across Tudat.

## Related Issue(s)

Closes #316.

## Feature or Bug Fix Details

- Passes `useAnomalousOxygen_` from `NRLMSISE00AtmosphereSettings` to model construction inside the propagation setup.
- Changes default storm condition usage to `false` for consistency.

## Testing Details

- Verified by comparing density outputs in propagation and standalone mode with `useAnomalousOxygen_ = True`.
- Confirmed that behaviour is consistent across both use cases after the fix.

## Checklist

- [x] Branch name follows TUDAT conventions (`fix/issue-316-nrlmsise-flag-bug`).
- [ ] Unit tests have been added or updated.
- [x] Code builds and runs without errors.
- [x] Latest changes from `develop` have been merged into the branch.
- [x] Code has been reviewed for clarity and maintainability.
- [x] The code follows TUDAT coding guidelines.