### PR TITLE
Add `ECLIPJ2000` as a valid base frame for `ItrsToGcrsRotationModel`

### DIFF
--- a/include/tudat/astro/ephemerides/itrsToGcrsRotationModel.h
+++ b/include/tudat/astro/ephemerides/itrsToGcrsRotationModel.h
@@ -18,6 +18,7 @@
 #include "tudat/math/interpolators/interpolator.h"
 #include "tudat/astro/ephemerides/rotationalEphemeris.h"
 #include "tudat/astro/earth_orientation/earthOrientationCalculator.h"
+#include "tudat/interface/spice/spiceInterface.h"
 
 namespace tudat
 {
@@ -75,12 +76,19 @@ public:
                            anglesCalculator,
                            std::placeholders::_1,
                            inputTimeScale );
+
         if( baseFrame == "J2000" )
         {
             frameBias_ = sofa_interface::getFrameBias(
                     0.0, anglesCalculator->getPrecessionNutationCalculator( )->getPrecessionNutationTheory( ) );
         }
-        else if( baseFrame != "GCRS" )
+        else if( baseFrame == "ECLIPJ2000" )
+        {
+            frameBias_ = spice_interface::getRotationFromJ2000ToEclipJ2000( ) *
+                    sofa_interface::getFrameBias( 0.0,
+                                                  anglesCalculator->getPrecessionNutationCalculator( )->getPrecessionNutationTheory( ) );
+        }
+        else if( baseFrame != "J2000" && baseFrame != "ECLIPJ2000" && baseFrame != "GCRS" )
         {
             throw std::runtime_error( "Error in GCRS<->ITRS model, base frame not recognized" );
         }

--- a/tests/src/astro/ephemerides/CMakeLists.txt
+++ b/tests/src/astro/ephemerides/CMakeLists.txt
@@ -132,16 +132,6 @@ if(TUDAT_BUILD_WITH_SOFA_INTERFACE)
     TUDAT_ADD_TEST_CASE(ItrsToGcrsRotationModel
             PRIVATE_LINKS
             ${Tudat_PROPAGATION_LIBRARIES}
-        #     tudat_simulation_setup
-        #     tudat
-        #     tudat_ephemerides
-        #     tudat_spice_interface
-        #     tudat_reference_frames
-        #     tudat_earth_orientation
-        #     tudat_sofa_interface
-        #     tudat_basic_astrodynamics
-        #     tudat_basic_mathematics
-        #     tudat_input_output
             )
 
 endif( )

--- a/tests/src/astro/ephemerides/CMakeLists.txt
+++ b/tests/src/astro/ephemerides/CMakeLists.txt
@@ -131,14 +131,17 @@ if(TUDAT_BUILD_WITH_SOFA_INTERFACE)
 
     TUDAT_ADD_TEST_CASE(ItrsToGcrsRotationModel
             PRIVATE_LINKS
-            tudat_ephemerides
-            tudat_spice_interface
-            tudat_reference_frames
-            tudat_earth_orientation
-            tudat_sofa_interface
-            tudat_basic_astrodynamics
-            tudat_basic_mathematics
-            tudat_input_output
+            ${Tudat_PROPAGATION_LIBRARIES}
+        #     tudat_simulation_setup
+        #     tudat
+        #     tudat_ephemerides
+        #     tudat_spice_interface
+        #     tudat_reference_frames
+        #     tudat_earth_orientation
+        #     tudat_sofa_interface
+        #     tudat_basic_astrodynamics
+        #     tudat_basic_mathematics
+        #     tudat_input_output
             )
 
 endif( )

--- a/tests/src/astro/ephemerides/unitTestItrsToGcrsRotationModel.cpp
+++ b/tests/src/astro/ephemerides/unitTestItrsToGcrsRotationModel.cpp
@@ -249,7 +249,10 @@ BOOST_AUTO_TEST_CASE( test_ItrsToGcrsRotationConsistency )
 
     // 5. Comparison in ITRS
     // Check that the two positions in ITRS are consistent
-    TUDAT_CHECK_MATRIX_CLOSE_FRACTION( marsPositionInItrsFromJ2000, marsPositionInItrsFromEclipj2000, 1.0E-4 );
+    for( unsigned int i = 0; i < 3; i++ )
+    {
+        BOOST_CHECK_CLOSE_FRACTION( marsPositionInItrsFromJ2000( i ), marsPositionInItrsFromEclipj2000( i ), 1.0E-15 );
+    }
 }
 
 BOOST_AUTO_TEST_SUITE_END( )


### PR DESCRIPTION
Introduce support for `ECLIPJ2000` as a base frame in the `ItrsToGcrsRotationModel` and add corresponding unit tests to ensure consistency between different base frames.