### PR TITLE
Part rotation logic and ssh improvements

### DIFF
--- a/include/tudat/astro/system_models/selfShadowing.h
+++ b/include/tudat/astro/system_models/selfShadowing.h
@@ -37,42 +37,41 @@ bool isPointInTriangle( const ParallelProjection& projection_, const double coor
 bool doEdgesIntersect(const Eigen::Vector2d& edge1Start, const Eigen::Vector2d& edge1End,
     const Eigen::Vector2d& edge2Start, const Eigen::Vector2d& edge2End);
 
-std::vector< std::vector< int > > arePointsInTriangle( const ParallelProjection& projection_, 
-    const std::vector<double>& gridCoordinatesL_, const std::vector<double>& gridCoordinatesM_,
-    std::vector< std::vector < int > >& pixelationMatrix_,
+void arePointsInTriangle( const ParallelProjection& projection_, 
+    const std::vector< double >& gridCoordinatesL_, const std::vector< double >& gridCoordinatesM_,
+    std::vector< int >& pixelationMatrix_,
     int indexMinL_ = 0, int indexMaxL_ = -1, int indexMinM_ = 0, int indexMaxM_ = -1 );
 
 template<typename T>
-inline std::vector<double> linspace(T start_in, T end_in, int num_in)
+inline std::vector< double >& linspace(T start_in, T end_in, int num_in, std::vector< double >& linspaced)
 {
-  std::vector<double> linspaced;
-
   double start = static_cast<double>(start_in);
   double end = static_cast<double>(end_in);
-  double num = static_cast<double>(num_in);
+  // resize array
+  linspaced.resize( num_in );
 
-  if (num == 0) { return linspaced; }
-  if (num == 1) 
+  if (num_in == 0) { return linspaced; }
+  if (num_in == 1) 
     {
-      linspaced.push_back(start);
+      linspaced[ 0 ] = start;
       return linspaced;
     }
 
-  double delta = (end - start) / (num - 1);
+  double delta = (end - start) / (static_cast<double>(num_in) - 1);
 
-  for(int i=0; i < num-1; ++i)
+  for(int i=0; i < num_in-1; ++i)
     {
-      linspaced.push_back(start + delta * i);
+      linspaced[ i ] = (start + delta * i);
     }
-  linspaced.push_back(end); 
+  linspaced[ num_in - 1 ] = end; 
 
   return linspaced;
 }
 
-std::vector< double > computeFractioWithPixelation( const std::vector<std::vector<int>>& sigmaMatrix_, 
+std::vector< double > computeFractioWithPixelation( const std::vector<std::vector< int > >& sigmaMatrix_, 
     const std::vector< std::shared_ptr< VehicleExteriorPanel > >& allPanels_, 
     const int maximumNumberOfPixels_, const std::vector< std::vector < ParallelProjection > >& projections_, 
-    const std::vector< int > toBePixelated_ );
+    const std::vector< int >& toBePixelated_ );
 
 class SelfShadowing
 {

--- a/include/tudat/astro/system_models/selfShadowing.h
+++ b/include/tudat/astro/system_models/selfShadowing.h
@@ -39,7 +39,7 @@ bool doEdgesIntersect(const Eigen::Vector2d& edge1Start, const Eigen::Vector2d& 
 
 std::vector< std::vector< int > > arePointsInTriangle( const ParallelProjection& projection_, 
     const std::vector<double>& gridCoordinatesL_, const std::vector<double>& gridCoordinatesM_,
-    const std::vector< std::vector < int > >& pixelationMatrix_,
+    std::vector< std::vector < int > >& pixelationMatrix_,
     int indexMinL_ = 0, int indexMaxL_ = -1, int indexMinM_ = 0, int indexMaxM_ = -1 );
 
 template<typename T>

--- a/include/tudat/astro/system_models/vehicleSystems.h
+++ b/include/tudat/astro/system_models/vehicleSystems.h
@@ -191,7 +191,18 @@ public:
             {
                 currentVehiclePartRotationToBodyFixedFrame_[ it.first ] = it.second->getRotationToBaseFrame( time );
             }
+            currentVehiclePartRotationToBodyFixedFrame_[ "" ] = Eigen::Quaterniond::Identity( );
+             unsigned int buffer = 0;
+            for( auto it: vehicleExteriorPanels_ )
+            {
+                for( unsigned int i = 0; i<it.second.size( ); i++)
+                {
+                    allPanels_.at( i + buffer )->updatePanel( currentVehiclePartRotationToBodyFixedFrame_.at( it.first ) );
+                }
+                buffer += it.second.size( );
+            }
             currentOrientationTime_ = time;
+
         }
     }
 
@@ -221,11 +232,74 @@ public:
             const std::map< std::string, std::vector< std::shared_ptr< VehicleExteriorPanel > > > vehicleExteriorPanels )
     {
         vehicleExteriorPanels_ = vehicleExteriorPanels;
+        // group all panels in a vector
+        totalNumberOfPanels_ = 0;
+        for ( auto it : vehicleExteriorPanels_ )
+        {
+            allPanels_.insert( allPanels_.end( ), it.second.begin( ), it.second.end( ) );
+            totalNumberOfPanels_ += it.second.size( );
+        }
+        // check if macro-model is loaded (find at least one isGeometryDefined == false)
+        panelGeometryDefined_ = true;
+        for (int i = 0; i<totalNumberOfPanels_; i++)
+        {
+            if ( !allPanels_.at( i )->isGeometryDefined( ) ) 
+            {   
+                panelGeometryDefined_ = false;
+                break;
+            }
+        }
+        if ( panelGeometryDefined_ )
+        {
+            system_models::Triangle3d triangleI, triangleJ;
+            std::vector<Eigen::Vector3d> verticesI, verticesJ;
+            // find neighbours
+            for ( int i = 0; i<totalNumberOfPanels_; i++)
+            {
+                std::vector< int > neighboringSurfaces;
+                for ( int j = 0; j<totalNumberOfPanels_; j++)
+                {
+                    if ( i == j )
+                    {
+                        continue;
+                    }
+                    system_models::Triangle3d triangleI = allPanels_.at( i )->getFrameFixedTriangle3d( );
+                    system_models::Triangle3d triangleJ = allPanels_.at( j )->getFrameFixedTriangle3d( );
+                    verticesI = { triangleI.getVertexA( ), triangleI.getVertexB( ), triangleI.getVertexC( )};
+                    verticesJ = { triangleJ.getVertexA( ), triangleJ.getVertexB( ), triangleJ.getVertexC( )};
+                    int match = 0;
+                    for (int n = 0; n<3; n++ )
+                    {
+                        for ( int m = 0; m<3; m++ )
+                        {
+                            if ( verticesI[ n ].isApprox(verticesJ[ m ]) )
+                            {
+                                match++;
+                            }
+                        }
+                    }
+                    if (match==2) 
+                    {
+                        neighboringSurfaces.push_back( j );
+                    }
+                    if ( neighboringSurfaces.size( ) == 3 )
+                    {   
+                        allPanels_.at( i )->setNeighboringSurfaces( neighboringSurfaces );
+                        break; // found all the neighbours, skip to next panel
+                    }
+                }
+            }
+        }
     }
 
     std::map< std::string, std::vector< std::shared_ptr< VehicleExteriorPanel > > > getVehicleExteriorPanels( )
     {
         return vehicleExteriorPanels_;
+    }
+
+    std::vector< std::shared_ptr< system_models::VehicleExteriorPanel > >& getAllPanels( ) 
+    {
+        return allPanels_;
     }
 
     int getTotalNumberOfPanels( )
@@ -333,12 +407,28 @@ public:
         return referencePoints_.at( referencePoint )->getTemplatedStateFromEphemeris< StateScalarType, TimeType >( time );
     }
 
+    bool isPanelGeometryDefined( ) const
+    {
+        return panelGeometryDefined_;
+    }
+
+    int getTotalNumberOfPanels( ) const
+    {
+        return totalNumberOfPanels_;
+    }
+
 private:
     std::map< std::string, std::shared_ptr< ephemerides::Ephemeris > > referencePoints_;
 
     std::map< std::string, std::shared_ptr< ephemerides::RotationalEphemeris > > vehiclePartOrientation_;
 
     std::map< std::string, std::vector< std::shared_ptr< VehicleExteriorPanel > > > vehicleExteriorPanels_;
