### PR TITLE
Pre-1962 Earth rotation

### DIFF
--- a/include/tudat/astro/basic_astro/timeConversions.h
+++ b/include/tudat/astro/basic_astro/timeConversions.h
@@ -83,6 +83,10 @@ const static double TAI_JULIAN_DAY_AT_TIME_SYNCHRONIZATION = 2443144.5003725;
 //! Julian day at which TT, TCG, and TCB all show exact same time (1977 January 1, 00:00:32.184), in long double precision.
 const static long double TAI_JULIAN_DAY_AT_TIME_SYNCHRONIZATION_LONG = 2443144.5003725L;
 
+const static double JULIAN_DAY_OF_UTC_INTRODUCTION = 2436934.5;
+
+const static double JULIAN_DAY_OF_EOP_INTRODUCTION = 2437665.5;
+
 //! Function to get the synchronization Julian day of TT, TCG, and TCB.
 /*!
  *  Function to get the synchronization Julian day of TT, TCG, and TCB, in the requested time representation type

--- a/include/tudat/io/mapTextFileReader.h
+++ b/include/tudat/io/mapTextFileReader.h
@@ -184,6 +184,26 @@ std::map< KeyType, std::vector< ScalarValueType > > readStlVectorMapFromFile( co
     return dataMap_;
 }
 
+template< typename KeyType, typename ScalarValueType >
+std::map< KeyType, ScalarValueType > readFloatingPointMapFromFile( const std::string& relativePath,
+                                                                              const std::string& separators = "\t ;,",
+                                                                              const std::string& skipLinesCharacter = "%" )
+{
+    std::map< KeyType, std::vector< ScalarValueType > > vectorMap = readStlVectorMapFromFile< KeyType, ScalarValueType >(
+        relativePath, separators, skipLinesCharacter );
+
+    std::map< KeyType, ScalarValueType > floatingPointMap;
+    for( auto it : vectorMap )
+    {
+        if( it.second.size( ) != 1 )
+        {
+            throw std::runtime_error( "Error when reading floating point map from file, rows contain more than one value for a key." );
+        }
+        floatingPointMap[ it.first ] = it.second.at( 0 );
+    }
+    return floatingPointMap;
+}
+
 }  // namespace input_output
 
 }  // namespace tudat

--- a/include/tudat/math/interpolators/oneDimensionalInterpolator.h
+++ b/include/tudat/math/interpolators/oneDimensionalInterpolator.h
@@ -310,6 +310,7 @@ protected:
                         {
                             throw std::runtime_error( "Error when checking interpolation boundary, inconsistent data encountered" );
                         }
+
                         break;
                     }
                     case use_nan_value:

--- a/src/astro/earth_orientation/earthOrientationCalculator.cpp
+++ b/src/astro/earth_orientation/earthOrientationCalculator.cpp
@@ -63,12 +63,14 @@ std::shared_ptr< EarthOrientationAnglesCalculator > createStandardEarthOrientati
     // Load polar motion corrections
     std::shared_ptr< interpolators::LinearInterpolator< double, Eigen::Vector2d > > cipInItrsInterpolator =
             std::make_shared< interpolators::LinearInterpolator< double, Eigen::Vector2d > >(
-                    eopReader->getCipInItrsMapInSecondsSinceJ2000( ) );
+                    eopReader->getCipInItrsMapInSecondsSinceJ2000( ), interpolators::huntingAlgorithm,
+                    interpolators::use_default_value, std::make_pair( Eigen::Vector2d::Zero( ), Eigen::Vector2d::Zero( ) ) );
 
     // Load nutation corrections
     std::shared_ptr< interpolators::LinearInterpolator< double, Eigen::Vector2d > > cipInGcrsCorrectionInterpolator =
             std::make_shared< interpolators::LinearInterpolator< double, Eigen::Vector2d > >(
-                    eopReader->getCipInGcrsCorrectionMapInSecondsSinceJ2000( ) );
+                    eopReader->getCipInGcrsCorrectionMapInSecondsSinceJ2000( ), interpolators::huntingAlgorithm,
+                    interpolators::use_default_value, std::make_pair( Eigen::Vector2d::Zero( ), Eigen::Vector2d::Zero( ) ) );
 
     // Load default polar motion correction (sub-diural frequencies) object
     std::shared_ptr< ShortPeriodEarthOrientationCorrectionCalculator< Eigen::Vector2d > > shortPeriodPolarMotionCalculator =

--- a/src/astro/earth_orientation/eopReader.cpp
+++ b/src/astro/earth_orientation/eopReader.cpp
@@ -21,15 +21,21 @@ namespace earth_orientation
 //! Constructor
 EOPReader::EOPReader( const std::string& eopFile, const std::string& format, const basic_astrodynamics::IAUConventions nutationTheory )
 {
-    if( format != "C04" )
+    if ( format != "C04" )
     {
         throw std::runtime_error( "Error, only C04 EOP file format currently supported by reader." );
     }
-    if( !( nutationTheory == basic_astrodynamics::iau_2000_a || nutationTheory == basic_astrodynamics::iau_2006 ) )
+    if ( !( nutationTheory == basic_astrodynamics::iau_2000_a || nutationTheory == basic_astrodynamics::iau_2006 ))
     {
         std::cerr << ( "Warning, only IAU2000 nutation theory format currently supported by reader." ) << std::endl;
     }
     readEopFile( eopFile );
+
+    // Add one hour buffer time
+    cipInItrs[ cipInItrs.begin( )->first - 3600.0 ] = cipInItrs.begin( )->second;
+    cipInGcrsCorrection[ cipInGcrsCorrection.begin( )->first - 3600.0 ] = cipInGcrsCorrection.begin( )->second;
+    ut1MinusUtc[ ut1MinusUtc.begin( )->first - 3600.0 ] = ut1MinusUtc.begin( )->second;
+    lengthOfDayOffset[ lengthOfDayOffset.begin( )->first - 3600.0 ] = lengthOfDayOffset.begin( )->second;
 }
 
 //! Function to read EOP file

--- a/src/astro/earth_orientation/eopReader.cpp
+++ b/src/astro/earth_orientation/eopReader.cpp
@@ -32,10 +32,10 @@ EOPReader::EOPReader( const std::string& eopFile, const std::string& format, con
     readEopFile( eopFile );
 
     // Add one hour buffer time
-    cipInItrs[ cipInItrs.begin( )->first - 3600.0 ] = cipInItrs.begin( )->second;
-    cipInGcrsCorrection[ cipInGcrsCorrection.begin( )->first - 3600.0 ] = cipInGcrsCorrection.begin( )->second;
-    ut1MinusUtc[ ut1MinusUtc.begin( )->first - 3600.0 ] = ut1MinusUtc.begin( )->second;
-    lengthOfDayOffset[ lengthOfDayOffset.begin( )->first - 3600.0 ] = lengthOfDayOffset.begin( )->second;
+    cipInItrs[ cipInItrs.begin( )->first - 1.0 / 24.0 ] = cipInItrs.begin( )->second;
+    cipInGcrsCorrection[ cipInGcrsCorrection.begin( )->first - 1.0 / 24.0 ] = cipInGcrsCorrection.begin( )->second;
+    ut1MinusUtc[ ut1MinusUtc.begin( )->first - 1.0 / 24.0 ] = ut1MinusUtc.begin( )->second;
+    lengthOfDayOffset[ lengthOfDayOffset.begin( )->first - 1.0 / 24.0 ] = lengthOfDayOffset.begin( )->second;
 }
 
 //! Function to read EOP file

--- a/src/astro/earth_orientation/terrestrialTimeScaleConverter.cpp
+++ b/src/astro/earth_orientation/terrestrialTimeScaleConverter.cpp
@@ -68,7 +68,8 @@ std::shared_ptr< TerrestrialTimeScaleConverter > createDefaultTimeConverter( con
             getDefaultUT1CorrectionCalculator( );
     std::shared_ptr< interpolators::JumpDataLinearInterpolator< double, double > > ut1MinusUtcInterpolator =
             std::make_shared< interpolators::JumpDataLinearInterpolator< double, double > >(
-                    eopReader->getUt1MinusUtcMapInSecondsSinceJ2000( ), 0.5, 1.0 );
+                    eopReader->getUt1MinusUtcMapInSecondsSinceJ2000( ), 0.5, 1.0, interpolators::huntingAlgorithm,
+                    interpolators::use_default_value, 0.0 );
     return std::make_shared< TerrestrialTimeScaleConverter >( ut1MinusUtcInterpolator, shortPeriodUt1CorrectionCalculator );
 }
 

--- a/src/interface/sofa/sofaTimeConversions.cpp
+++ b/src/interface/sofa/sofaTimeConversions.cpp
@@ -121,13 +121,26 @@ double getTDBminusTT( const double ttOrTdbSinceJ2000,
     double tai = basic_astrodynamics::convertTTtoTAI< double >( ttOrTdbSinceJ2000 );
 
     // Calculate current UT1 (by assuming it equal to UTC)
-    double ut1 = static_cast< double >( convertTAItoUTC< double >( tai ) );
+    double ut1 = TUDAT_NAN;
+
+    // Conversion is only valid from 1961 onwards
+    if( static_cast< double >( tai ) / physical_constants::JULIAN_DAY > ( basic_astrodynamics::JULIAN_DAY_OF_UTC_INTRODUCTION - basic_astrodynamics::JULIAN_DAY_ON_J2000 ) )
+    {
+        ut1 = static_cast< double >( convertTAItoUTC< double >( tai ) );
+    }
+    else
+    {
+        // Rough approximation, but suficient for TT<->TDB computation
+        ut1 = tai;
+    }
     double ut1FractionOfDay = std::fmod(
             ( ut1 / physical_constants::JULIAN_DAY ) - static_cast< double >( std::floor( ut1 / physical_constants::JULIAN_DAY ) ) + 0.5,
             1.0 );
 
     // Calculate and return difference (introducing addition approximation if input is in TT, by assuming TDB is equal to TT)
-    return getTDBminusTT( ttOrTdbSinceJ2000, ut1FractionOfDay, stationLongitude, distanceFromSpinAxis, distanceFromEquatorialPlane );
+    double tdbMinusTT = getTDBminusTT( ttOrTdbSinceJ2000, ut1FractionOfDay, stationLongitude, distanceFromSpinAxis, distanceFromEquatorialPlane );
+
+    return tdbMinusTT;
 }
 
 //! Function to calculate difference between TDB and TT.

--- a/src/simulation/environment_setup/createRotationModel.cpp
+++ b/src/simulation/environment_setup/createRotationModel.cpp
@@ -429,12 +429,16 @@ std::shared_ptr< ephemerides::RotationalEphemeris > createRotationModel(
                 // Load polar motion corrections
                 std::shared_ptr< interpolators::LinearInterpolator< double, Eigen::Vector2d > > cipInItrsInterpolator =
                         std::make_shared< interpolators::LinearInterpolator< double, Eigen::Vector2d > >(
-                                eopReader->getCipInItrsMapInSecondsSinceJ2000( ) );
+                                eopReader->getCipInItrsMapInSecondsSinceJ2000( ), interpolators::huntingAlgorithm,
+                                interpolators::use_default_value, std::make_pair( Eigen::Vector2d::Zero( ), Eigen::Vector2d::Zero( ) ) );
+
 
                 // Load nutation corrections
                 std::shared_ptr< interpolators::LinearInterpolator< double, Eigen::Vector2d > > cipInGcrsCorrectionInterpolator =
                         std::make_shared< interpolators::LinearInterpolator< double, Eigen::Vector2d > >(
-                                eopReader->getCipInGcrsCorrectionMapInSecondsSinceJ2000( ) );
+                                eopReader->getCipInGcrsCorrectionMapInSecondsSinceJ2000( ), interpolators::huntingAlgorithm,
+                                interpolators::use_default_value, std::make_pair( Eigen::Vector2d::Zero( ), Eigen::Vector2d::Zero( ) ) );
+
 
                 // Create polar motion correction (sub-diural frequencies) object
                 std::shared_ptr< earth_orientation::ShortPeriodEarthOrientationCorrectionCalculator< Eigen::Vector2d > >
@@ -473,7 +477,8 @@ std::shared_ptr< ephemerides::RotationalEphemeris > createRotationModel(
 
                 std::shared_ptr< interpolators::OneDimensionalInterpolator< double, double > > dailyUtcUt1CorrectionInterpolator =
                         std::make_shared< interpolators::JumpDataLinearInterpolator< double, double > >(
-                                eopReader->getUt1MinusUtcMapInSecondsSinceJ2000( ), 0.5, 1.0 );
+                                eopReader->getUt1MinusUtcMapInSecondsSinceJ2000( ), 0.5, 1.0, interpolators::huntingAlgorithm,
+                                interpolators::use_default_value, 0.0 );
 
                 // Create default time scale converter
                 std::shared_ptr< earth_orientation::TerrestrialTimeScaleConverter > terrestrialTimeScaleConverter =

--- a/tests/src/astro/earth_orientation/unitTestEarthOrientationCalculator.cpp
+++ b/tests/src/astro/earth_orientation/unitTestEarthOrientationCalculator.cpp
@@ -214,6 +214,40 @@ BOOST_AUTO_TEST_CASE( testEarthOrientationAngleFunctionsAgainstSofa )
     BOOST_CHECK_SMALL( std::fabs( era - eraTime ), 1.0E-12 );
 }
 
+BOOST_AUTO_TEST_CASE( testHistoricalEarthRotation )
+{
+    std::shared_ptr< EarthOrientationAnglesCalculator > earthOrientationCalculator = createStandardEarthOrientationCalculator( );
+    basic_astrodynamics::DateTime dateTimePreC04( 1958, 12, 30, 12, 0.0, 0.0 );
+    basic_astrodynamics::DateTime dateTimeStartC04( 1962, 1, 1, 0, 0.0, 0.0 );
+
+    Eigen::Vector2d polarMotionPreC04 = earthOrientationCalculator->getPolarMotionCalculator()->getDailyIersValueInterpolator( )->interpolate( dateTimePreC04.epoch< double >( ) );
+    Eigen::Vector2d polarMotionPostC04 = earthOrientationCalculator->getPolarMotionCalculator()->getDailyIersValueInterpolator( )->interpolate( dateTimeStartC04.epoch< double >( ) );
+
+    Eigen::Vector2d pnCorrectionPreC04 = earthOrientationCalculator->getPrecessionNutationCalculator()->getDailyCorrectionInterpolator()->interpolate( dateTimePreC04.epoch< double >( ) );
+    Eigen::Vector2d pnCorrectionPostC04 = earthOrientationCalculator->getPrecessionNutationCalculator()->getDailyCorrectionInterpolator()->interpolate( dateTimeStartC04.epoch< double >( ) );
+
+    double ut1CorrectionPreC04 = earthOrientationCalculator->getTerrestrialTimeScaleConverter()->getDailyUtcUt1CorrectionInterpolator( )->interpolate( dateTimePreC04.epoch< double >( ) );
+    double ut1CorrectionPostC04 = earthOrientationCalculator->getTerrestrialTimeScaleConverter()->getDailyUtcUt1CorrectionInterpolator( )->interpolate( dateTimeStartC04.epoch< double >( ) );
+
+    // Check if polar motion is zero before c04 file starts
+    BOOST_CHECK_EQUAL( polarMotionPreC04( 0 ) == 0, true );
+    BOOST_CHECK_EQUAL( polarMotionPreC04( 1 ) == 0, true );
+
+    BOOST_CHECK_EQUAL( polarMotionPostC04( 0 ) == 0, false );
+    BOOST_CHECK_EQUAL( polarMotionPostC04( 1 ) == 0, false );
+
+    // Check if pn correction is zero before c04 file starts (also 0 after it starts due to absence of corrections)
+    BOOST_CHECK_EQUAL( pnCorrectionPreC04( 0 ) == 0, true );
+    BOOST_CHECK_EQUAL( pnCorrectionPreC04( 1 ) == 0, true );
+
+    BOOST_CHECK_EQUAL( pnCorrectionPostC04( 0 ) == 0, true );
+    BOOST_CHECK_EQUAL( pnCorrectionPostC04( 1 ) == 0, true );
+
+    // Check if UTC-UT1 is zero before c04 file starts
+    BOOST_CHECK_EQUAL( ut1CorrectionPreC04 == 0, true );
+    BOOST_CHECK_EQUAL( ut1CorrectionPostC04 == 0, false );
+}
+
 BOOST_AUTO_TEST_SUITE_END( )
 
 }  // namespace unit_tests

--- a/tests/src/astro/earth_orientation/unitTestTimeScaleConverter.cpp
+++ b/tests/src/astro/earth_orientation/unitTestTimeScaleConverter.cpp
@@ -373,6 +373,45 @@ BOOST_AUTO_TEST_CASE( testTimeScaleConversionDuringLeapSeconds )
     }
 }
 
+//! Test validity of time scale converter around leap seconds
+BOOST_AUTO_TEST_CASE( testHistoricalDeltaTValues )
+{
+    std::vector< basic_astrodynamics::DateTime > testDateTimes =
+        { basic_astrodynamics::DateTime( 1972, 1, 1, 0, 0, 0.0 ),
+          basic_astrodynamics::DateTime( 1962, 1, 1, 0, 0, 60.0 ),
+          basic_astrodynamics::DateTime( 1961, 12, 31, 23, 0, 0.0 ) };
+
+    std::vector< double > referenceUTDifference =
+        { -0.0454859,
+          0.0326338,
+          0.0 };
+
+    std::shared_ptr< TerrestrialTimeScaleConverter > timeScaleConverter =
+        createStandardEarthOrientationCalculator( )->getTerrestrialTimeScaleConverter( );
+
+    for( unsigned int i = 0; i < testDateTimes.size( ); i++ )
+    {
+        double currentUt1 = timeScaleConverter->getCurrentTime( tdb_scale, ut1_scale, testDateTimes.at( i ).epoch< double >( ) );
+        double currentUtc = timeScaleConverter->getCurrentTime( tdb_scale, utc_scale, testDateTimes.at( i ).epoch< double >( ) );
+        BOOST_CHECK_SMALL( ( currentUt1-currentUtc ) - referenceUTDifference.at( i ), 1.0E-4 );
+    }
+
+    double switchEpoch = ( JULIAN_DAY_OF_EOP_INTRODUCTION - basic_astrodynamics::JULIAN_DAY_ON_J2000 ) * physical_constants::JULIAN_DAY;
+    basic_astrodynamics::DateTime dateTimeJustAfterSwitch = basic_astrodynamics::DateTime::fromTime( switchEpoch + 1.0 );
+
+    double currentUt1 = timeScaleConverter->getCurrentTime( tai_scale, ut1_scale, dateTimeJustAfterSwitch.epoch< double >( ) );
+    double currentUtc = timeScaleConverter->getCurrentTime( tai_scale, utc_scale, dateTimeJustAfterSwitch.epoch< double >( ) );
+    double expectedUtDifference = 0.0326338 + 1.5314e-05; // First entrt from C04 file plus short-period correction
+    BOOST_CHECK_SMALL( expectedUtDifference - ( currentUt1 - currentUtc ), 1.0E-6 );
+
+    basic_astrodynamics::DateTime dateTimeJustBeforeSwitch = basic_astrodynamics::DateTime::fromTime( switchEpoch - 1.0 );
+
+    currentUt1 = timeScaleConverter->getCurrentTime( tai_scale, ut1_scale, dateTimeJustBeforeSwitch.epoch< double >( ) );
+    currentUtc = timeScaleConverter->getCurrentTime( tai_scale, utc_scale, dateTimeJustBeforeSwitch.epoch< double >( ) );
+    BOOST_CHECK_EQUAL( currentUt1, currentUtc );
+
+}
+
 BOOST_AUTO_TEST_SUITE_END( )
 
 }  // namespace unit_tests


### PR DESCRIPTION
First version of code to address https://github.com/tudat-team/tudat/issues/350

* Adds a check to the sofa interface in the TDB-TT computation to not call the Delta AT (UTC-UT1) calculation before UTC was defined (1-1-1961). If computing TDB-TT before this date. the value of UT1 is set equal to TAI. This is a very rough approximation, but since the UT1 impact on the TDB-TT computation is very small, and it only applies before 1961, I think it's fine.
* The IERS C04 files with Earth orientation parameters only starts on 1-1-1962. If data is requested before these epochs, the EOPs are set to 0. This could be enhanced with the C01 files, which have polar motion values going back much earlier (mid-19th century), but for now there is no need for these
* Adds a data file (in resources) based on https://webspace.science.uu.nl/~gent0113/deltat/deltat.htm with values of TT-UT1 going back to the year 1620. These are used before 1-1-1962, where the C04 file does not provide UTC-UT1. In this period, we set UTC=UT1. This a simplification (and before 1-1-1960 untrue since UTC was undefined). But, for applications that rely on UTC being approximately equal to other time scales (which, before 1960 is the only use for having a value of 'UTC', I'd say), this seems fine.