### PR TITLE
Add `.git-blame-ignore-revs` file

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# valeriof7: Apply clang formatting to the codebase.
+3c7d26f864fd04559a2c5cc26fcf431bbbced194


### PR DESCRIPTION
This file is used by editors to ignore commits in the inline blame, where no changes to the content have been made (such as reformatting commits). It can also be used from the command line in the `git blame` command, by adding the `--ignore-revs-file .git-blame-ignore-revs` flag.