+
+    std::vector< std::shared_ptr< system_models::VehicleExteriorPanel > > allPanels_;
+
+    bool panelGeometryDefined_;
+
+    int totalNumberOfPanels_;
 
     double currentOrientationTime_;
 

--- a/include/tudat/simulation/propagation_setup/environmentUpdater.h
+++ b/include/tudat/simulation/propagation_setup/environmentUpdater.h
@@ -743,13 +743,11 @@ private:
                             break;
                         }
                         case body_segment_orientation_update: {
-                            // Check if current body has radiation pressure target model set.
                             if( bodyList_.at( currentBodies.at( i ) )->getVehicleSystems( ) == nullptr )
                             {
                                 throw std::runtime_error( "Request body segment orientation update of " + currentBodies.at( i ) +
                                                           ", but body has no vehicle systems" );
                             }
-                            // If vehicle has radiation pressure target model, add its update function to update list.
                             updateTimeFunctionList[ body_segment_orientation_update ].push_back(
                                     std::make_pair( currentBodies.at( i ),
                                                     std::bind( &system_models::VehicleSystems::updatePartOrientations,

--- a/src/astro/orbit_determination/acceleration_partials/panelledRadiationPressureAccelerationPartial.cpp
+++ b/src/astro/orbit_determination/acceleration_partials/panelledRadiationPressureAccelerationPartial.cpp
@@ -42,9 +42,9 @@ void PanelledRadiationPressurePartial::update( const double currentTime )
             double currentPanelArea = 0.0, currentPanelEmissivity = 0.0, cosineOfPanelInclination = 0.0;
         
             std::vector< double > illuminatedPanelFractions;
-            std::vector< std::shared_ptr< system_models::VehicleExteriorPanel > > allPanels = panelledTargetModel_->getAllRotatedPanels( );
+            std::vector< std::shared_ptr< system_models::VehicleExteriorPanel > > allPanels = panelledTargetModel_->getAllPanels( );
             auto selfShadowingPerSource = panelledTargetModel_->getSelfShadowingPerSources( );
-            if ( selfShadowingPerSource.count( acceleratingBody_ ) == 0 || selfShadowingPerSource.at( acceleratingBody_ )->getMaximumNumberOfPixels( ) == 0 )
+            if ( selfShadowingPerSource.count( acceleratingBody_ ) == 0 )
             {   
                 // SSH off
                 illuminatedPanelFractions = unityIlluminationFraction_;

--- a/src/astro/system_models/selfShadowing.cpp
+++ b/src/astro/system_models/selfShadowing.cpp
@@ -26,7 +26,7 @@ namespace system_models
 
 bool firstDiscrimination( const std::shared_ptr< system_models::VehicleExteriorPanel > panel, const Eigen::Vector3d& v) 
 {
-    if ( panel->getFrameFixedSurfaceNormal( )( ).dot(v) < 0 ) 
+    if ( panel->getBodyFixedSurfaceNormal( )( ).dot(v) < 0 ) 
     {
         return 1;
     }
@@ -79,20 +79,27 @@ std::vector< bool > isTriangleInTriangle( const ParallelProjection& projection1,
                                                   projection2.getTriangle2d( ).getVertexC( ) };
     std::vector< bool > testPointsLambdaActuallyPositive = projection2.getAreLambdasActuallyPositive( );
     std::vector< bool > results( 3 );
+    Eigen::Vector2d testPoint;
+    Eigen::Vector2d pointA = projection1.getTriangle2d( ).getVertexA( );
+    Eigen::Vector2d pointB = projection1.getTriangle2d( ).getVertexB( );
+    Eigen::Vector2d pointC = projection1.getTriangle2d( ).getVertexC( );
+    double ymin, ymax, xmax;
+    double xIntersect;
+    int count;
+    bool resultToBeChecked;
+
     for ( int i=0; i<3; i++ )
     {
-        int count = 0;
-        Eigen::Vector2d testPoint = testPoints[i];
-        Eigen::Vector2d pointA = projection1.getTriangle2d( ).getVertexA( );
-        Eigen::Vector2d pointB = projection1.getTriangle2d( ).getVertexB( );
-        Eigen::Vector2d pointC = projection1.getTriangle2d( ).getVertexC( );
+        count = 0;
+        testPoint = testPoints[i];
+        
         // edge from pointA to pointB
         {
-            double ymin = (pointA( 1 ) < pointB( 1 )) ? pointA( 1 ) : pointB( 1 );
-            double ymax = (pointA( 1 ) < pointB( 1 )) ? pointB( 1 ) : pointA( 1 );
-            double xmax = (pointA( 0 ) > pointB( 0 )) ? pointA( 0 ) : pointB( 0 );
+            ymin = (pointA( 1 ) < pointB( 1 )) ? pointA( 1 ) : pointB( 1 );
+            ymax = (pointA( 1 ) < pointB( 1 )) ? pointB( 1 ) : pointA( 1 );
+            xmax = (pointA( 0 ) > pointB( 0 )) ? pointA( 0 ) : pointB( 0 );
             if ((testPoint( 1 ) > ymin) && (testPoint( 1 ) <= ymax) && (testPoint( 0 ) <= xmax)) {
-                double xIntersect = pointA( 0 ) + (testPoint( 1 ) - pointA( 1 )) * 
+                xIntersect = pointA( 0 ) + (testPoint( 1 ) - pointA( 1 )) * 
                 (pointB( 0 ) - pointA( 0 )) / (pointB( 1 ) - pointA( 1 ));
                 if (pointA( 0 ) == pointB( 0 ) || testPoint( 0 ) <= xIntersect)
                     count++;
@@ -100,14 +107,14 @@ std::vector< bool > isTriangleInTriangle( const ParallelProjection& projection1,
         }
         // edge from pointB to pointC
         {
-            double ymin = (pointB( 1 ) < pointC( 1 )) ? pointB( 1 ) : pointC( 1 );
-            double ymax = (pointB( 1 ) < pointC( 1 )) ? pointC( 1 ) : pointB( 1 );
-            double xmax = (pointB( 0 ) > pointC( 0 )) ? pointB( 0 ) : pointC( 0 );
+            ymin = (pointB( 1 ) < pointC( 1 )) ? pointB( 1 ) : pointC( 1 );
+            ymax = (pointB( 1 ) < pointC( 1 )) ? pointC( 1 ) : pointB( 1 );
+            xmax = (pointB( 0 ) > pointC( 0 )) ? pointB( 0 ) : pointC( 0 );
             if (ymax == ymin && testPoint( 1 ) == ymax) {
                 count++;
             }
             if ((testPoint( 1 ) > ymin) && (testPoint( 1 ) <= ymax) && (testPoint( 0 ) <= xmax)) {
-                double xIntersect = pointB( 0 ) + (testPoint( 1 ) - pointB( 1 )) * 
+                xIntersect = pointB( 0 ) + (testPoint( 1 ) - pointB( 1 )) * 
                 (pointC( 0 ) - pointB( 0 )) / (pointC( 1 ) - pointB( 1 ));
                 if (pointB( 0 ) == pointC( 0 ) || testPoint( 0 ) <= xIntersect)
                     count++;
@@ -115,17 +122,17 @@ std::vector< bool > isTriangleInTriangle( const ParallelProjection& projection1,
         }
         // edge from pointC to pointA
         {
-            double ymin = (pointC( 1 ) < pointA( 1 )) ? pointC( 1 ) : pointA( 1 );
-            double ymax = (pointC( 1 ) < pointA( 1 )) ? pointA( 1 ) : pointC( 1 );
-            double xmax = (pointC( 0 ) > pointA( 0 )) ? pointC( 0 ) : pointA( 0 );
+            ymin = (pointC( 1 ) < pointA( 1 )) ? pointC( 1 ) : pointA( 1 );
+            ymax = (pointC( 1 ) < pointA( 1 )) ? pointA( 1 ) : pointC( 1 );
+            xmax = (pointC( 0 ) > pointA( 0 )) ? pointC( 0 ) : pointA( 0 );
             if ((testPoint( 1 ) > ymin) && (testPoint( 1 ) <= ymax) && (testPoint( 0 ) <= xmax)) {
-                double xIntersect = pointC( 0 ) + (testPoint( 1 ) - pointC( 1 )) * 
+                xIntersect = pointC( 0 ) + (testPoint( 1 ) - pointC( 1 )) * 
                 (pointA( 0 ) - pointC( 0 )) / (pointA( 1 ) - pointC( 1 ));
                 if (pointC( 0 ) == pointA( 0 ) || testPoint( 0 ) <= xIntersect)
                     count++;
             }
         }
-        bool resultToBeChecked = ( count & 1 ) != 0;
+        resultToBeChecked = ( count & 1 ) != 0;
         results[ i ] = ( testPointsLambdaActuallyPositive[ i ] ) ? resultToBeChecked : false; 
     }
     return results;
@@ -138,43 +145,52 @@ bool isPointInTriangle( const ParallelProjection& projection_,
     Eigen::Vector2d pointB = projection_.getTriangle2d( ).getVertexB( );
     Eigen::Vector2d pointC = projection_.getTriangle2d( ).getVertexC( );
     int count = 0;
+    double ymin, ymax, xmax;
+    double xIntersect;
     // edge from pointA to pointB
     {
-        double ymin = (pointA( 1 ) < pointB( 1 )) ? pointA( 1 ) : pointB( 1 );
-        double ymax = (pointA( 1 ) < pointB( 1 )) ? pointB( 1 ) : pointA( 1 );
-        double xmax = (pointA( 0 ) > pointB( 0 )) ? pointA( 0 ) : pointB( 0 );
+        ymin = (pointA( 1 ) < pointB( 1 )) ? pointA( 1 ) : pointB( 1 );
+        ymax = (pointA( 1 ) < pointB( 1 )) ? pointB( 1 ) : pointA( 1 );
+        xmax = (pointA( 0 ) > pointB( 0 )) ? pointA( 0 ) : pointB( 0 );
         if ((coordM > ymin) && (coordM <= ymax) && (coordL <= xmax)) {
-            double xIntersect = pointA( 0 ) + (coordM - pointA( 1 )) * 
+            xIntersect = pointA( 0 ) + (coordM - pointA( 1 )) * 
             (pointB( 0 ) - pointA( 0 )) / (pointB( 1 ) - pointA( 1 ));
             if (pointA( 0 ) == pointB( 0 ) || coordL <= xIntersect)
+            {
                 count++;
+            }
         }
     }
     // edge from pointB to pointC
     {
-        double ymin = (pointB( 1 ) < pointC( 1 )) ? pointB( 1 ) : pointC( 1 );
-        double ymax = (pointB( 1 ) < pointC( 1 )) ? pointC( 1 ) : pointB( 1 );
-        double xmax = (pointB( 0 ) > pointC( 0 )) ? pointB( 0 ) : pointC( 0 );
+        ymin = (pointB( 1 ) < pointC( 1 )) ? pointB( 1 ) : pointC( 1 );
+        ymax = (pointB( 1 ) < pointC( 1 )) ? pointC( 1 ) : pointB( 1 );
+        xmax = (pointB( 0 ) > pointC( 0 )) ? pointB( 0 ) : pointC( 0 );
         if (ymax == ymin && coordM == ymax) {
             count++;
         }
         if ((coordM > ymin) && (coordM <= ymax) && (coordL <= xmax)) {
-            double xIntersect = pointB( 0 ) + (coordM - pointB( 1 )) * 
+            xIntersect = pointB( 0 ) + (coordM - pointB( 1 )) * 
             (pointC( 0 ) - pointB( 0 )) / (pointC( 1 ) - pointB( 1 ));
             if (pointB( 0 ) == pointC( 0 ) || coordL <= xIntersect)
+            {
                 count++;
+            }
+            
         }
     }
     // edge from pointC to pointA
     {
-        double ymin = (pointC( 1 ) < pointA( 1 )) ? pointC( 1 ) : pointA( 1 );
-        double ymax = (pointC( 1 ) < pointA( 1 )) ? pointA( 1 ) : pointC( 1 );
-        double xmax = (pointC( 0 ) > pointA( 0 )) ? pointC( 0 ) : pointA( 0 );
+        ymin = (pointC( 1 ) < pointA( 1 )) ? pointC( 1 ) : pointA( 1 );
+        ymax = (pointC( 1 ) < pointA( 1 )) ? pointA( 1 ) : pointC( 1 );
+        xmax = (pointC( 0 ) > pointA( 0 )) ? pointC( 0 ) : pointA( 0 );
         if ((coordM > ymin) && (coordM <= ymax) && (coordL <= xmax)) {
-            double xIntersect = pointC( 0 ) + (coordM - pointC( 1 )) * 
+            xIntersect = pointC( 0 ) + (coordM - pointC( 1 )) * 
             (pointA( 0 ) - pointC( 0 )) / (pointA( 1 ) - pointC( 1 ));
             if (pointC( 0 ) == pointA( 0 ) || coordL <= xIntersect)
+            {
                 count++;
+            }  
         }
     }
     return ( count & 1 ) != 0;
@@ -225,10 +241,10 @@ bool doEdgesIntersect(const Eigen::Vector2d& edge1Start, const Eigen::Vector2d& 
 // same exact logic but checks all the points on a line parallel to the ray direction, checking the intersection with the edges, instead of all the points one by one
 std::vector< std::vector< int > > arePointsInTriangle( const ParallelProjection& projection_, 
     const std::vector<double>& gridCoordinatesL_, const std::vector<double>& gridCoordinatesM_,
-    const std::vector< std::vector < int > >& pixelationMatrix_,
+    std::vector< std::vector < int > >& pixelationMatrix_,
     int indexMinL_, int indexMaxL_, int indexMinM_, int indexMaxM_ )
 {   
-    std::vector< std::vector < int > > pixelationMatrixUpdated = pixelationMatrix_;
+    std::vector< std::vector < int > >& pixelationMatrixUpdated = pixelationMatrix_;
     int value = 1;
     if ( indexMaxL_ == -1 )
     {
@@ -239,53 +255,72 @@ std::vector< std::vector< int > > arePointsInTriangle( const ParallelProjection&
     {
         indexMaxM_ = gridCoordinatesM_.size( );
     }
+    double coordM;
+    const Eigen::Vector2d pointA = projection_.getTriangle2d( ).getVertexA( );
+    const Eigen::Vector2d pointB = projection_.getTriangle2d( ).getVertexB( );
+    const Eigen::Vector2d pointC = projection_.getTriangle2d( ).getVertexC( );
+
+    double minLab = (pointA( 1 ) < pointB( 1 )) ? pointA( 1 ) : pointB( 1 );
+    double maxLab = (pointA( 1 ) < pointB( 1 )) ? pointB( 1 ) : pointA( 1 );
+    double minLbc = (pointB( 1 ) < pointC( 1 )) ? pointB( 1 ) : pointC( 1 );
+    double maxLbc = (pointB( 1 ) < pointC( 1 )) ? pointC( 1 ) : pointB( 1 );
+    double minLca = (pointC( 1 ) < pointA( 1 )) ? pointC( 1 ) : pointA( 1 );
+    double maxLca = (pointC( 1 ) < pointA( 1 )) ? pointA( 1 ) : pointC( 1 );
+    double xIntersect;
+    double minIntersection, maxIntersection;
     
     for ( int i=indexMinM_; i<indexMaxM_; i++ )
     {
         // loop over all y-parallel rays
-        const double coordM = gridCoordinatesM_[i];
-        const Eigen::Vector2d pointA = projection_.getTriangle2d( ).getVertexA( );
-        const Eigen::Vector2d pointB = projection_.getTriangle2d( ).getVertexB( );
-        const Eigen::Vector2d pointC = projection_.getTriangle2d( ).getVertexC( );
+        coordM = gridCoordinatesM_[i];
+        
         std::vector< double > intersections;
 
         // edge 1
-        double minLab = (pointA( 1 ) < pointB( 1 )) ? pointA( 1 ) : pointB( 1 );
-        double maxLab = (pointA( 1 ) < pointB( 1 )) ? pointB( 1 ) : pointA( 1 );
         if ((coordM > minLab) && (coordM <= maxLab)) {
-            double xIntersect = pointA( 0 ) + (coordM - pointA( 1 )) * (pointB( 0 ) - pointA( 0 )) / (pointB( 1 ) - pointA( 1 ));
+            xIntersect = pointA( 0 ) + (coordM - pointA( 1 )) * (pointB( 0 ) - pointA( 0 )) / (pointB( 1 ) - pointA( 1 ));
             intersections.push_back(xIntersect);
         }
         // edge 2
-        double minLbc = (pointB( 1 ) < pointC( 1 )) ? pointB( 1 ) : pointC( 1 );
-        double maxLbc = (pointB( 1 ) < pointC( 1 )) ? pointC( 1 ) : pointB( 1 );
         if ((coordM > minLbc) && (coordM <= maxLbc)) {
-            double xIntersect = pointB( 0 ) + (coordM - pointB( 1 )) * (pointC( 0 ) - pointB( 0 )) / (pointC( 1 ) - pointB( 1 ));
+            xIntersect = pointB( 0 ) + (coordM - pointB( 1 )) * (pointC( 0 ) - pointB( 0 )) / (pointC( 1 ) - pointB( 1 ));
             intersections.push_back(xIntersect);
         }
         // edge 3
-        double minLca = (pointC( 1 ) < pointA( 1 )) ? pointC( 1 ) : pointA( 1 );
-        double maxLca = (pointC( 1 ) < pointA( 1 )) ? pointA( 1 ) : pointC( 1 );
         if ((coordM > minLca) && (coordM <= maxLca)) {
-            double xIntersect = pointC( 0 ) + (coordM - pointC( 1 )) * (pointA( 0 ) - pointC( 0 )) / (pointA( 1 ) - pointC( 1 ));
+            xIntersect = pointC( 0 ) + (coordM - pointC( 1 )) * (pointA( 0 ) - pointC( 0 )) / (pointA( 1 ) - pointC( 1 ));
             intersections.push_back(xIntersect);
         }
         if (intersections.empty()) {
             continue;
         }
-        double minIntersection = *std::min_element(intersections.begin(), intersections.end());
-        double maxIntersection = *std::max_element(intersections.begin(), intersections.end());
-        for (int j = indexMinL_; j<indexMaxL_; j++)
-        {
-            if ( gridCoordinatesL_.at( j ) >= minIntersection && gridCoordinatesL_.at( j ) <= maxIntersection && 
-                value == 0)
-            {
-                pixelationMatrixUpdated.at( i ).at( j ) = value;
+        minIntersection = std::min(intersections[0], intersections[1]);
+        maxIntersection = std::max(intersections[0], intersections[1]);
+        //for (int j = indexMinL_; j<indexMaxL_; j++)
+        //{
+        //    if ( gridCoordinatesL_.at( j ) >= minIntersection && gridCoordinatesL_.at( j ) <= maxIntersection && 
+        //        value == 0)
+        //    {
+        //        pixelationMatrixUpdated.at( i ).at( j ) = value;
+        //    }
+        //    if ( gridCoordinatesL_.at( j ) >= minIntersection && gridCoordinatesL_.at( j ) <= maxIntersection && 
+        //        value == 1 && pixelationMatrixUpdated.at( i ).at( j ) == 0)
+        //    {
+        //        pixelationMatrixUpdated.at( i ).at( j ) = value;
+        //    }
+        //}
+        if (value == 0) {
+            for (int j = indexMinL_; j < indexMaxL_; j++) {
+                if (gridCoordinatesL_[j] >= minIntersection && gridCoordinatesL_[j] <= maxIntersection) {
+                    pixelationMatrixUpdated[i][j] = 0;
+                }
             }
-            if ( gridCoordinatesL_.at( j ) >= minIntersection && gridCoordinatesL_.at( j ) <= maxIntersection && 
-                value == 1 && pixelationMatrixUpdated.at( i ).at( j ) == 0)
-            {
-                pixelationMatrixUpdated.at( i ).at( j ) = value;
+        } else { // value == 1
+            for (int j = indexMinL_; j < indexMaxL_; j++) {
+                if (gridCoordinatesL_[j] >= minIntersection && gridCoordinatesL_[j] <= maxIntersection && 
+                    pixelationMatrixUpdated[i][j] == 0) {
+                    pixelationMatrixUpdated[i][j] = 1;
+                }
             }
         }
     }
@@ -301,19 +336,26 @@ std::vector< double > computeFractioWithPixelation( const std::vector<std::vecto
 {
     std::vector< double > fractions( toBePixelated_.size( ) );
     std::vector< double > gridCoordinatesL, gridCoordinatesM;
+    int index;
+    double minL, maxL, minM, maxM;
+    double deltaL, deltaM;
+    double numberM, numberL;
+    double sizeL, sizeM;
+    int indexMinL, indexMaxL, indexMinM, indexMaxM;
+    double fractionOnes, fractionZeros;
+
     for ( int i=0; i<static_cast< int >( toBePixelated_.size( ) ); i++ )
     {
-        int index = toBePixelated_.at( i );
-        double minL = allPanels_.at( index )->getSelfProjection( ).getMinimumL( );
-        double maxL = allPanels_.at( index )->getSelfProjection( ).getMaximumL( );
-        double minM = allPanels_.at( index )->getSelfProjection( ).getMinimumM( );
-        double maxM = allPanels_.at( index )->getSelfProjection( ).getMaximumM( );
+        index = toBePixelated_.at( i );
+        minL = allPanels_.at( index )->getSelfProjection( ).getMinimumL( );
+        maxL = allPanels_.at( index )->getSelfProjection( ).getMaximumL( );
+        minM = allPanels_.at( index )->getSelfProjection( ).getMinimumM( );
+        maxM = allPanels_.at( index )->getSelfProjection( ).getMaximumM( );
 
-        double deltaL = maxL - minL;
-        double deltaM = maxM - minM;
+        deltaL = maxL - minL;
+        deltaM = maxM - minM;
 
         // choosing number of pixels
-        double numberM, numberL;
         if (deltaM>=deltaL) {
             numberM = static_cast< double >( maximumNumberOfPixels_ );
             numberL = static_cast< double >( std::max(2, static_cast< int >(std::round( numberM * deltaL/deltaM))));
@@ -322,8 +364,8 @@ std::vector< double > computeFractioWithPixelation( const std::vector<std::vecto
             numberL = static_cast< double >( maximumNumberOfPixels_ );
             numberM = static_cast< double >( std::max(2, static_cast< int >(std::round( numberL * deltaM/deltaL))));
         }
-        double sizeL = deltaL / numberL;
-        double sizeM = deltaM / numberM;
+        sizeL = deltaL / numberL;
+        sizeM = deltaM / numberM;
         // creating the grid
         gridCoordinatesL = linspace(minL + sizeL/2, maxL - sizeL/2, numberL );
         gridCoordinatesM = linspace(minM + sizeM/2, maxM - sizeM/2, numberM );
@@ -340,19 +382,19 @@ std::vector< double > computeFractioWithPixelation( const std::vector<std::vecto
                 continue;
             }
             // resize pixelation grid to accelerate the process
-            int indexMinL = clamp(static_cast< int >( 
+            indexMinL = clamp(static_cast< int >( 
                 std::floor((projections_.at( index ).at( j ).getMinimumL( )-minL)/sizeL)) - 1, 0, static_cast< int >( numberL ) - 1);
-            int indexMaxL = clamp(static_cast< int >( 
+            indexMaxL = clamp(static_cast< int >( 
                 std::ceil((projections_.at( index ).at( j ).getMaximumL( )-minL)/sizeL)) + 1, indexMinL + 1, static_cast< int >( numberL ));
-            int indexMinM = clamp(static_cast< int >(
+            indexMinM = clamp(static_cast< int >(
                 std::floor((projections_.at( index ).at( j ).getMinimumM( )-minM)/sizeM)) - 1, 0, static_cast< int >( numberM ) - 1);
-            int indexMaxM = clamp(static_cast< int >(
+            indexMaxM = clamp(static_cast< int >(
                 std::ceil((projections_.at( index ).at( j ).getMaximumM( )-minM)/sizeM)) + 1, indexMinM + 1, static_cast< int >( numberM ));
             // apply PIP to shadowing and update pixelation matrix (assign value of 1)  
             pixelationMatrix = arePointsInTriangle(projections_.at( index ).at( j ), 
                 gridCoordinatesL, gridCoordinatesM, pixelationMatrix, indexMinL, indexMaxL, indexMinM, indexMaxM);
         }
-        double fractionOnes = 0;
+        fractionOnes = 0;
         for (int p = 0; p< static_cast< int >( gridCoordinatesM.size() ); p++) 
         {
             for (int q = 0; q< static_cast< int >( gridCoordinatesL.size() ); q++) 
@@ -363,7 +405,7 @@ std::vector< double > computeFractioWithPixelation( const std::vector<std::vecto
                 }
             }
         }
-        double fractionZeros = 0;
+        fractionZeros = 0;
         for (int p = 0; p< static_cast< int >( gridCoordinatesM.size() ); p++) 
         {
             for (int q = 0; q< static_cast< int >( gridCoordinatesL.size() ); q++) 
@@ -457,7 +499,7 @@ void SelfShadowing::updateIlluminatedPanelFractions( const Eigen::Vector3d& inco
                 {
                     continue;
                 }
-                ParallelProjection projection( allPanels_.at( i )->getTriangle3d( ), allPanels_.at( j )->getTriangle3d( ), incomingDirection );
+                ParallelProjection projection( allPanels_.at( i )->getBodyFixedTriangle3d( ), allPanels_.at( j )->getBodyFixedTriangle3d( ), incomingDirection );
                 if ( secondDiscrimination( projection ) )
                 {
                     // testing for those panels that yield p-sh (this case)

--- a/src/simulation/environment_setup/createRadiationPressureTargetModel.cpp
+++ b/src/simulation/environment_setup/createRadiationPressureTargetModel.cpp
@@ -191,8 +191,9 @@ std::vector< std::shared_ptr< electromagnetism::RadiationPressureTargetModel > >
             }
 
             radiationPressureTargetModels.push_back( std::make_shared< PaneledRadiationPressureTargetModel >(
-                    bodyFixedPanels, segmentFixedPanels, segmentFixedToBodyFixedRotations, sourceToTargetOccultingBodies,
-                    panelledTargetModelSettings->getMaximumNumberOfPixelsPerSource( ) ) );
+                    bodyFixedPanels, bodies.at( body )->getVehicleSystems( )->getAllPanels( ), segmentFixedPanels, 
+                    segmentFixedToBodyFixedRotations, sourceToTargetOccultingBodies,
+                    panelledTargetModelSettings->getMaximumNumberOfPixelsPerSource( ), bodies.at( body )->getVehicleSystems( )->isPanelGeometryDefined( ) ) );
             break;
         }
         case RadiationPressureTargetModelType::multi_type_target: {

--- a/src/simulation/propagation_setup/createEnvironmentUpdater.cpp
+++ b/src/simulation/propagation_setup/createEnvironmentUpdater.cpp
@@ -429,7 +429,7 @@ createTranslationalEquationsOfMotionEnvironmentUpdaterSettings( const basic_astr
                                 }
                             }
 
-                            if( paneledRadiationPressureTargetModel->getSegmentFixedPanels( ).size( ) > 0 )
+                            if( paneledRadiationPressureTargetModel->getTotalNumberOfPanels( ) > 0 )
                             {
                                 singleAccelerationUpdateNeeds[ body_segment_orientation_update ].push_back( targetName );
                             }

--- a/src/simulation/propagation_setup/propagationOutput.cpp
+++ b/src/simulation/propagation_setup/propagationOutput.cpp
@@ -603,20 +603,11 @@ int getDependentVariableSize( const std::shared_ptr< SingleDependentVariableSave
             break;
         case full_body_paneled_geometry: {
             std::string targetBody = dependentVariableSettings->associatedBody_;
-            std::shared_ptr< electromagnetism::PaneledRadiationPressureTargetModel >  paneledRadiationPressureTargetModel = 
-                std::dynamic_pointer_cast< electromagnetism::PaneledRadiationPressureTargetModel >(
-                    bodies.at( targetBody )->getRadiationPressureTargetModel( ) );
-            if ( paneledRadiationPressureTargetModel == nullptr )
+            if ( !bodies.at( targetBody )->getVehicleSystems( )->isPanelGeometryDefined( ) )
             {
-                std::string errorMessage = "Error, full body panel geometry only implemented for paneled radiation pressure target model, however, paneled target " + 
-                        targetBody + " not found";
-                throw std::runtime_error( errorMessage );
+                throw std::runtime_error( "Error, full body panelled geometry for " + targetBody + " not found" );
             }
-            if ( !paneledRadiationPressureTargetModel->isPanelGeometryDefined( ) )
-            {
-                throw std::runtime_error( "Error, macromodel for paneled target " + targetBody + " not found" );
-            }
-            int totalNumberOfPanels = paneledRadiationPressureTargetModel->getTotalNumberOfPanels( );
+            int totalNumberOfPanels = bodies.at( targetBody )->getVehicleSystems( )->getTotalNumberOfPanels( );
             variableSize = 9 * totalNumberOfPanels;
             break;
         }

--- a/tests/src/astro/electromagnetism/unitTestRadiationPressureAcceleration.cpp
+++ b/tests/src/astro/electromagnetism/unitTestRadiationPressureAcceleration.cpp
@@ -270,7 +270,11 @@ BOOST_AUTO_TEST_CASE( testRadiationPressureAcceleration_IsotropicPointSource_Pan
                                                                  Eigen::Vector3d::UnitX( ),  // never pointing towards source in these tests
                                                                  reflectionLawFromAbsorptivityAndDiffuseReflectivity( 0.3, 0.4 ) )
     };
-    auto targetModel = std::make_shared< PaneledRadiationPressureTargetModel >( panels );
+    auto targetModel = std::make_shared< PaneledRadiationPressureTargetModel >( panels, panels );
+    for ( auto it: panels )
+    {
+        it->updatePanel( Eigen::Quaterniond::Identity( ) );
+    }
 
     // Using the same target position but different target rotations
     {
@@ -480,12 +484,16 @@ BOOST_AUTO_TEST_CASE( testRadiationPressureAcceleration_IsotropicPointSource_Pan
                         2.3, -Eigen::Vector3d::UnitX( ), reflectionLawFromSpecularAndDiffuseReflectivity( 0.1, 0.46 ) ),
             };
         }
-        bodies.at( "Vehicle" )->setRadiationPressureTargetModels( { std::make_shared< PaneledRadiationPressureTargetModel >( panels ) } );
+        bodies.at( "Vehicle" )->setRadiationPressureTargetModels( { std::make_shared< PaneledRadiationPressureTargetModel >( panels, panels ) } );
 
         std::vector< double > areas;
         std::vector< Eigen::Vector3d > panelSurfaceNormals;
         std::vector< double > specularReflectivities;
         std::vector< double > diffuseReflectivities;
+        for( auto it: panels )
+        {
+            it->updatePanel( Eigen::Quaterniond::Identity( ) );
+        }
         for( auto& panel: panels )
         {
             areas.push_back( panel->getPanelArea( ) );
@@ -842,8 +850,7 @@ BOOST_AUTO_TEST_CASE( testRadiationPressureAcceleration_IsotropicPointSource_Pan
                         4.0, -Eigen::Vector3d::UnitX( ), reflectionLawFromSpecularAndDiffuseReflectivity( 0.1, 0.46 ) ),
             };
             bodies.at( "Vehicle" )
-                    ->setRadiationPressureTargetModels( { std::make_shared< PaneledRadiationPressureTargetModel >( panels ) } );
-
+                ->setRadiationPressureTargetModels( { std::make_shared< PaneledRadiationPressureTargetModel >( panels, panels ) } );
             SelectedAccelerationMap accelerationMap{ { "Vehicle",
                                                        {
                                                                { "Sun", { radiationPressureAcceleration( paneled_target ) } },
@@ -855,6 +862,10 @@ BOOST_AUTO_TEST_CASE( testRadiationPressureAcceleration_IsotropicPointSource_Pan
             // Compute radiation pressure acceleration for different Sun positions.
             Eigen::Vector3d sunCenteredVehiclePosition;
             std::shared_ptr< Ephemeris > vehicleEphemeris = bodies.at( "Vehicle" )->getEphemeris( );
+            for( auto it: panels )
+            {
+                it->updatePanel( Eigen::Quaterniond::Identity( ) );
+            }
 
             for( unsigned int i = 0; i < testTimes.size( ); i++ )
             {
@@ -915,7 +926,7 @@ BOOST_AUTO_TEST_CASE( testRadiationPressureAcceleration_IsotropicPointSource_Pan
                         reflectionLawFromSpecularAndDiffuseReflectivity( 0.1, 0.46 ) ),
             };
             bodies.at( "Vehicle" )
-                    ->setRadiationPressureTargetModels( { std::make_shared< PaneledRadiationPressureTargetModel >( panels ),
+                    ->setRadiationPressureTargetModels( { std::make_shared< PaneledRadiationPressureTargetModel >( panels, panels ),
                                                           std::make_shared< CannonballRadiationPressureTargetModel >( 1000.0, 0.3 ) } );
 
             SelectedAccelerationMap accelerationMap{ { "Vehicle",
@@ -925,6 +936,10 @@ BOOST_AUTO_TEST_CASE( testRadiationPressureAcceleration_IsotropicPointSource_Pan
             auto accelerationModelMap = createAccelerationModelsMap(
                     bodies, accelerationMap, std::vector< std::string >{ "Vehicle" }, std::vector< std::string >{ "Sun" } );
             auto accelerationModelTimeVaryingPanelSurfaceNormal = accelerationModelMap.at( "Vehicle" ).at( "Sun" ).at( 0 );
+            for( auto it: panels )
+            {
+                it->updatePanel( Eigen::Quaterniond::Identity( ) );
+            }
 
             // Compute radiation pressure acceleration for different Sun positions.
             Eigen::Vector3d sunCenteredVehiclePosition;
@@ -1006,8 +1021,11 @@ BOOST_AUTO_TEST_CASE( testRadiationPressureAcceleration_StaticallyPaneledSource_
                                                                  Eigen::Vector3d::UnitX( ),  // never pointing towards source in these tests
                                                                  reflectionLawFromAbsorptivityAndDiffuseReflectivity( 0.3, 0.4 ) )
     };
-    auto targetModel = std::make_shared< PaneledRadiationPressureTargetModel >( targetPanels );
-
+    auto targetModel = std::make_shared< PaneledRadiationPressureTargetModel >( targetPanels, targetPanels );
+    for ( auto it: targetPanels )
+    {
+        it->updatePanel( Eigen::Quaterniond::Identity( ) );
+    }
     // Only panel 1 towards source
     // Magnitude 2/pi because target area 1, source area 2, for target only absorption, pi due to diffuse albedo of source
     const Eigen::Vector3d expectedAcceleration = 2 * Eigen::Vector3d::UnitX( ) / mathematical_constants::PI;

--- a/tests/src/astro/electromagnetism/unitTestRadiationPressureTargetModel.cpp
+++ b/tests/src/astro/electromagnetism/unitTestRadiationPressureTargetModel.cpp
@@ -82,12 +82,15 @@ BOOST_AUTO_TEST_CASE( testPaneledRadiationPressureTargetModel_PointingAway )
     const auto expectedForce = Eigen::Vector3d::Zero( );
 
     const auto reflectionLaw = std::make_shared< SpecularDiffuseMixReflectionLaw >( 0.2, 0.4, 0.4 );
-    PaneledRadiationPressureTargetModel targetModel(
-            { std::make_shared< system_models::VehicleExteriorPanel >( Eigen::Vector3d( 1, 0, -1 ).normalized( ), 1.0, "", reflectionLaw ),
+    std::vector< std::shared_ptr< system_models::VehicleExteriorPanel > > allPanels = { std::make_shared< system_models::VehicleExteriorPanel >( Eigen::Vector3d( 1, 0, -1 ).normalized( ), 1.0, "", reflectionLaw ),
               std::make_shared< system_models::VehicleExteriorPanel >( Eigen::Vector3d( -1, 0, -2 ).normalized( ), 1.0, "", reflectionLaw ),
               std::make_shared< system_models::VehicleExteriorPanel >( Eigen::Vector3d( 0, 1, -3 ).normalized( ), 1.0, "", reflectionLaw ),
-              std::make_shared< system_models::VehicleExteriorPanel >(
-                      Eigen::Vector3d( 0, -1, -4 ).normalized( ), 1.0, "", reflectionLaw ) } );
+              std::make_shared< system_models::VehicleExteriorPanel >( Eigen::Vector3d( 0, -1, -4 ).normalized( ), 1.0, "", reflectionLaw ) };
+    PaneledRadiationPressureTargetModel targetModel( allPanels, allPanels );
+    for ( auto it: allPanels )
+    {
+        it->updatePanel( Eigen::Quaterniond::Identity( ) );
+    }
     targetModel.updateMembers( TUDAT_NAN );
 
     const auto sourceIrradiance = 1000;
@@ -102,12 +105,15 @@ BOOST_AUTO_TEST_CASE( testPaneledRadiationPressureTargetModel_LateralCancellatio
 {
     // Purely diffuse Lambertian radiation so radiation pressure force is along normal of each panel
     const auto reflectionLaw = std::make_shared< SpecularDiffuseMixReflectionLaw >( 0, 0, 1 );
-    PaneledRadiationPressureTargetModel targetModel(
-            { std::make_shared< system_models::VehicleExteriorPanel >( Eigen::Vector3d( 1, 0, 1 ).normalized( ), 1.0, "", reflectionLaw ),
+    std::vector< std::shared_ptr< system_models::VehicleExteriorPanel > > allPanels = { std::make_shared< system_models::VehicleExteriorPanel >( Eigen::Vector3d( 1, 0, 1 ).normalized( ), 1.0, "", reflectionLaw ),
               std::make_shared< system_models::VehicleExteriorPanel >( Eigen::Vector3d( -1, 0, 1 ).normalized( ), 1.0, "", reflectionLaw ),
               std::make_shared< system_models::VehicleExteriorPanel >( Eigen::Vector3d( 0, 1, 1 ).normalized( ), 1.0, "", reflectionLaw ),
-              std::make_shared< system_models::VehicleExteriorPanel >(
-                      Eigen::Vector3d( 0, -1, 1 ).normalized( ), 1.0, "", reflectionLaw ) } );
+              std::make_shared< system_models::VehicleExteriorPanel >( Eigen::Vector3d( 0, -1, 1 ).normalized( ), 1.0, "", reflectionLaw ) };
+    PaneledRadiationPressureTargetModel targetModel( allPanels, allPanels );
+    for ( auto it: allPanels )
+    {
+        it->updatePanel( Eigen::Quaterniond::Identity( ) );
+    }
     targetModel.updateMembers( TUDAT_NAN );
 
     const auto sourceIrradiance = 1000;
@@ -132,13 +138,17 @@ BOOST_AUTO_TEST_CASE( testRadiationPressureTargetModel_EquivalentSinglePanel )
     const Eigen::Vector3d bodyFixedPanelLocation = Eigen::Vector3d( 2, -7, 8 ).normalized( );
 
     auto cannonballModel = CannonballRadiationPressureTargetModel( mathematical_constants::PI * radius * radius, coefficient );
-    auto paneledModel = PaneledRadiationPressureTargetModel(
-            { std::make_shared< system_models::VehicleExteriorPanel >( -sourceToTargetDirection,
+    std::vector< std::shared_ptr< system_models::VehicleExteriorPanel > > allPanels = { std::make_shared< system_models::VehicleExteriorPanel >( -sourceToTargetDirection,
                                                                        mathematical_constants::PI * radius * radius,
                                                                        "",
                                                                        // This gives an equivalent coefficient of 1.6
                                                                        reflectionLawFromSpecularAndDiffuseReflectivity( 0.6, 0 ),
-                                                                       bodyFixedPanelLocation ) } );
+                                                                       bodyFixedPanelLocation ) };
+    auto paneledModel = PaneledRadiationPressureTargetModel( allPanels, allPanels );
+    for ( auto it: allPanels )
+    {
+        it->updatePanel( Eigen::Quaterniond::Identity( ) );
+    }
 
     cannonballModel.enableTorqueComputation( [ = ]( ) { return Eigen::Vector3d::Zero( ); } );
     paneledModel.enableTorqueComputation( [ = ]( ) { return Eigen::Vector3d::Zero( ); } );
@@ -196,7 +206,11 @@ BOOST_AUTO_TEST_CASE( testRadiationPressureTargetModel_EquivalentSphere )
                 std::make_shared< system_models::VehicleExteriorPanel >( surfaceNormal, panelArea, "", reflectionLaw, relativeCenter ) );
     }
 
-    auto paneledModel = PaneledRadiationPressureTargetModel( panels );
+    auto paneledModel = PaneledRadiationPressureTargetModel( panels, panels );
+    for ( auto it: panels )
+    {
+        it->updatePanel( Eigen::Quaterniond::Identity( ) );
+    }
 
     Eigen::Vector3d centerOfMass = Eigen::Vector3d::UnitX( );
     cannonballModel.enableTorqueComputation( [ = ]( ) { return centerOfMass; } );

--- a/tests/src/astro/orbit_determination/acceleration_partials/unitTestAccelerationPartials.cpp
+++ b/tests/src/astro/orbit_determination/acceleration_partials/unitTestAccelerationPartials.cpp
@@ -176,11 +176,12 @@ BOOST_AUTO_TEST_CASE( testPanelledRadiationPressureAccelerationPartials )
         addBodyExteriorPanelledShape( std::make_shared< FullPanelledBodySettings >( panelSettingsList ), "Vehicle", bodies );
 
         auto paneledRadiationPressureTargetSettings = std::make_shared< PaneledRadiationPressureTargetModelSettings >( );
-
+        
         std::shared_ptr< electromagnetism::PaneledRadiationPressureTargetModel > radiationPressureInterface =
                 std::dynamic_pointer_cast< electromagnetism::PaneledRadiationPressureTargetModel >(
                         createRadiationPressureTargetModel( paneledRadiationPressureTargetSettings, "Vehicle", bodies ).at( 0 ) );
         vehicle->addRadiationPressureTargetModel( radiationPressureInterface );
+        vehicle->getVehicleSystems( )->updatePartOrientations( 0.0 );
 
         // Create acceleration model.
         std::shared_ptr< RadiationPressureAcceleration > accelerationModel = std::dynamic_pointer_cast< RadiationPressureAcceleration >(

--- a/tests/src/astro/system_models/unitTestSelfShadowing.cpp
+++ b/tests/src/astro/system_models/unitTestSelfShadowing.cpp
@@ -120,9 +120,7 @@ BOOST_AUTO_TEST_CASE( testFractionAnalytical )
     
     std::map< std::string, std::shared_ptr< SelfShadowing > > mapSSH = targetModel.getSelfShadowingPerSources( );
     Eigen::Vector3d incomingDirection = Eigen::Vector3d::UnitX( );
-    std::cout<<"TEST 1"<<std::endl;
     bodies.at( "L_SHAPED" )->getVehicleSystems( )->updatePartOrientations( 0.0 );
-    std::cout<<"TEST 2"<<std::endl;
 
     for ( unsigned int i = 0; i<angles.size( ); i++ )
     {
@@ -132,11 +130,8 @@ BOOST_AUTO_TEST_CASE( testFractionAnalytical )
         
 
         mapSSH[ "Sun" ]->reset( );
-        std::cout<<"TEST 32"<<std::endl;
         mapSSH[ "Sun" ]->updateIlluminatedPanelFractions( incomingDirection );
-        std::cout<<"TEST 3"<<std::endl;
         std::vector< double > illuminatedPanelFractions = mapSSH[ "Sun" ]->getIlluminatedPanelFractions( );
-        std::cout<<"TEST 4"<<std::endl;
         double trueFractionShaded = 1.0 - std::tan( angles[ i ] );
         double trueFractionLit = 1.0;
 

--- a/tests/src/astro/system_models/unitTestSelfShadowing.cpp
+++ b/tests/src/astro/system_models/unitTestSelfShadowing.cpp
@@ -27,6 +27,13 @@ using namespace tudat::electromagnetism;
 using namespace tudat::system_models;
 using mathematical_constants::PI;
 
+using namespace tudat::propagators;
+using namespace tudat::numerical_integrators;
+using namespace tudat::orbital_element_conversions;
+using namespace tudat::basic_mathematics;
+using namespace tudat::gravitation;
+using namespace tudat::estimatable_parameters;
+
 namespace unit_tests
 {
 
@@ -82,12 +89,18 @@ BOOST_AUTO_TEST_CASE( testFractionAnalytical )
     std::vector< std::shared_ptr< VehicleExteriorPanel > > bodyFixedPanels = sortedBodyPanelMap.at( "" );
     std::map< std::string, std::vector< std::string > > sourceToTargetOccultingBodies = std::map< std::string, std::vector< std::string > >( );
     const std::map< std::string, int > maximumNumberOfPixelsPerSource = {{"Sun", 1000}};
+    for (const auto& pair : panelSettings->partRotationModelSettings_) {
+        std::cout << pair.first << std::endl;
+    }
+    
 
-    PaneledRadiationPressureTargetModel targetModel( bodyFixedPanels, 
+    PaneledRadiationPressureTargetModel targetModel( bodyFixedPanels,
+            bodyFixedPanels, 
             std::map< std::string, std::vector< std::shared_ptr< system_models::VehicleExteriorPanel > > >( ),
             std::map< std::string, std::function< Eigen::Quaterniond( ) > >( ),
             sourceToTargetOccultingBodies, 
-            maximumNumberOfPixelsPerSource );
+            maximumNumberOfPixelsPerSource,
+            true );
     
     std::vector< double > angles = { PI/50, PI/20, PI/10, PI/8, PI/6, PI/4 };
 
@@ -107,17 +120,23 @@ BOOST_AUTO_TEST_CASE( testFractionAnalytical )
     
     std::map< std::string, std::shared_ptr< SelfShadowing > > mapSSH = targetModel.getSelfShadowingPerSources( );
     Eigen::Vector3d incomingDirection = Eigen::Vector3d::UnitX( );
-    mapSSH[ "Sun" ]->updateIlluminatedPanelFractions( incomingDirection );
+    std::cout<<"TEST 1"<<std::endl;
+    bodies.at( "L_SHAPED" )->getVehicleSystems( )->updatePartOrientations( 0.0 );
+    std::cout<<"TEST 2"<<std::endl;
 
     for ( unsigned int i = 0; i<angles.size( ); i++ )
     {
         incomingDirection( 0 ) = -std::sin( angles[ i ] );
         incomingDirection( 1 ) = 0;
         incomingDirection( 2 ) = -std::cos( angles[ i ] );
+        
 
         mapSSH[ "Sun" ]->reset( );
+        std::cout<<"TEST 32"<<std::endl;
         mapSSH[ "Sun" ]->updateIlluminatedPanelFractions( incomingDirection );
+        std::cout<<"TEST 3"<<std::endl;
         std::vector< double > illuminatedPanelFractions = mapSSH[ "Sun" ]->getIlluminatedPanelFractions( );
+        std::cout<<"TEST 4"<<std::endl;
         double trueFractionShaded = 1.0 - std::tan( angles[ i ] );
         double trueFractionLit = 1.0;
 
@@ -132,6 +151,125 @@ BOOST_AUTO_TEST_CASE( testFractionAnalytical )
         BOOST_CHECK( std::abs( actualFractionShadowed - trueFractionShaded ) < 1e-3);
     }
    
+}
+
+BOOST_AUTO_TEST_CASE( testComputationalEfficiency )
+{
+    spice_interface::loadStandardSpiceKernels( );
+
+    // Set simulation time settings.
+    const double simulationStartEpoch = 0.0;
+    const double simulationEndEpoch = 0.5 * tudat::physical_constants::JULIAN_DAY;
+
+    // Define body settings for simulation.
+    std::vector< std::string > bodiesToCreate;
+    bodiesToCreate.push_back( "Sun" );
+    bodiesToCreate.push_back( "Earth" );
+    bodiesToCreate.push_back( "Moon" );
+
+    // Create body objects.
+    BodyListSettings bodySettings = getDefaultBodySettings( bodiesToCreate, "SSB", "J2000" );
+    SystemOfBodies bodies = createSystemOfBodies( bodySettings );
+
+    ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+    ///////////////////////             CREATE VEHICLE            /////////////////////////////////////////////////////////
+    ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+    std::map< std::string, std::vector< double > > materialProperties;
+    materialProperties[ "dummy" ] = { 0.4, 0.4 };
+    materialProperties[ "TO_BE_SHADOWED" ] = { 0.4, 0.4 };
+    materialProperties[ "TO_BE_LIT" ] = { 0.4, 0.4 };
+
+    std::map< std::string, bool > instantaneousReradiation;
+    instantaneousReradiation[ "dummy" ] = true;
+    instantaneousReradiation[ "TO_BE_SHADOWED" ] = true;
+    instantaneousReradiation[ "TO_BE_LIT" ] = true;
+
+    std::vector< std::shared_ptr< BodyPanelSettings > > bodyPanelSettingList = bodyPanelSettingsListFromDae( 
+        tudat::paths::getTudatTestDataPath( ) + "selfShadowingUnitTest.dae",
+        Eigen::Vector3d::Zero( ),
+        materialProperties,
+        instantaneousReradiation
+    );
+
+    std::shared_ptr< FullPanelledBodySettings > panelSettings = fullPanelledBodySettings( bodyPanelSettingList );
+    // Create spacecraft object.
+    bodies.createEmptyBody( "Vehicle" );
+    bodies.at( "Vehicle" )->setConstantBodyMass( 400.0 );
+    // Define constant rotational ephemeris
+    Eigen::Vector7d rotationalStateVehicle;
+    rotationalStateVehicle.segment( 0, 4 ) =
+            linear_algebra::convertQuaternionToVectorFormat( Eigen::Quaterniond( Eigen::Matrix3d::Identity( ) ) );
+    rotationalStateVehicle.segment( 4, 3 ) = Eigen::Vector3d::Zero( );
+    bodies.at( "Vehicle" )
+            ->setRotationalEphemeris(
+                    std::make_shared< ConstantRotationalEphemeris >( rotationalStateVehicle, "ECLIPJ2000" ) );
+    addBodyExteriorPanelledShape( panelSettings,
+        "Vehicle",
+        bodies );
+    
+    std::map< std::string, std::vector< std::string > > sourceToTargetOccultingBodies = std::map< std::string, std::vector< std::string > >( );
+    const std::map< std::string, int > maximumNumberOfPixelsPerSource = {{"Sun", 100}};
+
+    bodies.at( "Vehicle" )
+                    ->setRadiationPressureTargetModels( { createRadiationPressureTargetModel(
+                            std::make_shared< PaneledRadiationPressureTargetModelSettings >( sourceToTargetOccultingBodies, maximumNumberOfPixelsPerSource ), "Vehicle", bodies ) } );
+
+    
+    ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+    ///////////////////////            CREATE ACCELERATIONS          //////////////////////////////////////////////////////
+    ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+    // Define propagator settings variables.
+    SelectedAccelerationMap accelerationMap;
+    std::vector< std::string > bodiesToPropagate;
+    std::vector< std::string > centralBodies;
+
+    // Define propagation settings.
+    std::map< std::string, std::vector< std::shared_ptr< AccelerationSettings > > > accelerationsOfAsterix;
+    accelerationsOfAsterix[ "Earth" ].push_back( std::make_shared< AccelerationSettings >( basic_astrodynamics::point_mass_gravity ) );
+    accelerationsOfAsterix[ "Sun" ].push_back( std::make_shared< AccelerationSettings >( basic_astrodynamics::point_mass_gravity ) );
+    accelerationsOfAsterix[ "Moon" ].push_back( std::make_shared< AccelerationSettings >( basic_astrodynamics::point_mass_gravity ) );
+    accelerationsOfAsterix[ "Sun" ].push_back( std::make_shared< AccelerationSettings >( basic_astrodynamics::radiation_pressure ) );
+
+    accelerationMap[ "Vehicle" ] = accelerationsOfAsterix;
+    bodiesToPropagate.push_back( "Vehicle" );
+    centralBodies.push_back( "Earth" );
+
+    basic_astrodynamics::AccelerationMap accelerationModelMap =
+            createAccelerationModelsMap( bodies, accelerationMap, bodiesToPropagate, centralBodies );
+
+    ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+    ///////////////////////             CREATE PROPAGATION SETTINGS            ////////////////////////////////////////////
+    ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+    // Set Keplerian elements for Asterix.
+    Eigen::Vector6d asterixInitialStateInKeplerianElements;
+    asterixInitialStateInKeplerianElements( semiMajorAxisIndex ) = 7500.0E3;
+    asterixInitialStateInKeplerianElements( eccentricityIndex ) = 0.1;
+    asterixInitialStateInKeplerianElements( inclinationIndex ) = unit_conversions::convertDegreesToRadians( 85.3 );
+    asterixInitialStateInKeplerianElements( argumentOfPeriapsisIndex ) = unit_conversions::convertDegreesToRadians( 235.7 );
+    asterixInitialStateInKeplerianElements( longitudeOfAscendingNodeIndex ) = unit_conversions::convertDegreesToRadians( 23.4 );
+    asterixInitialStateInKeplerianElements( trueAnomalyIndex ) = unit_conversions::convertDegreesToRadians( 139.87 );
+
+    double earthGravitationalParameter = bodies.at( "Earth" )->getGravityFieldModel( )->getGravitationalParameter( );
+    const Eigen::Vector6d asterixInitialState =
+            convertKeplerianToCartesianElements( asterixInitialStateInKeplerianElements, earthGravitationalParameter );
+
+    const double fixedStepSize = 10.0;
+    std::shared_ptr< IntegratorSettings<> > integratorSettings =
+            rungeKuttaFixedStepSettings< double >( fixedStepSize, numerical_integrators::rungeKuttaFehlberg78 );
+
+    
+    std::shared_ptr< TranslationalStatePropagatorSettings< double > > propagatorSettings =
+                std::make_shared< TranslationalStatePropagatorSettings< double > >( centralBodies,
+                                                                                    accelerationModelMap,
+                                                                                    bodiesToPropagate,
+                                                                                    asterixInitialState,
+                                                                                    simulationStartEpoch,
+                                                                                    integratorSettings,
+                                                                                    propagationTimeTerminationSettings( simulationEndEpoch ),
+                                                                                    cowell);
+    SingleArcDynamicsSimulator<> dynamicsSimulator( bodies, propagatorSettings );
 }
 
 BOOST_AUTO_TEST_SUITE_END( )


### PR DESCRIPTION
Following from tudat-team/tudatpy#479, here is the PR that moves the panel rotation logic to the environmentUpdater. Rotated panels are now updated at the vehicle level more efficiently, allowing multiple models to access them.

Furthermore, profiling revealed that the bottleneck in the SSH algorithm was at the level of pixelation and PIP testing, with (de)allocation operations being dominant. These fixes are not final, but the code is already more efficient than the first version. 

In unitTestSelfShadowing.cpp I have added the propagation script I used for profiling, it can be safely removed as it has no other use.