### PR TITLE
Fix sign of madrid ground station velocity

### DIFF
--- a/src/simulation/environment_setup/defaultBodies.cpp
+++ b/src/simulation/environment_setup/defaultBodies.cpp
@@ -574,7 +574,7 @@ std::vector< std::shared_ptr< GroundStationSettings > > getDsnStationSettings( )
     goldstoneStationVelocity /= physical_constants::JULIAN_YEAR;
     Eigen::Vector3d canberraStationVelocity( -0.0335, -0.0041, 0.0392 );
     canberraStationVelocity /= physical_constants::JULIAN_YEAR;
-    Eigen::Vector3d madridStationVelocity( -0.0100, -0.0242, 0.0156 );
+    Eigen::Vector3d madridStationVelocity( -0.0100, 0.0242, 0.0156 );
     madridStationVelocity /= physical_constants::JULIAN_YEAR;
 
     std::vector< std::shared_ptr< GroundStationSettings > > stationSettingsList;


### PR DESCRIPTION
According to https://naif.jpl.nasa.gov/pub/naif/generic_kernels/spk/stations/earthstns_itrf93_201023.cmt (Table Velocity Data) and https://deepspace.jpl.nasa.gov/dsndocs/810-005/301/301K.pdf (Table 3, page 13), the y velocity component of the Madrid DSN station is +0.0242 m/yr instead of -0.0242 m/yr.