### PR TITLE
Use path to solar weather data file as input instead of actual data

### DIFF
--- a/include/tudat/simulation/estimation_setup/createLightTimeCorrection.h
+++ b/include/tudat/simulation/estimation_setup/createLightTimeCorrection.h
@@ -250,15 +250,14 @@ class JakowskiIonosphericCorrectionSettings : public LightTimeCorrectionSettings
 public:
     JakowskiIonosphericCorrectionSettings( const double ionosphereHeight = 400.0e3,
                                            const double firstOrderDelayCoefficient = 40.3,
-                                           const input_output::solar_activity::SolarActivityDataMap &solarActivityData =
-                                                   input_output::solar_activity::readSolarActivityData( paths::getSpaceWeatherDataPath( ) +
-                                                                                                        "/sw19571001.txt" ),
+                                           const std::string solarActivityDataPath = paths::getSpaceWeatherDataPath( ) + "/sw19571001.txt",
                                            const double geomagneticPoleLatitude = unit_conversions::convertDegreesToRadians( 80.9 ),
                                            const double geomagneticPoleLongitude = unit_conversions::convertDegreesToRadians( -72.6 ),
                                            const bool useUtcTimeForLocalTimeComputation = false,
                                            const std::string &bodyWithAtmosphere = "Earth" ):
         LightTimeCorrectionSettings( jakowski_vtec_ionospheric ), ionosphereHeight_( ionosphereHeight ),
-        firstOrderDelayCoefficient_( firstOrderDelayCoefficient ), solarActivityData_( solarActivityData ),
+        firstOrderDelayCoefficient_( firstOrderDelayCoefficient ),
+        solarActivityData_( input_output::solar_activity::readSolarActivityData( solarActivityDataPath ) ),
         geomagneticPoleLatitude_( geomagneticPoleLatitude ), geomagneticPoleLongitude_( geomagneticPoleLongitude ),
         useUtcTimeForLocalTime_( useUtcTimeForLocalTimeComputation ), bodyWithAtmosphere_( bodyWithAtmosphere )
     { }
@@ -412,8 +411,7 @@ inline std::shared_ptr< LightTimeCorrectionSettings > tabulatedIonosphericCorrec
 inline std::shared_ptr< LightTimeCorrectionSettings > jakowskiIonosphericCorrectionSettings(
         const double ionosphereHeight = 400.0e3,
         const double firstOrderDelayCoefficient = 40.3,
-        const input_output::solar_activity::SolarActivityDataMap &solarActivityData =
-                input_output::solar_activity::readSolarActivityData( paths::getSpaceWeatherDataPath( ) + "/sw19571001.txt" ),
+        const std::string solarActivityDataPath = paths::getSpaceWeatherDataPath( ) + "/sw19571001.txt",
         const double geomagneticPoleLatitude = unit_conversions::convertDegreesToRadians( 80.9 ),
         const double geomagneticPoleLongitude = unit_conversions::convertDegreesToRadians( -72.6 ),
         const bool useUtcTimeForLocalTimeComputation = false,
@@ -421,7 +419,7 @@ inline std::shared_ptr< LightTimeCorrectionSettings > jakowskiIonosphericCorrect
 {
     return std::make_shared< JakowskiIonosphericCorrectionSettings >( ionosphereHeight,
                                                                       firstOrderDelayCoefficient,
-                                                                      solarActivityData,
+                                                                      solarActivityDataPath,
                                                                       geomagneticPoleLatitude,
                                                                       geomagneticPoleLongitude,
                                                                       useUtcTimeForLocalTimeComputation,


### PR DESCRIPTION
This PR modifies how the solar activity data is loaded in the Jakowski ionospheric correction. Instead of passing the data, the file path is given as an input.

Tudatpy companion PR is opened in https://github.com/tudat-team/tudatpy/pull/303.