### PR TITLE
Drag/Side/Lift direction scaling coefficients

### DIFF
--- a/include/tudat/astro/aerodynamics/aerodynamicAcceleration.h
+++ b/include/tudat/astro/aerodynamics/aerodynamicAcceleration.h
@@ -73,7 +73,8 @@ public:
                              const std::function< double( ) > currentMass ):
                              flightConditions_( flightConditions ),
                              currentMass_( currentMass ),
-                             dragComponentScaling_( 1.0 ), liftComponentScaling_( 1.0 ), 
+                             dragComponentScaling_( 1.0 ), 
+                             liftComponentScaling_( 1.0 ), 
                              sideComponentScaling_( 1.0 )
     {
         coefficientInterface_ = flightConditions_->getAerodynamicCoefficientInterface( );
@@ -106,11 +107,11 @@ public:
                                                                    coefficientInterface_->getReferenceArea( ),
                                                                    currentForceCoefficients_,
                                                                    currentMass_( ) );
-            scaledAerodynamicAcceleration( );
+            scaleAerodynamicAcceleration( );
         }
     }
 
-    void scaledAerodynamicAcceleration( )
+    void scaleAerodynamicAcceleration( )
     {
        currentAcceleration_ = currentUnscaledAcceleration_;
        if( isScalingModelSet_ )

--- a/include/tudat/astro/aerodynamics/aerodynamicAcceleration.h
+++ b/include/tudat/astro/aerodynamics/aerodynamicAcceleration.h
@@ -116,7 +116,7 @@ public:
        currentAcceleration_ = currentUnscaledAcceleration_;
 
        currentUnscaledAccelerationInAerodynamicFrame_ = flightConditions_->getAerodynamicAngleCalculator( )->getRotationQuaternionBetweenFrames(
-                reference_frames::inertial_frame, aerodynamicCompleteCoefficientFrame_ ) * currentAcceleration_;
+                reference_frames::inertial_frame, reference_frames::aerodynamic_frame ) * currentAcceleration_;
                 
        if( isScalingModelSet_ )
        {
@@ -124,7 +124,7 @@ public:
             currentAccelerationInAerodynamicFrame_( 1 ) = currentUnscaledAccelerationInAerodynamicFrame_( 1 ) * sideComponentScaling_;
             currentAccelerationInAerodynamicFrame_( 2 ) = currentUnscaledAccelerationInAerodynamicFrame_( 2 ) * liftComponentScaling_;
             currentAcceleration_ = flightConditions_->getAerodynamicAngleCalculator( )->getRotationQuaternionBetweenFrames(
-                aerodynamicCompleteCoefficientFrame_, reference_frames::inertial_frame ) * currentAccelerationInAerodynamicFrame_;
+                 reference_frames::aerodynamic_frame, reference_frames::inertial_frame ) * currentAccelerationInAerodynamicFrame_;
        }
     }
 
@@ -156,16 +156,19 @@ public:
 
     void setDragComponentScaling( double dragComponentScaling )
     {
+        enableScaling( );
         dragComponentScaling_ = dragComponentScaling;
     }
 
     void setSideComponentScaling( double sideComponentScaling )
     {
+        enableScaling( );
         sideComponentScaling_ = sideComponentScaling;
     }
 
     void setLiftComponentScaling( double liftComponentScaling )
     {
+        enableScaling( );
         liftComponentScaling_ = liftComponentScaling;
     }
 

--- a/include/tudat/astro/aerodynamics/aerodynamicAcceleration.h
+++ b/include/tudat/astro/aerodynamics/aerodynamicAcceleration.h
@@ -114,13 +114,15 @@ public:
     void scaleAerodynamicAcceleration( )
     {
        currentAcceleration_ = currentUnscaledAcceleration_;
+
+       currentUnscaledAccelerationInAerodynamicFrame_ = flightConditions_->getAerodynamicAngleCalculator( )->getRotationQuaternionBetweenFrames(
+                reference_frames::inertial_frame, aerodynamicCompleteCoefficientFrame_ ) * currentAcceleration_;
+                
        if( isScalingModelSet_ )
        {
-            currentAccelerationInAerodynamicFrame_ = flightConditions_->getAerodynamicAngleCalculator( )->getRotationQuaternionBetweenFrames(
-                reference_frames::inertial_frame, aerodynamicCompleteCoefficientFrame_ ) * currentAcceleration_;
-            currentAccelerationInAerodynamicFrame_( 0 ) *= dragComponentScaling_;
-            currentAccelerationInAerodynamicFrame_( 1 ) *= sideComponentScaling_;
-            currentAccelerationInAerodynamicFrame_( 2 ) *= liftComponentScaling_;
+            currentAccelerationInAerodynamicFrame_( 0 ) = currentUnscaledAccelerationInAerodynamicFrame_( 0 ) * dragComponentScaling_;
+            currentAccelerationInAerodynamicFrame_( 1 ) = currentUnscaledAccelerationInAerodynamicFrame_( 1 ) * sideComponentScaling_;
+            currentAccelerationInAerodynamicFrame_( 2 ) = currentUnscaledAccelerationInAerodynamicFrame_( 2 ) * liftComponentScaling_;
             currentAcceleration_ = flightConditions_->getAerodynamicAngleCalculator( )->getRotationQuaternionBetweenFrames(
                 aerodynamicCompleteCoefficientFrame_, reference_frames::inertial_frame ) * currentAccelerationInAerodynamicFrame_;
        }
@@ -187,6 +189,11 @@ public:
         return currentUnscaledAcceleration_;
     }
 
+    Eigen::Vector3d getCurrentUnscaledAccelerationInAerodynamicFrame( )
+    {
+        return currentUnscaledAccelerationInAerodynamicFrame_;
+    }
+
 
 private:
 
@@ -206,6 +213,8 @@ private:
 
     // new acceleration scaling
     Eigen::Vector3d currentUnscaledAcceleration_;
+
+    Eigen::Vector3d currentUnscaledAccelerationInAerodynamicFrame_;
 
     Eigen::Vector3d currentAccelerationInAerodynamicFrame_;
 

--- a/include/tudat/astro/aerodynamics/aerodynamicAcceleration.h
+++ b/include/tudat/astro/aerodynamics/aerodynamicAcceleration.h
@@ -72,7 +72,9 @@ public:
     AerodynamicAcceleration( const std::shared_ptr< AtmosphericFlightConditions > flightConditions,
                              const std::function< double( ) > currentMass ):
                              flightConditions_( flightConditions ),
-                             currentMass_( currentMass )
+                             currentMass_( currentMass ),
+                             dragComponentScaling_( 1.0 ), liftComponentScaling_( 1.0 ), 
+                             sideComponentScaling_( 1.0 )
     {
         coefficientInterface_ = flightConditions_->getAerodynamicCoefficientInterface( );
         aerodynamicCoefficientFrame_ = coefficientInterface_->getForceCoefficientsFrame( );
@@ -100,11 +102,27 @@ public:
             currentForceCoefficients_ = coefficientMultiplier_ *  ( flightConditions_->getAerodynamicAngleCalculator( )->getRotationQuaternionBetweenFrames(
                 aerodynamicCompleteCoefficientFrame_, reference_frames::inertial_frame ) * currentForceCoefficients_ );
 
-            currentAcceleration_ = computeAerodynamicAcceleration( flightConditions_->getCurrentDynamicPressure( ),
+            currentUnscaledAcceleration_ = computeAerodynamicAcceleration( flightConditions_->getCurrentDynamicPressure( ),
                                                                    coefficientInterface_->getReferenceArea( ),
                                                                    currentForceCoefficients_,
                                                                    currentMass_( ) );
+            scaledAerodynamicAcceleration( );
         }
+    }
+
+    void scaledAerodynamicAcceleration( )
+    {
+       currentAcceleration_ = currentUnscaledAcceleration_;
+       if( isScalingModelSet_ )
+       {
+            currentAccelerationInAerodynamicFrame_ = flightConditions_->getAerodynamicAngleCalculator( )->getRotationQuaternionBetweenFrames(
+                reference_frames::inertial_frame, aerodynamicCompleteCoefficientFrame_ ) * currentAcceleration_;
+            currentAccelerationInAerodynamicFrame_( 0 ) *= dragComponentScaling_;
+            currentAccelerationInAerodynamicFrame_( 1 ) *= sideComponentScaling_;
+            currentAccelerationInAerodynamicFrame_( 2 ) *= liftComponentScaling_;
+            currentAcceleration_ = flightConditions_->getAerodynamicAngleCalculator( )->getRotationQuaternionBetweenFrames(
+                aerodynamicCompleteCoefficientFrame_, reference_frames::inertial_frame ) * currentAccelerationInAerodynamicFrame_;
+       }
     }
 
     std::shared_ptr< AtmosphericFlightConditions > getFlightConditions( ) const
@@ -127,6 +145,48 @@ public:
     {
         return currentMass_( );
     }
+
+    void enableScaling( )
+    {
+        isScalingModelSet_ = true;
+    }
+
+    void setDragComponentScaling( double dragComponentScaling )
+    {
+        dragComponentScaling_ = dragComponentScaling;
+    }
+
+    void setSideComponentScaling( double sideComponentScaling )
+    {
+        sideComponentScaling_ = sideComponentScaling;
+    }
+
+    void setLiftComponentScaling( double liftComponentScaling )
+    {
+        liftComponentScaling_ = liftComponentScaling;
+    }
+
+    double getDragComponentScaling( )
+    {
+        return dragComponentScaling_;
+    }
+
+    double getSideComponentScaling( )
+    {
+        return sideComponentScaling_;
+    }
+    
+    double getLiftComponentScaling( )
+    {
+        return liftComponentScaling_;
+    }
+
+    Eigen::Vector3d getCurrentUnscaledAcceleration( )
+    {
+        return currentUnscaledAcceleration_;
+    }
+
+
 private:
 
     std::shared_ptr< AtmosphericFlightConditions > flightConditions_;
@@ -142,6 +202,19 @@ private:
     AerodynamicCoefficientFrames aerodynamicCoefficientFrame_;
 
     reference_frames::AerodynamicsReferenceFrames aerodynamicCompleteCoefficientFrame_;
+
+    // new acceleration scaling
+    Eigen::Vector3d currentUnscaledAcceleration_;
+
+    Eigen::Vector3d currentAccelerationInAerodynamicFrame_;
+
+    bool isScalingModelSet_;
+
+    double dragComponentScaling_;
+
+    double liftComponentScaling_;
+
+    double sideComponentScaling_;
 
 };
 

--- a/include/tudat/astro/orbit_determination/acceleration_partials/aerodynamicAccelerationPartial.h
+++ b/include/tudat/astro/orbit_determination/acceleration_partials/aerodynamicAccelerationPartial.h
@@ -24,6 +24,18 @@ namespace tudat
 namespace acceleration_partials
 {
 
+void computeAerodynamicAccelerationWrtDragComponent(
+    const std::shared_ptr< aerodynamics::AerodynamicAcceleration > accelerationModel, 
+    Eigen::MatrixXd& partial );
+
+void computeAerodynamicAccelerationWrtSideComponent(
+    const std::shared_ptr< aerodynamics::AerodynamicAcceleration > accelerationModel, 
+    Eigen::MatrixXd& partial );
+
+void computeAerodynamicAccelerationWrtLiftComponent(
+    const std::shared_ptr< aerodynamics::AerodynamicAcceleration > accelerationModel, 
+    Eigen::MatrixXd& partial );
+
 //! Class to calculate the partials of the aerodynamic acceleration w.r.t. parameters and states.
 /*!
  * Class to calculate the partials of the aerodynamic acceleration w.r.t. parameters and states. Note that the state partials
@@ -206,26 +218,8 @@ public:
      *  \param parameter Parameter w.r.t. which partial is to be taken.
      *  \return Pair of parameter partial function and number of columns in partial (0 for no dependency, 1 otherwise).
      */
-    std::pair< std::function< void( Eigen::MatrixXd& ) >, int > getParameterPartialFunction(
-            std::shared_ptr< estimatable_parameters::EstimatableParameter< double > > parameter )
-    {
-        std::function< void( Eigen::MatrixXd& ) > partialFunction;
-        int numberOfColumns = 0;
-
-        // Check if parameter is gravitational parameter.
-        if( parameter->getParameterName( ).first == estimatable_parameters::constant_drag_coefficient )
-        {
-            // Check if parameter body is accelerated body,
-            if( parameter->getParameterName( ).second.first == acceleratedBody_ )
-            {
-                partialFunction = std::bind(
-                        &AerodynamicAccelerationPartial::computeAccelerationPartialWrtCurrentDragCoefficient, this, std::placeholders::_1 );
-                numberOfColumns = 1;
-            }
-        }
-
-        return std::make_pair( partialFunction, numberOfColumns );
-    }
+    std::pair< std::function< void( Eigen::MatrixXd& ) >, int > AerodynamicAccelerationPartial::getParameterPartialFunction(
+            std::shared_ptr< estimatable_parameters::EstimatableParameter< double > > parameter );
 
     //! Function for setting up and retrieving a function returning a partial w.r.t. a vector parameter.
     /*!

--- a/include/tudat/astro/orbit_determination/acceleration_partials/aerodynamicAccelerationPartial.h
+++ b/include/tudat/astro/orbit_determination/acceleration_partials/aerodynamicAccelerationPartial.h
@@ -24,18 +24,6 @@ namespace tudat
 namespace acceleration_partials
 {
 
-void computeAerodynamicAccelerationWrtDragComponent(
-    const std::shared_ptr< aerodynamics::AerodynamicAcceleration > accelerationModel, 
-    Eigen::MatrixXd& partial );
-
-void computeAerodynamicAccelerationWrtSideComponent(
-    const std::shared_ptr< aerodynamics::AerodynamicAcceleration > accelerationModel, 
-    Eigen::MatrixXd& partial );
-
-void computeAerodynamicAccelerationWrtLiftComponent(
-    const std::shared_ptr< aerodynamics::AerodynamicAcceleration > accelerationModel, 
-    Eigen::MatrixXd& partial );
-
 //! Class to calculate the partials of the aerodynamic acceleration w.r.t. parameters and states.
 /*!
  * Class to calculate the partials of the aerodynamic acceleration w.r.t. parameters and states. Note that the state partials
@@ -67,6 +55,16 @@ public:
     {
         bodyStatePerturbations_ << 10.0, 10.0, 10.0, 1.0E-2, 1.0E-2, 1.0E-2;
     }
+
+    void computeAerodynamicAccelerationWrtDragComponent(
+        Eigen::MatrixXd& partial );
+
+    void computeAerodynamicAccelerationWrtSideComponent(
+        Eigen::MatrixXd& partial );
+
+    void computeAerodynamicAccelerationWrtLiftComponent(
+        Eigen::MatrixXd& partial );
+
 
     //! Function for calculating the partial of the acceleration w.r.t. the position of body undergoing acceleration..
     /*!

--- a/include/tudat/astro/orbit_determination/acceleration_partials/aerodynamicAccelerationPartial.h
+++ b/include/tudat/astro/orbit_determination/acceleration_partials/aerodynamicAccelerationPartial.h
@@ -218,7 +218,7 @@ public:
      *  \param parameter Parameter w.r.t. which partial is to be taken.
      *  \return Pair of parameter partial function and number of columns in partial (0 for no dependency, 1 otherwise).
      */
-    std::pair< std::function< void( Eigen::MatrixXd& ) >, int > AerodynamicAccelerationPartial::getParameterPartialFunction(
+    std::pair< std::function< void( Eigen::MatrixXd& ) >, int > getParameterPartialFunction(
             std::shared_ptr< estimatable_parameters::EstimatableParameter< double > > parameter );
 
     //! Function for setting up and retrieving a function returning a partial w.r.t. a vector parameter.

--- a/include/tudat/astro/orbit_determination/estimatable_parameters/aerodynamicScalingCoefficient.h
+++ b/include/tudat/astro/orbit_determination/estimatable_parameters/aerodynamicScalingCoefficient.h
@@ -43,15 +43,15 @@ public:
     {
         if( parameterName_.first == drag_component_scaling_factor )
         {
-            return radiationPressureAcceleration_->getDragComponentScaling( );
+            return aerodynamicAcceleration_->getDragComponentScaling( );
         }
         else if( parameterName_.first == side_component_scaling_factor )
         {
-            return radiationPressureAcceleration_->getSideComponentScaling( );
+            return aerodynamicAcceleration_->getSideComponentScaling( );
         }
         else if( parameterName_.first == lift_component_scaling_factor )
         {
-            return radiationPressureAcceleration_->getLiftComponentScaling( );
+            return aerodynamicAcceleration_->getLiftComponentScaling( );
         }
         else
         {
@@ -64,15 +64,15 @@ public:
     {
         if( parameterName_.first == drag_component_scaling_factor )
         {
-            return radiationPressureAcceleration_->setDragComponentScaling( parameterValue );
+            return aerodynamicAcceleration_->setDragComponentScaling( parameterValue );
         }
         else if( parameterName_.first == side_component_scaling_factor )
         {
-            return radiationPressureAcceleration_->setSideComponentScaling( parameterValue );
+            return aerodynamicAcceleration_->setSideComponentScaling( parameterValue );
         }
         else if( parameterName_.first == lift_component_scaling_factor )
         {
-            return radiationPressureAcceleration_->setLiftComponentScaling( parameterValue );
+            return aerodynamicAcceleration_->setLiftComponentScaling( parameterValue );
         }
         else
         {

--- a/include/tudat/astro/orbit_determination/estimatable_parameters/aerodynamicScalingCoefficient.h
+++ b/include/tudat/astro/orbit_determination/estimatable_parameters/aerodynamicScalingCoefficient.h
@@ -1,0 +1,97 @@
+/*    Copyright (c) 2010-2019, Delft University of Technology
+ *    All rigths reserved
+ *
+ *    This file is part of the Tudat. Redistribution and use in source and
+ *    binary forms, with or without modification, are permitted exclusively
+ *    under the terms of the Modified BSD license. You should have received
+ *    a copy of the license with this file. If not, please or visit:
+ *    http://tudat.tudelft.nl/LICENSE.
+ */
+
+#ifndef TUDAT_AERODYNAMICSCALINGCOEFFICIENT_H
+#define TUDAT_AERODYNAMICSCALINGCOEFFICIENT_H
+
+#include "tudat/astro/orbit_determination/estimatable_parameters/estimatableParameter.h"
+
+namespace tudat
+{
+
+namespace estimatable_parameters
+{
+
+class AerodynamicScalingFactor : public EstimatableParameter< double >
+{
+public:
+    AerodynamicScalingFactor( const std::shared_ptr< aerodynamics::AerodynamicAcceleration > aerodynamicAcceleration,
+                              const EstimatebleParametersEnum parameterType,
+                              const std::string& associatedBody ):
+        EstimatableParameter< double >( parameterType, associatedBody ),
+        aerodynamicAcceleration_( aerodynamicAcceleration )
+    {
+        if( ( parameterType != drag_component_scaling_factor ) &&
+            ( parameterType != side_component_scaling_factor ) && 
+            ( parameterType != lift_component_scaling_factor ) )
+        {
+            throw std::runtime_error( "Error when creating aerodynamic scaling parameter, type is inconsistent: " +
+                                      std::to_string( parameterType ) );
+        }
+    }
+
+    ~AerodynamicScalingFactor( ) { }
+
+    double getParameterValue( )
+    {
+        if( parameterName_.first == drag_component_scaling_factor )
+        {
+            return radiationPressureAcceleration_->getDragComponentScaling( );
+        }
+        else if( parameterName_.first == side_component_scaling_factor )
+        {
+            return radiationPressureAcceleration_->getSideComponentScaling( );
+        }
+        else if( parameterName_.first == lift_component_scaling_factor )
+        {
+            return radiationPressureAcceleration_->getLiftComponentScaling( );
+        }
+        else
+        {
+            throw std::runtime_error( "Error when getting aerodynamic scaling parameter, type is inconsistent: " +
+                                      std::to_string( parameterName_.first ) );
+        }
+    }
+
+    void setParameterValue( double parameterValue )
+    {
+        if( parameterName_.first == drag_component_scaling_factor )
+        {
+            return radiationPressureAcceleration_->setDragComponentScaling( parameterValue );
+        }
+        else if( parameterName_.first == side_component_scaling_factor )
+        {
+            return radiationPressureAcceleration_->setSideComponentScaling( parameterValue );
+        }
+        else if( parameterName_.first == lift_component_scaling_factor )
+        {
+            return radiationPressureAcceleration_->setLiftComponentScaling( parameterValue );
+        }
+        else
+        {
+            throw std::runtime_error( "Error when setting aerodynamic scaling parameter, type is inconsistent: " +
+                                      std::to_string( parameterName_.first ) );
+        }
+    }
+
+    int getParameterSize( )
+    {
+        return 1;
+    }
+
+protected:
+    std::shared_ptr< aerodynamics::AerodynamicAcceleration > aerodynamicAcceleration_;
+};
+
+}  // namespace estimatable_parameters
+
+}  // namespace tudat
+
+#endif  // TUDAT_AERODYNAMICSCALINGCOEFFICIENT_H

--- a/include/tudat/astro/orbit_determination/estimatable_parameters/estimatableParameter.h
+++ b/include/tudat/astro/orbit_determination/estimatable_parameters/estimatableParameter.h
@@ -87,7 +87,10 @@ enum EstimatebleParametersEnum {
     mode_coupled_tidal_love_numbers,
     nominal_rotation_pole_position,
     rotation_pole_position_rate,
-    rotation_longitudinal_libration_terms
+    rotation_longitudinal_libration_terms,
+    drag_component_scaling_factor,
+    side_component_scaling_factor,
+    lift_component_scaling_factor,
 
 };
 

--- a/include/tudat/simulation/environment_setup/createAerodynamicCoefficientInterface.h
+++ b/include/tudat/simulation/environment_setup/createAerodynamicCoefficientInterface.h
@@ -493,8 +493,6 @@ int maximumNumberOfPixels_;
 
 bool onlyDrag_;
 
-aerodynamics::AerodynamicCoefficientFrames coefficientFrame_;
-
 // constant force coefficient (variable cross-section)
 Eigen::Vector3d constantForceCoefficient_;
 

--- a/include/tudat/simulation/estimation_setup/createEstimatableParameters.h
+++ b/include/tudat/simulation/estimation_setup/createEstimatableParameters.h
@@ -282,16 +282,16 @@ std::vector< std::shared_ptr< basic_astrodynamics::AccelerationModel3d > > getAc
                             accelerationModelListToCheck = accelerationModelMap.at( parameterSettings->parameterType_.second.first );
                     for( const auto& it : accelerationModelListToCheck )
                     {
-                        if( basic_astrodynamics::getAccelerationModelType( it.second ) == basic_astrodynamics::aerodynamic )
+                        if( basic_astrodynamics::getAccelerationModelType( it ) == basic_astrodynamics::aerodynamic )
                         {
-                            accelerationModelList.push_back( it.second );
+                            accelerationModelList.push_back( it );
                         }
                     }
                 }
                 else
                 {
                     throw std::runtime_error( "Error, trying to setup aerodynamic scaling coefficient for body " + 
-                        parameterSettings->parameterType_.second.first + " but no aerodynamic acceleration is defined." )
+                        parameterSettings->parameterType_.second.first + " but no aerodynamic acceleration is defined." );
                 }
             }
             break;

--- a/include/tudat/simulation/estimation_setup/createEstimatableParameters.h
+++ b/include/tudat/simulation/estimation_setup/createEstimatableParameters.h
@@ -278,11 +278,12 @@ std::vector< std::shared_ptr< basic_astrodynamics::AccelerationModel3d > > getAc
                 if( accelerationModelMap.count( parameterSettings->parameterType_.second.first ) != 0 )
                 {
                     // Retrieve acceleration model.
-                    std::map< std::string, std::vector< std::shared_ptr< basic_astrodynamics::AccelerationModel< Eigen::Vector3d > > > >
-                            accelerationModelListToCheck = accelerationModelMap.at( parameterSettings->parameterType_.second.first );
+                    basic_astrodynamics::SingleBodyAccelerationMap accelerationModelListToCheck = accelerationModelMap.at( 
+                        parameterSettings->parameterType_.second.first );
+                        
                     for( const auto& it : accelerationModelListToCheck )
                     {
-                        for ( const auto accelerationModel : it.second )
+                        for ( const auto& accelerationModel : it.second )
                         {
                             if( basic_astrodynamics::getAccelerationModelType( accelerationModel ) == basic_astrodynamics::aerodynamic )
                             {

--- a/include/tudat/simulation/estimation_setup/createEstimatableParameters.h
+++ b/include/tudat/simulation/estimation_setup/createEstimatableParameters.h
@@ -52,6 +52,7 @@
 #include "tudat/simulation/propagation_setup/dynamicsSimulator.h"
 #include "tudat/simulation/environment_setup/body.h"
 #include "tudat/astro/orbit_determination/estimatable_parameters/specularDiffuseReflectivity.h"
+#include "tudat/astro/orbit_determination/estimatable_parameters/aerodynamicScalingCoefficient.h"
 
 namespace tudat
 {
@@ -261,6 +262,36 @@ std::vector< std::shared_ptr< basic_astrodynamics::AccelerationModel3d > > getAc
                             accelerationModelList.push_back( accelerationModelListToCheck[ i ] );
                         }
                     }
+                }
+            }
+            break;
+        }
+        case drag_component_scaling_factor:
+        case side_component_scaling_factor:
+        case lift_component_scaling_factor: {
+            if( parameterSettings == nullptr )
+            {
+                throw std::runtime_error( "Error, expected aerodynamic scaling factor parameter settings." );
+            }
+            else
+            {
+                if( accelerationModelMap.count( parameterSettings->parameterType_.second.first ) != 0 )
+                {
+                    // Retrieve acceleration model.
+                    std::vector< std::shared_ptr< basic_astrodynamics::AccelerationModel< Eigen::Vector3d > > >
+                            accelerationModelListToCheck = accelerationModelMap.at( parameterSettings->parameterType_.second.first );
+                    for( const auto& it : accelerationModelListToCheck )
+                    {
+                        if( basic_astrodynamics::getAccelerationModelType( it.second ) == basic_astrodynamics::aerodynamic )
+                        {
+                            accelerationModelList.push_back( it.second );
+                        }
+                    }
+                }
+                else
+                {
+                    throw std::runtime_error( "Error, trying to setup aerodynamic scaling coefficient for body " + 
+                        parameterSettings->parameterType_.second.first + " but no aerodynamic acceleration is defined." )
                 }
             }
             break;
@@ -940,6 +971,20 @@ std::shared_ptr< estimatable_parameters::EstimatableParameter< double > > create
                                     currentBody->getAerodynamicCoefficientInterface( ) ),
                             currentBodyName );
                 }
+                break;
+            }
+            case drag_component_scaling_factor:
+            case side_component_scaling_factor:
+            case lift_component_scaling_factor: {
+
+                std::vector< std::shared_ptr< basic_astrodynamics::AccelerationModel3d > > associatedAccelerationModels =
+                        getAccelerationModelsListForParametersFromBase< InitialStateParameterType, TimeType >( propagatorSettings,
+                                                                                                               doubleParameterName );
+                                                                                                    
+                doubleParameterToEstimate =
+                        std::make_shared< AerodynamicScalingFactor >( associatedAccelerationModels.at( 0 ),
+                                                                      doubleParameterName->parameterType_.first,
+                                                                      currentBodyName );
                 break;
             }
             case ppn_parameter_gamma: {

--- a/include/tudat/simulation/estimation_setup/createEstimatableParameters.h
+++ b/include/tudat/simulation/estimation_setup/createEstimatableParameters.h
@@ -282,9 +282,9 @@ std::vector< std::shared_ptr< basic_astrodynamics::AccelerationModel3d > > getAc
                             accelerationModelListToCheck = accelerationModelMap.at( parameterSettings->parameterType_.second.first );
                     for( const auto& it : accelerationModelListToCheck )
                     {
-                        if( basic_astrodynamics::getAccelerationModelType( it ) == basic_astrodynamics::aerodynamic )
+                        if( basic_astrodynamics::getAccelerationModelType( it.second ) == basic_astrodynamics::aerodynamic )
                         {
-                            accelerationModelList.push_back( it );
+                            accelerationModelList.push_back( it.second );
                         }
                     }
                 }

--- a/include/tudat/simulation/estimation_setup/createEstimatableParameters.h
+++ b/include/tudat/simulation/estimation_setup/createEstimatableParameters.h
@@ -282,10 +282,13 @@ std::vector< std::shared_ptr< basic_astrodynamics::AccelerationModel3d > > getAc
                             accelerationModelListToCheck = accelerationModelMap.at( parameterSettings->parameterType_.second.first );
                     for( const auto& it : accelerationModelListToCheck )
                     {
-                        if( basic_astrodynamics::getAccelerationModelType( it.second ) == basic_astrodynamics::aerodynamic )
+                        for ( const auto accelerationModel : it.second )
                         {
-                            accelerationModelList.push_back( it.second );
-                        }
+                            if( basic_astrodynamics::getAccelerationModelType( accelerationModel ) == basic_astrodynamics::aerodynamic )
+                            {
+                                accelerationModelList.push_back( accelerationModel );
+                            }
+                        }  
                     }
                 }
                 else

--- a/include/tudat/simulation/estimation_setup/createEstimatableParameters.h
+++ b/include/tudat/simulation/estimation_setup/createEstimatableParameters.h
@@ -278,7 +278,7 @@ std::vector< std::shared_ptr< basic_astrodynamics::AccelerationModel3d > > getAc
                 if( accelerationModelMap.count( parameterSettings->parameterType_.second.first ) != 0 )
                 {
                     // Retrieve acceleration model.
-                    std::vector< std::shared_ptr< basic_astrodynamics::AccelerationModel< Eigen::Vector3d > > >
+                    std::map< std::string, std::vector< std::shared_ptr< basic_astrodynamics::AccelerationModel< Eigen::Vector3d > > > >
                             accelerationModelListToCheck = accelerationModelMap.at( parameterSettings->parameterType_.second.first );
                     for( const auto& it : accelerationModelListToCheck )
                     {
@@ -982,9 +982,10 @@ std::shared_ptr< estimatable_parameters::EstimatableParameter< double > > create
                                                                                                                doubleParameterName );
                                                                                                     
                 doubleParameterToEstimate =
-                        std::make_shared< AerodynamicScalingFactor >( associatedAccelerationModels.at( 0 ),
-                                                                      doubleParameterName->parameterType_.first,
-                                                                      currentBodyName );
+                        std::make_shared< AerodynamicScalingFactor >( 
+                            std::dynamic_pointer_cast< aerodynamics::AerodynamicAcceleration>( associatedAccelerationModels.at( 0 ) ),
+                            doubleParameterName->parameterType_.first,
+                            currentBodyName );
                 break;
             }
             case ppn_parameter_gamma: {

--- a/include/tudat/simulation/estimation_setup/estimatableParameterSettings.h
+++ b/include/tudat/simulation/estimation_setup/estimatableParameterSettings.h
@@ -1115,6 +1115,21 @@ inline std::shared_ptr< EstimatableParameterSettings > constantDragCoefficient( 
     return std::make_shared< EstimatableParameterSettings >( bodyName, constant_drag_coefficient );
 }
 
+inline std::shared_ptr< EstimatableParameterSettings > dragComponentScaling( const std::string bodyName )
+{
+    return std::make_shared< EstimatableParameterSettings >( bodyName, drag_component_scaling_factor );
+}
+
+inline std::shared_ptr< EstimatableParameterSettings > sideComponentScaling( const std::string bodyName )
+{
+    return std::make_shared< EstimatableParameterSettings >( bodyName, side_component_scaling_factor );
+}
+
+inline std::shared_ptr< EstimatableParameterSettings > liftComponentScaling( const std::string bodyName )
+{
+    return std::make_shared< EstimatableParameterSettings >( bodyName,lift_component_scaling_factor );
+}
+
 inline std::shared_ptr< EstimatableParameterSettings > radiationPressureCoefficient( const std::string bodyName )
 {
     return std::make_shared< EstimatableParameterSettings >( bodyName, radiation_pressure_coefficient );

--- a/src/astro/orbit_determination/acceleration_partials/aerodynamicAccelerationPartial.cpp
+++ b/src/astro/orbit_determination/acceleration_partials/aerodynamicAccelerationPartial.cpp
@@ -24,7 +24,7 @@ void AerodynamicAccelerationPartial::computeAerodynamicAccelerationWrtDragCompon
                         reference_frames::aerodynamic_frame, reference_frames::inertial_frame );
 
     Eigen::Vector3d currentDragComponentPartial = Eigen::Vector3d::Zero( );
-    Eigen::Vector3d unscaledAcceleration = accelerationModel_->getCurrentUnscaledAcceleration( );
+    Eigen::Vector3d unscaledAcceleration = aerodynamicAcceleration_->getCurrentUnscaledAcceleration( );
     currentDragComponentPartial( 0 ) = unscaledAcceleration( 0 );
     partial = rotationToInertialFrame * currentDragComponentPartial;
 };
@@ -37,7 +37,7 @@ void AerodynamicAccelerationPartial::computeAerodynamicAccelerationWrtSideCompon
                         reference_frames::aerodynamic_frame, reference_frames::inertial_frame );
 
     Eigen::Vector3d currentSideComponentPartial = Eigen::Vector3d::Zero( );
-    Eigen::Vector3d unscaledAcceleration = accelerationModel_->getCurrentUnscaledAcceleration( );
+    Eigen::Vector3d unscaledAcceleration = aerodynamicAcceleration_->getCurrentUnscaledAcceleration( );
     currentSideComponentPartial( 1 ) = unscaledAcceleration( 1 );
     partial = rotationToInertialFrame * currentSideComponentPartial;
 };
@@ -50,7 +50,7 @@ void AerodynamicAccelerationPartial::computeAerodynamicAccelerationWrtLiftCompon
                         reference_frames::aerodynamic_frame, reference_frames::inertial_frame );
 
     Eigen::Vector3d currentLiftComponentPartial = Eigen::Vector3d::Zero( );
-    Eigen::Vector3d unscaledAcceleration = accelerationModel_->getCurrentUnscaledAcceleration( );
+    Eigen::Vector3d unscaledAcceleration = aerodynamicAcceleration_->getCurrentUnscaledAcceleration( );
     currentLiftComponentPartial( 2 ) = unscaledAcceleration( 2 );
     partial = rotationToInertialFrame * currentLiftComponentPartial;  
 };

--- a/src/astro/orbit_determination/acceleration_partials/aerodynamicAccelerationPartial.cpp
+++ b/src/astro/orbit_determination/acceleration_partials/aerodynamicAccelerationPartial.cpp
@@ -16,6 +16,36 @@ namespace tudat
 namespace acceleration_partials
 {
 
+void computeAerodynamicAccelerationWrtDragComponent(
+    const std::shared_ptr< aerodynamics::AerodynamicAcceleration > accelerationModel, 
+    Eigen::MatrixXd& partial )
+{
+    Eigen::Vector3d currentDragComponentPartial = Eigen::Vector3d::Zero( );
+    Eigen::Vector3d unscaledAcceleration = accelerationModel->getCurrentUnscaledAcceleration( );
+    currentDragComponentPartial( 0 ) = unscaledAcceleration( 0 );
+    partial = currentDragComponentPartial;
+};
+
+void computeAerodynamicAccelerationWrtSideComponent(
+    const std::shared_ptr< aerodynamics::AerodynamicAcceleration > accelerationModel, 
+    Eigen::MatrixXd& partial )
+{
+    Eigen::Vector3d currentSideComponentPartial = Eigen::Vector3d::Zero( );
+    Eigen::Vector3d unscaledAcceleration = accelerationModel->getCurrentUnscaledAcceleration( );
+    currentSideComponentPartial( 1 ) = unscaledAcceleration( 1 );
+    partial = currentSideComponentPartial;
+};
+
+void computeAerodynamicAccelerationWrtLiftComponent(
+    const std::shared_ptr< aerodynamics::AerodynamicAcceleration > accelerationModel, 
+    Eigen::MatrixXd& partial )
+{
+    Eigen::Vector3d currentLiftComponentPartial = Eigen::Vector3d::Zero( );
+    Eigen::Vector3d unscaledAcceleration = accelerationModel->getCurrentUnscaledAcceleration( );
+    currentLiftComponentPartial( 2 ) = unscaledAcceleration( 2 );
+    partial = currentLiftComponentPartial;  
+};
+
 //! Function for updating partial w.r.t. the bodies' positions
 void AerodynamicAccelerationPartial::update( const double currentTime )
 {
@@ -68,6 +98,54 @@ void AerodynamicAccelerationPartial::update( const double currentTime )
     aerodynamicAcceleration_->updateMembers( currentTime );
 
     currentTime_ = currentTime;
+}
+
+std::pair< std::function< void( Eigen::MatrixXd& ) >, int > AerodynamicAccelerationPartial::getParameterPartialFunction(
+            std::shared_ptr< estimatable_parameters::EstimatableParameter< double > > parameter )
+{
+    std::function< void( Eigen::MatrixXd& ) > partialFunction;
+    int numberOfColumns = 0;
+    if( parameter->getParameterName( ).second.first == acceleratedBody_ )
+    {
+        switch( parameter->getParameterName( ).first )
+        {
+            case estimatable_parameters::constant_drag_coefficient:
+            {
+                partialFunction = std::bind(
+                    &AerodynamicAccelerationPartial::computeAccelerationPartialWrtCurrentDragCoefficient, this, std::placeholders::_1 );
+                numberOfColumns = 1;
+                break;
+            }
+            case estimatable_parameters::drag_component_scaling_factor:
+            {
+                partialFunction = std::bind(
+                    &computeAerodynamicAccelerationWrtDragComponent, 
+                    AerodynamicAcceleration_, std::placeholders::_1 );
+                numberOfColumns = 1;
+                break;
+            }
+            case estimatable_parameters::side_component_scaling_factor:
+            {
+                partialFunction = std::bind(
+                    &computeAerodynamicAccelerationWrtSideComponent, 
+                    AerodynamicAcceleration_, std::placeholders::_1 );
+                numberOfColumns = 1;
+                break;
+            }
+            case estimatable_parameters::lift_component_scaling_factor:
+            {
+                partialFunction = std::bind(
+                    &computeAerodynamicAccelerationWrtLiftComponent, 
+                    AerodynamicAcceleration_, std::placeholders::_1 );
+                numberOfColumns = 1;
+                break;
+            }
+            default:
+                break;
+        }
+    }
+
+    return std::make_pair( partialFunction, numberOfColumns );
 }
 
 }  // namespace acceleration_partials

--- a/src/astro/orbit_determination/acceleration_partials/aerodynamicAccelerationPartial.cpp
+++ b/src/astro/orbit_determination/acceleration_partials/aerodynamicAccelerationPartial.cpp
@@ -16,34 +16,43 @@ namespace tudat
 namespace acceleration_partials
 {
 
-void computeAerodynamicAccelerationWrtDragComponent(
-    const std::shared_ptr< aerodynamics::AerodynamicAcceleration > accelerationModel, 
+void AerodynamicAccelerationPartial::computeAerodynamicAccelerationWrtDragComponent(
     Eigen::MatrixXd& partial )
 {
+    Eigen::Quaterniond rotationToInertialFrame =
+                flightConditions_->getAerodynamicAngleCalculator( )->getRotationQuaternionBetweenFrames(
+                        reference_frames::aerodynamic_frame, reference_frames::inertial_frame );
+
     Eigen::Vector3d currentDragComponentPartial = Eigen::Vector3d::Zero( );
-    Eigen::Vector3d unscaledAcceleration = accelerationModel->getCurrentUnscaledAcceleration( );
+    Eigen::Vector3d unscaledAcceleration = accelerationModel_->getCurrentUnscaledAcceleration( );
     currentDragComponentPartial( 0 ) = unscaledAcceleration( 0 );
-    partial = currentDragComponentPartial;
+    partial = rotationToInertialFrame * currentDragComponentPartial;
 };
 
-void computeAerodynamicAccelerationWrtSideComponent(
-    const std::shared_ptr< aerodynamics::AerodynamicAcceleration > accelerationModel, 
+void AerodynamicAccelerationPartial::computeAerodynamicAccelerationWrtSideComponent(
     Eigen::MatrixXd& partial )
 {
+    Eigen::Quaterniond rotationToInertialFrame =
+                flightConditions_->getAerodynamicAngleCalculator( )->getRotationQuaternionBetweenFrames(
+                        reference_frames::aerodynamic_frame, reference_frames::inertial_frame );
+
     Eigen::Vector3d currentSideComponentPartial = Eigen::Vector3d::Zero( );
-    Eigen::Vector3d unscaledAcceleration = accelerationModel->getCurrentUnscaledAcceleration( );
+    Eigen::Vector3d unscaledAcceleration = accelerationModel_->getCurrentUnscaledAcceleration( );
     currentSideComponentPartial( 1 ) = unscaledAcceleration( 1 );
-    partial = currentSideComponentPartial;
+    partial = rotationToInertialFrame * currentSideComponentPartial;
 };
 
-void computeAerodynamicAccelerationWrtLiftComponent(
-    const std::shared_ptr< aerodynamics::AerodynamicAcceleration > accelerationModel, 
+void AerodynamicAccelerationPartial::computeAerodynamicAccelerationWrtLiftComponent(
     Eigen::MatrixXd& partial )
 {
+    Eigen::Quaterniond rotationToInertialFrame =
+                flightConditions_->getAerodynamicAngleCalculator( )->getRotationQuaternionBetweenFrames(
+                        reference_frames::aerodynamic_frame, reference_frames::inertial_frame );
+
     Eigen::Vector3d currentLiftComponentPartial = Eigen::Vector3d::Zero( );
-    Eigen::Vector3d unscaledAcceleration = accelerationModel->getCurrentUnscaledAcceleration( );
+    Eigen::Vector3d unscaledAcceleration = accelerationModel_->getCurrentUnscaledAcceleration( );
     currentLiftComponentPartial( 2 ) = unscaledAcceleration( 2 );
-    partial = currentLiftComponentPartial;  
+    partial = rotationToInertialFrame * currentLiftComponentPartial;  
 };
 
 //! Function for updating partial w.r.t. the bodies' positions
@@ -119,24 +128,24 @@ std::pair< std::function< void( Eigen::MatrixXd& ) >, int > AerodynamicAccelerat
             case estimatable_parameters::drag_component_scaling_factor:
             {
                 partialFunction = std::bind(
-                    &computeAerodynamicAccelerationWrtDragComponent, 
-                    aerodynamicAcceleration_, std::placeholders::_1 );
+                    &AerodynamicAccelerationPartial::computeAerodynamicAccelerationWrtDragComponent, 
+                    this, std::placeholders::_1 );
                 numberOfColumns = 1;
                 break;
             }
             case estimatable_parameters::side_component_scaling_factor:
             {
                 partialFunction = std::bind(
-                    &computeAerodynamicAccelerationWrtSideComponent, 
-                    aerodynamicAcceleration_, std::placeholders::_1 );
+                    &AerodynamicAccelerationPartial::computeAerodynamicAccelerationWrtSideComponent, 
+                    this, std::placeholders::_1 );
                 numberOfColumns = 1;
                 break;
             }
             case estimatable_parameters::lift_component_scaling_factor:
             {
                 partialFunction = std::bind(
-                    &computeAerodynamicAccelerationWrtLiftComponent, 
-                    aerodynamicAcceleration_, std::placeholders::_1 );
+                    &AerodynamicAccelerationPartial::computeAerodynamicAccelerationWrtLiftComponent, 
+                    this, std::placeholders::_1 );
                 numberOfColumns = 1;
                 break;
             }

--- a/src/astro/orbit_determination/acceleration_partials/aerodynamicAccelerationPartial.cpp
+++ b/src/astro/orbit_determination/acceleration_partials/aerodynamicAccelerationPartial.cpp
@@ -120,7 +120,7 @@ std::pair< std::function< void( Eigen::MatrixXd& ) >, int > AerodynamicAccelerat
             {
                 partialFunction = std::bind(
                     &computeAerodynamicAccelerationWrtDragComponent, 
-                    AerodynamicAcceleration_, std::placeholders::_1 );
+                    aerodynamicAcceleration_, std::placeholders::_1 );
                 numberOfColumns = 1;
                 break;
             }
@@ -128,7 +128,7 @@ std::pair< std::function< void( Eigen::MatrixXd& ) >, int > AerodynamicAccelerat
             {
                 partialFunction = std::bind(
                     &computeAerodynamicAccelerationWrtSideComponent, 
-                    AerodynamicAcceleration_, std::placeholders::_1 );
+                    aerodynamicAcceleration_, std::placeholders::_1 );
                 numberOfColumns = 1;
                 break;
             }
@@ -136,7 +136,7 @@ std::pair< std::function< void( Eigen::MatrixXd& ) >, int > AerodynamicAccelerat
             {
                 partialFunction = std::bind(
                     &computeAerodynamicAccelerationWrtLiftComponent, 
-                    AerodynamicAcceleration_, std::placeholders::_1 );
+                    aerodynamicAcceleration_, std::placeholders::_1 );
                 numberOfColumns = 1;
                 break;
             }

--- a/src/astro/orbit_determination/acceleration_partials/aerodynamicAccelerationPartial.cpp
+++ b/src/astro/orbit_determination/acceleration_partials/aerodynamicAccelerationPartial.cpp
@@ -24,7 +24,7 @@ void AerodynamicAccelerationPartial::computeAerodynamicAccelerationWrtDragCompon
                         reference_frames::aerodynamic_frame, reference_frames::inertial_frame );
 
     Eigen::Vector3d currentDragComponentPartial = Eigen::Vector3d::Zero( );
-    Eigen::Vector3d unscaledAcceleration = aerodynamicAcceleration_->getCurrentUnscaledAcceleration( );
+    Eigen::Vector3d unscaledAcceleration = aerodynamicAcceleration_->getCurrentUnscaledAccelerationInAerodynamicFrame( );
     currentDragComponentPartial( 0 ) = unscaledAcceleration( 0 );
     partial = rotationToInertialFrame * currentDragComponentPartial;
 };
@@ -37,7 +37,7 @@ void AerodynamicAccelerationPartial::computeAerodynamicAccelerationWrtSideCompon
                         reference_frames::aerodynamic_frame, reference_frames::inertial_frame );
 
     Eigen::Vector3d currentSideComponentPartial = Eigen::Vector3d::Zero( );
-    Eigen::Vector3d unscaledAcceleration = aerodynamicAcceleration_->getCurrentUnscaledAcceleration( );
+    Eigen::Vector3d unscaledAcceleration = aerodynamicAcceleration_->getCurrentUnscaledAccelerationInAerodynamicFrame( );
     currentSideComponentPartial( 1 ) = unscaledAcceleration( 1 );
     partial = rotationToInertialFrame * currentSideComponentPartial;
 };
@@ -50,7 +50,7 @@ void AerodynamicAccelerationPartial::computeAerodynamicAccelerationWrtLiftCompon
                         reference_frames::aerodynamic_frame, reference_frames::inertial_frame );
 
     Eigen::Vector3d currentLiftComponentPartial = Eigen::Vector3d::Zero( );
-    Eigen::Vector3d unscaledAcceleration = aerodynamicAcceleration_->getCurrentUnscaledAcceleration( );
+    Eigen::Vector3d unscaledAcceleration = aerodynamicAcceleration_->getCurrentUnscaledAccelerationInAerodynamicFrame( );
     currentLiftComponentPartial( 2 ) = unscaledAcceleration( 2 );
     partial = rotationToInertialFrame * currentLiftComponentPartial;  
 };

--- a/src/astro/orbit_determination/estimatable_parameters/estimatableParameter.cpp
+++ b/src/astro/orbit_determination/estimatable_parameters/estimatableParameter.cpp
@@ -183,6 +183,15 @@ std::string getParameterTypeString( const EstimatebleParametersEnum parameterTyp
         case rotation_longitudinal_libration_terms:
             parameterDescription = "longitudinal libration terms ";
             break;
+        case drag_component_scaling_factor:
+            parameterDescription = "drag component scaling factor ";
+            break;
+        case side_component_scaling_factor:
+            parameterDescription = "side component scaling factor ";
+            break;
+        case lift_component_scaling_factor:
+            parameterDescription = "lift component scaling factor ";
+            break;
         default:
             std::string errorMessage =
                     "Error when getting parameter string, did not recognize parameter " + std::to_string( parameterType );
@@ -374,6 +383,15 @@ bool isDoubleParameter( const EstimatebleParametersEnum parameterType )
             break;
         case rotation_longitudinal_libration_terms:
             isDoubleParameter = false;
+            break;
+        case drag_component_scaling_factor:
+            isDoubleParameter = true;
+            break;
+        case side_component_scaling_factor:
+            isDoubleParameter = true;
+            break;
+        case lift_component_scaling_factor:
+            isDoubleParameter = true;
             break;
         default:
             throw std::runtime_error( "Error, parameter type " + std::to_string( parameterType ) +

--- a/src/simulation/estimation_setup/createCartesianStatePartials.cpp
+++ b/src/simulation/estimation_setup/createCartesianStatePartials.cpp
@@ -166,6 +166,12 @@ std::map< observation_models::LinkEndType, std::shared_ptr< CartesianStatePartia
                         break;
                     case estimatable_parameters::source_perpendicular_direction_radiation_pressure_scaling_factor:
                         break;
+                    case estimatable_parameters::drag_component_scaling_factor:
+                        break;
+                    case estimatable_parameters::side_component_scaling_factor:
+                        break;
+                    case estimatable_parameters::lift_component_scaling_factor:
+                        break;
                     default:
 
                         std::string errorMessage = "Parameter " + std::to_string( parameterToEstimate->getParameterName( ).first ) +

--- a/tests/src/astro/aerodynamics/unitTestAerodynamicMomentAndAerodynamicForce.cpp
+++ b/tests/src/astro/aerodynamics/unitTestAerodynamicMomentAndAerodynamicForce.cpp
@@ -278,68 +278,6 @@ BOOST_AUTO_TEST_CASE( testAerodynamicForceAndAcceleration )
         TUDAT_CHECK_MATRIX_CLOSE_FRACTION( expectedForce, force, tolerance );
     }
 
-    // Test 6: Test the acceleration model class with inverted coefficients.
-    {
-        // Set initial state
-        Eigen::Vector6d initialState = Eigen::Vector6d::Zero( );
-
-        initialState( 0 ) = 6.8E6;
-        initialState( 3 ) = airSpeed;
-
-        SystemOfBodies bodies = SystemOfBodies( "SSB", "ECLIPJ2000" );
-
-        bodies.createEmptyBody( "TreasurePlanet" );
-        std::shared_ptr< basic_astrodynamics::OblateSpheroidBodyShapeModel > oblateSpheroidModel =
-            std::make_shared< basic_astrodynamics::OblateSpheroidBodyShapeModel >( 6E6, 0.0 );
-        bodies.at( "TreasurePlanet" )->setShapeModel( oblateSpheroidModel );
-        bodies.at( "TreasurePlanet" )->setEphemeris( std::make_shared< ephemerides::ConstantEphemeris >( Eigen::Vector6d::Zero( ) ) );
-        bodies.createEmptyBody( "Legacy" );
-        bodies.at( "Legacy" )->setConstantBodyMass( mass );
-        bodies.at( "Legacy" )->setEphemeris( std::make_shared< ephemerides::ConstantEphemeris >( initialState ) );
-
-        std::shared_ptr< AerodynamicCoefficientSettings > aerodynamicCoefficientSettings =
-                std::make_shared< ConstantAerodynamicCoefficientSettings >(
-                        referenceArea, -forceCoefficients, negative_aerodynamic_frame_coefficients );
-        
-        // Set constant density and constant rotation models to TreasurePlanet
-        DensityFunction densityFunction = [=](double a, double b, double c, double d) { return density; };                
-        bodies.at( "TreasurePlanet" )->setAtmosphereModel( 
-                createAtmosphereModel( std::make_shared< simulation_setup::CustomConstantTemperatureAtmosphereSettings >( densityFunction, 300.0 ),
-                                       "TreasurePlanet" ) );
-        bodies.at( "TreasurePlanet" )
-                    ->setRotationalEphemeris( createRotationModel(
-                            constantRotationModelSettings( "ECLIPJ2000", "TreasurePlanetFixed", Eigen::Matrix3d::Identity( ) ),
-                            "TreasurePlanet",
-                            bodies ) );
-        // Create and set aerodynamic coefficients object
-        bodies.at( "Legacy" )
-                ->setAerodynamicCoefficientInterface(
-                        createAerodynamicCoefficientInterface( aerodynamicCoefficientSettings, "Legacy", bodies ) );
-        bodies.at( "Legacy" )
-                    ->setRotationalEphemeris( createRotationModel(
-                            constantRotationModelSettings( "ECLIPJ2000", "LegacyFixed", Eigen::Matrix3d::Identity( ) ),
-                            "Legacy",
-                            bodies ) );
-
-        std::shared_ptr< AtmosphericFlightConditions > bodyFlightConditions = createAtmosphericFlightConditions(
-                bodies.at( "Legacy" ), bodies.at( "TreasurePlanet" ), "Legacy", "TreasurePlanet" );
-        bodies.at( "Legacy" )->setFlightConditions( bodyFlightConditions );
-
-        AerodynamicAcceleration aerodynamicAcceleration( bodyFlightConditions, std::bind( &Body::getBodyMass, bodies.at( "Legacy" ) ) );
-        
-        //update environment
-        bodies.at( "TreasurePlanet" )->setCurrentRotationalStateToLocalFrameFromEphemeris( 0.0 );
-        bodies.at( "Legacy" )->setCurrentRotationalStateToLocalFrameFromEphemeris( 0.0 );
-        bodies.at( "TreasurePlanet" )->setState( Eigen::Vector6d::Zero( ) );
-        bodies.at( "Legacy" )->setState( initialState );
-        bodyFlightConditions->updateConditions( 0.0 );
-        aerodynamicAcceleration.updateMembers( );
-
-        Eigen::Vector3d force = aerodynamicAcceleration.getAcceleration( ) * mass;   
-        // Check if computed force matches expected.
-
-        TUDAT_CHECK_MATRIX_CLOSE_FRACTION( expectedForce, force, tolerance );
-    }
 }
 
 //! Test implementation of aerodynamic moment and rotational acceleration models.

--- a/tests/src/astro/aerodynamics/unitTestAerodynamicMomentAndAerodynamicForce.cpp
+++ b/tests/src/astro/aerodynamics/unitTestAerodynamicMomentAndAerodynamicForce.cpp
@@ -156,7 +156,6 @@ BOOST_AUTO_TEST_CASE( testAerodynamicForceAndAcceleration )
     }
     // Test 5: Test the acceleration model class without inverted coefficients.
     {
-        
         // Set initial state
         Eigen::Vector6d initialState = Eigen::Vector6d::Zero( );
 
@@ -177,6 +176,69 @@ BOOST_AUTO_TEST_CASE( testAerodynamicForceAndAcceleration )
         std::shared_ptr< AerodynamicCoefficientSettings > aerodynamicCoefficientSettings =
                 std::make_shared< ConstantAerodynamicCoefficientSettings >(
                         referenceArea, forceCoefficients, positive_aerodynamic_frame_coefficients );
+        
+        // Set constant density and constant rotation models to TreasurePlanet
+        DensityFunction densityFunction = [=](double a, double b, double c, double d) { return density; };                
+        bodies.at( "TreasurePlanet" )->setAtmosphereModel( 
+                createAtmosphereModel( std::make_shared< simulation_setup::CustomConstantTemperatureAtmosphereSettings >( densityFunction, 300.0 ),
+                                       "TreasurePlanet" ) );
+        bodies.at( "TreasurePlanet" )
+                    ->setRotationalEphemeris( createRotationModel(
+                            constantRotationModelSettings( "ECLIPJ2000", "TreasurePlanetFixed", Eigen::Matrix3d::Identity( ) ),
+                            "TreasurePlanet",
+                            bodies ) );
+        // Create and set aerodynamic coefficients object
+        bodies.at( "Legacy" )
+                ->setAerodynamicCoefficientInterface(
+                        createAerodynamicCoefficientInterface( aerodynamicCoefficientSettings, "Legacy", bodies ) );
+        bodies.at( "Legacy" )
+                    ->setRotationalEphemeris( createRotationModel(
+                            constantRotationModelSettings( "ECLIPJ2000", "LegacyFixed", Eigen::Matrix3d::Identity( ) ),
+                            "Legacy",
+                            bodies ) );
+
+        std::shared_ptr< AtmosphericFlightConditions > bodyFlightConditions = createAtmosphericFlightConditions(
+                bodies.at( "Legacy" ), bodies.at( "TreasurePlanet" ), "Legacy", "TreasurePlanet" );
+        bodies.at( "Legacy" )->setFlightConditions( bodyFlightConditions );
+
+        AerodynamicAcceleration aerodynamicAcceleration( bodyFlightConditions, std::bind( &Body::getBodyMass, bodies.at( "Legacy" ) ) );
+        
+        //update environment
+        bodies.at( "TreasurePlanet" )->setCurrentRotationalStateToLocalFrameFromEphemeris( 0.0 );
+        bodies.at( "Legacy" )->setCurrentRotationalStateToLocalFrameFromEphemeris( 0.0 );
+        bodies.at( "TreasurePlanet" )->setState( Eigen::Vector6d::Zero( ) );
+        bodies.at( "Legacy" )->setState( initialState );
+        bodyFlightConditions->updateConditions( 0.0 );
+        aerodynamicAcceleration.updateMembers( );
+
+        Eigen::Vector3d force = aerodynamicAcceleration.getAcceleration( ) * mass;   
+        // Check if computed force matches expected.
+
+        TUDAT_CHECK_MATRIX_CLOSE_FRACTION( expectedForce, force, tolerance );
+    }
+
+    // Test 6: Test the acceleration model class with inverted coefficients.
+    {
+        // Set initial state
+        Eigen::Vector6d initialState = Eigen::Vector6d::Zero( );
+
+        initialState( 0 ) = 6.8E6;
+        initialState( 3 ) = airSpeed;
+
+        SystemOfBodies bodies = SystemOfBodies( "SSB", "ECLIPJ2000" );
+
+        bodies.createEmptyBody( "TreasurePlanet" );
+        std::shared_ptr< basic_astrodynamics::OblateSpheroidBodyShapeModel > oblateSpheroidModel =
+            std::make_shared< basic_astrodynamics::OblateSpheroidBodyShapeModel >( 6E6, 0.0 );
+        bodies.at( "TreasurePlanet" )->setShapeModel( oblateSpheroidModel );
+        bodies.at( "TreasurePlanet" )->setEphemeris( std::make_shared< ephemerides::ConstantEphemeris >( Eigen::Vector6d::Zero( ) ) );
+        bodies.createEmptyBody( "Legacy" );
+        bodies.at( "Legacy" )->setConstantBodyMass( mass );
+        bodies.at( "Legacy" )->setEphemeris( std::make_shared< ephemerides::ConstantEphemeris >( initialState ) );
+
+        std::shared_ptr< AerodynamicCoefficientSettings > aerodynamicCoefficientSettings =
+                std::make_shared< ConstantAerodynamicCoefficientSettings >(
+                        referenceArea, -forceCoefficients, negative_aerodynamic_frame_coefficients );
         
         // Set constant density and constant rotation models to TreasurePlanet
         DensityFunction densityFunction = [=](double a, double b, double c, double d) { return density; };                
@@ -1186,7 +1248,7 @@ BOOST_AUTO_TEST_CASE( test_panelled_coefficients )
                                 newtonModel.setIncomingDirection( incomingDirection );
                                 forceCoefficients = newtonModel.computeAerodynamicCoefficients( );
                                 
-                                panelNormal = panelNormal = localFrameSurfaceNormal( );
+                                panelNormal = localFrameSurfaceNormal( );
                                 cosineDelta = panelNormal.dot( -incomingDirection );
                                 cosineDelta = cosineDelta > 0 ? cosineDelta : 0.0;
                                 Cp = 2 * cosineDelta * cosineDelta;
@@ -1319,6 +1381,158 @@ BOOST_AUTO_TEST_CASE( test_panelled_coefficients )
                                         BOOST_CHECK_SMALL( std::fabs( forceCoefficients( k ) - actualForceCoefficients( k ) ), tolerance );
                                 }
                         } 
+                }
+        }
+}
+
+BOOST_AUTO_TEST_CASE( test_panelled_coefficients_propagation )
+{  
+        const double tolerance = std::numeric_limits< double >::epsilon( );
+
+        SystemOfBodies bodies = SystemOfBodies( "SSB", "ECLIPJ2000" );
+        std::vector< std::string > centralBodies = { "TreasurePlanet" };
+        std::vector< std::string > bodiesToPropagate = { "Legacy" };
+
+        // create central body
+        bodies.createEmptyBody( "TreasurePlanet" );
+        std::shared_ptr< basic_astrodynamics::OblateSpheroidBodyShapeModel > oblateSpheroidModel =
+            std::make_shared< basic_astrodynamics::OblateSpheroidBodyShapeModel >( 6E6, 0.0 );
+        bodies.at( "TreasurePlanet" )->setShapeModel( oblateSpheroidModel );
+        bodies.at( "TreasurePlanet" )->setEphemeris( std::make_shared< ephemerides::ConstantEphemeris >( Eigen::Vector6d::Zero( ) ) );
+        const double density = 3.5e-5;
+        bodies.at( "TreasurePlanet" )
+                    ->setRotationalEphemeris( createRotationModel(
+                            constantRotationModelSettings( "ECLIPJ2000", "TreasurePlanetFixed", Eigen::Matrix3d::Identity( ) ),
+                            "TreasurePlanet",
+                            bodies ) );
+        DensityFunction densityFunction = [=](double a, double b, double c, double d) { return density; };                
+        bodies.at( "TreasurePlanet" )->setAtmosphereModel( 
+                createAtmosphereModel( std::make_shared< simulation_setup::CustomConstantTemperatureAtmosphereSettings >( densityFunction, 300.0 ),
+                                       "TreasurePlanet" ) );
+        double gravitationalParameter = 4e14;
+        bodies.at( "TreasurePlanet" )->setGravityFieldModel( std::make_shared< gravitation::GravityFieldModel >( gravitationalParameter ) );
+
+        // create spacecraft
+        Eigen::Vector6d systemInitialState = Eigen::Vector6d::Zero( );
+        systemInitialState( 0 ) = 6.8E6;
+        systemInitialState( 4 ) = 7.5E3;
+
+        double referenceArea = 1.0;
+        bodies.createEmptyBody( "Legacy" );
+        bodies.at( "Legacy" )->setConstantBodyMass( 1000 );
+        bodies.at( "Legacy" )->setEphemeris( std::make_shared< ephemerides::ConstantEphemeris >( systemInitialState ) );
+        bodies.at( "Legacy" )
+                    ->setRotationalEphemeris( createRotationModel(
+                            std::make_shared< SynchronousRotationModelSettings >( "TreasurePlanet", "ECLIPJ2000", "" ),
+                            "Legacy",
+                            bodies ) );
+
+        // add panel (always perpendicular to relative velocity vector)
+        std::function< Eigen::Vector3d( ) > localFrameSurfaceNormal = [ = ]( ){ 
+            Eigen::Vector3d normal( 0.0, 1.0, 0.0); 
+            return normal; };
+        std::function< Eigen::Vector3d( ) > localFramePositionVector = [ = ]( ){ 
+            Eigen::Vector3d position( 0.0, 0.0, 0.0); 
+            return position; };
+        Eigen::Vector3d frameOrigin( 0.0, 0.0, 0.0 );
+        Eigen::Vector3d vertexA( 0.0, 0.0, 0.0 );
+        Eigen::Vector3d vertexB( 1.0, 0.0, 0.0 );
+        Eigen::Vector3d vertexC( 0.0, 0.0, 1.0 );
+        Triangle3d triangle3d( vertexA, vertexB, vertexC );
+
+        std::shared_ptr< system_models::VehicleExteriorPanel > exteriorPanel = std::make_shared< system_models::VehicleExteriorPanel >(
+            localFrameSurfaceNormal, localFramePositionVector, 0.5, 500.0, "", nullptr,
+            triangle3d, frameOrigin, true );
+        
+        exteriorPanel->setEnergyAccomodationCoefficient( 1.0 );
+        exteriorPanel->setNormalAccomodationCoefficient( 1.0 );
+        exteriorPanel->setTangentialAccomodationCoefficient( 1.0 );
+        exteriorPanel->setNormalVelocityAtWallRatio( 1.0 );
+        
+        std::vector< std::shared_ptr< system_models::VehicleExteriorPanel > > allPanels = { exteriorPanel };
+        std::map< std::string, std::vector< std::shared_ptr< VehicleExteriorPanel > > > vehicleExteriorPanelsMap;
+        vehicleExteriorPanelsMap[ "" ] = allPanels;
+
+        // add vehicle system
+        std::shared_ptr< system_models::VehicleSystems > vehicleSystem = std::make_shared< system_models::VehicleSystems>( 1000 );
+        vehicleSystem->setVehicleExteriorPanels( vehicleExteriorPanelsMap );
+        bodies.at( "Legacy" )->setVehicleSystems( vehicleSystem );
+
+        // create aerodynamic coefficient interface
+        std::shared_ptr< AerodynamicCoefficientSettings > aerodynamicCoefficientSettings =
+                std::make_shared< PanelledAerodynamicCoefficientSettings >(
+                        aerodynamics::newton, 
+                        referenceArea, 
+                        0,
+                        false,
+                        body_fixed_frame_coefficients );
+        bodies.at( "Legacy" )
+                ->setAerodynamicCoefficientInterface(
+                        createAerodynamicCoefficientInterface( aerodynamicCoefficientSettings, "Legacy", bodies ) );
+
+        // acceleration map
+        SelectedAccelerationMap accelerationMap;
+
+        std::map< std::string, std::vector< std::shared_ptr< AccelerationSettings > > > accelerationsOfLegacy;
+        accelerationsOfLegacy[ "TreasurePlanet" ].push_back( std::make_shared< AccelerationSettings >( point_mass_gravity ) );
+        accelerationsOfLegacy[ "TreasurePlanet" ].push_back( std::make_shared< AccelerationSettings >( aerodynamic ) );
+        accelerationMap[ "Legacy" ] = accelerationsOfLegacy;
+
+        // dependent variables
+        std::vector< std::shared_ptr< SingleDependentVariableSaveSettings > > dependentVariables;
+        dependentVariables.push_back(
+                std::make_shared< SingleDependentVariableSaveSettings >( body_fixed_airspeed_based_velocity_variable, "Legacy" ) );
+        dependentVariables.push_back(
+                std::make_shared< SingleDependentVariableSaveSettings >( aerodynamic_coefficients, "Legacy", "TreasurePlanet" ) );
+
+        // create acceleration models and propagation settings.
+        basic_astrodynamics::AccelerationMap accelerationModelMap =
+                createAccelerationModelsMap( bodies, accelerationMap, bodiesToPropagate, centralBodies );
+        
+        // integrator settings
+        const double simulationStartEpoch = 0.0;
+        const double fixedStepSize = 10.0;
+        const double simulationEndEpoch = 100.0;
+
+        std::shared_ptr< IntegratorSettings<> > integratorSettings =
+                std::make_shared< IntegratorSettings<> >( rungeKutta4, simulationStartEpoch, fixedStepSize );
+
+        auto terminationSettings = std::make_shared< propagators::PropagationTimeTerminationSettings >( simulationEndEpoch );
+        std::shared_ptr< TranslationalStatePropagatorSettings< double > > translationalPropagatorSettings =
+                std::make_shared< TranslationalStatePropagatorSettings< double > >( centralBodies,
+                                                                                    accelerationModelMap,
+                                                                                    bodiesToPropagate,
+                                                                                    systemInitialState,
+                                                                                    simulationStartEpoch,
+                                                                                    integratorSettings,
+                                                                                    terminationSettings,
+                                                                                    cowell,
+                                                                                    dependentVariables );
+        // create simulation object and propagate dynamics
+        SingleArcDynamicsSimulator<> dynamicsSimulator( bodies, translationalPropagatorSettings );
+
+        std::map< double, Eigen::Matrix< double, Eigen::Dynamic, 1 > > dependentVariableOutput =
+                dynamicsSimulator.getDependentVariableHistory( );
+
+        // check dependent variables (aerodynamic coefficients)
+        Eigen::Vector3d incomingDirection, bodyFixedAirspeed, aerodynamicCoefficients, actualAerodynamicCoefficients, panelNormal;
+        double cosineDelta, Cp;
+        for( auto it: dependentVariableOutput )
+        {
+                bodyFixedAirspeed = it.second.segment( 0, 3 );
+                aerodynamicCoefficients = it.second.segment( 3, 3 );
+
+                // newton
+                incomingDirection = bodyFixedAirspeed.normalized( );
+                panelNormal = localFrameSurfaceNormal( );
+                cosineDelta = panelNormal.dot( -incomingDirection );
+                cosineDelta = cosineDelta > 0 ? cosineDelta : 0.0;
+                Cp = 2 * cosineDelta * cosineDelta;
+                actualAerodynamicCoefficients = -Cp * panelNormal * 0.5 / referenceArea;
+
+                for( int k=0; k<3; k++ )
+                {
+                        BOOST_CHECK_SMALL( std::fabs( aerodynamicCoefficients( k ) - actualAerodynamicCoefficients( k ) ), tolerance );
                 }
         }
 }

--- a/tests/src/astro/aerodynamics/unitTestWindModel.cpp
+++ b/tests/src/astro/aerodynamics/unitTestWindModel.cpp
@@ -226,11 +226,11 @@ BOOST_AUTO_TEST_CASE( testWindModelInPropagation )
                 // Test aerodynamic acceleration unit vector
                 BOOST_CHECK_SMALL( std::fabs( airSpeedVelocityUnitVectorInInertialFrame.normalized( )( i ) +
                                               aerodynamicAcceleration.normalized( )( i ) ),
-                                   10.0 * std::numeric_limits< double >::epsilon( ) );
+                                   15.0 * std::numeric_limits< double >::epsilon( ) );
 
                 // Test aerodynamic acceleration
                 BOOST_CHECK_SMALL( std::fabs( aerodynamicAcceleration( i ) - expectedAerodynamicAcceleration( i ) ),
-                                   aerodynamicAcceleration.norm( ) * 10.0 * std::numeric_limits< double >::epsilon( ) );
+                                   aerodynamicAcceleration.norm( ) * 15.0 * std::numeric_limits< double >::epsilon( ) );
             }
 
             // Test airspeed

--- a/tests/src/astro/orbit_determination/CMakeLists.txt
+++ b/tests/src/astro/orbit_determination/CMakeLists.txt
@@ -167,4 +167,9 @@ TUDAT_ADD_TEST_CASE(CovariancePropagation
 
 endif( )
 
+TUDAT_ADD_TEST_CASE(EstimationDragScaling
+         PRIVATE_LINKS
+         ${Tudat_ESTIMATION_LIBRARIES}
+         )
+
 

--- a/tests/src/astro/orbit_determination/unitTestArcwiseEnvironmentParameters.cpp
+++ b/tests/src/astro/orbit_determination/unitTestArcwiseEnvironmentParameters.cpp
@@ -295,7 +295,7 @@ BOOST_AUTO_TEST_CASE( test_ArcwiseEnvironmentParameters )
     {
         BOOST_CHECK_SMALL( std::fabs( parameterEstimate( i ) ), 1.0E-2 );
         BOOST_CHECK_SMALL( std::fabs( parameterEstimate( i + 3 ) ), 1.0E-4 );
-        BOOST_CHECK_SMALL( std::fabs( parameterEstimate( i + 6 ) ), 1.0E-5 );
+        BOOST_CHECK_SMALL( std::fabs( parameterEstimate( i + 6 ) ), 1.1E-5 );
         BOOST_CHECK_SMALL( std::fabs( parameterEstimate( i + 9 ) ), 1.0E-4 );
     }
 }

--- a/tests/src/astro/orbit_determination/unitTestEstimationDragScaling.cpp
+++ b/tests/src/astro/orbit_determination/unitTestEstimationDragScaling.cpp
@@ -149,9 +149,7 @@ BOOST_AUTO_TEST_CASE( test_EstimationDragScaling )
         residuals.push_back( estimationOutput->residualStandardDeviation_ );
 
     }
-    std::cout<<residuals.at( 0 )<<std::endl;
-    std::cout<<residuals.at( 1 )<<std::endl;
-    BOOST_CHECK( std::abs( residuals.at( 0 ) - residuals.at( 1 ) ) < 1e-10 );
+    BOOST_CHECK( std::abs( residuals.at( 0 ) - residuals.at( 1 ) ) < 1e-8 );
 
 }
 BOOST_AUTO_TEST_SUITE_END( )

--- a/tests/src/astro/orbit_determination/unitTestEstimationDragScaling.cpp
+++ b/tests/src/astro/orbit_determination/unitTestEstimationDragScaling.cpp
@@ -1,0 +1,161 @@
+/*    Copyright (c) 2010-2019, Delft University of Technology
+ *    All rigths reserved
+ *
+ *    This file is part of the Tudat. Redistribution and use in source and
+ *    binary forms, with or without modification, are permitted exclusively
+ *    under the terms of the Modified BSD license. You should have received
+ *    a copy of the license with this file. If not, please or visit:
+ *    http://tudat.tudelft.nl/LICENSE.
+ */
+
+#define BOOST_TEST_DYN_LINK
+#define BOOST_TEST_MAIN
+
+#include <iostream>
+#include <ctime>
+
+#include <boost/format.hpp>
+#include <boost/test/unit_test.hpp>
+
+#include "tudat/simulation/estimation_setup/fitOrbitToEphemeris.h"
+#include "tudat/simulation/estimation_setup/orbitDeterminationManager.h"
+#include "tudat/simulation/estimation_setup/observationSimulationSettings.h"
+#include "tudat/simulation/estimation_setup/simulateObservations.h"
+
+namespace tudat
+{
+namespace unit_tests
+{
+
+using namespace tudat;
+using namespace tudat::observation_models;
+using namespace tudat::orbit_determination;
+using namespace tudat::estimatable_parameters;
+using namespace tudat::simulation_setup;
+using namespace tudat::basic_astrodynamics;
+using namespace tudat::propagators;
+
+BOOST_AUTO_TEST_SUITE( test_estimation_drag_scaling )
+
+BOOST_AUTO_TEST_CASE( test_EstimationDragScaling )
+{
+    
+    std::vector< double > residuals;
+    
+    for( unsigned int i = 0; i < 2; i++ )
+    {
+        spice_interface::loadStandardSpiceKernels( );
+
+        spice_interface::loadSpiceKernelInTudat( paths::getTudatTestDataPath( ) +
+                                                 "/dsn_n_way_doppler_observation_model/mgs_map1_ipng_mgs95j.bsp" );
+
+        double initialTime = DateTime( 1999, 3, 10, 0, 0, 0.0 ).epoch< double >( );
+        double finalTime = initialTime + 3600 * 6;
+
+        std::vector< std::string > bodyNames;
+        bodyNames.push_back( "Mars" );
+
+        BodyListSettings bodySettings = getDefaultBodySettings( bodyNames, "Mars" );
+        bodySettings.addSettings( "MGS" );
+        bodySettings.at( "MGS" )->ephemerisSettings =
+            std::make_shared< InterpolatedSpiceEphemerisSettings >( initialTime - 3600.0, finalTime + 3600.0, 30.0, "Mars" );
+
+        // Create bodies needed in simulation
+        SystemOfBodies bodies = createSystemOfBodies( bodySettings );
+        bodies.at( "Mars" )->setAtmosphereModel( 
+                createAtmosphereModel( std::make_shared< ExponentialAtmosphereSettings >( aerodynamics::mars ),
+                                       "Mars" ) );
+        bodies.at( "MGS" )->setConstantBodyMass( 2.0 );
+
+        Eigen::Vector3d forceCoefficients( 1.0, 0.0, 0.0 );
+
+        std::shared_ptr< AerodynamicCoefficientSettings > aerodynamicCoefficientSettings =
+                std::make_shared< ConstantAerodynamicCoefficientSettings >(
+                        2000.0, forceCoefficients, aerodynamics::negative_aerodynamic_frame_coefficients );
+        bodies.at( "MGS" )
+                ->setAerodynamicCoefficientInterface(
+                        createAerodynamicCoefficientInterface( aerodynamicCoefficientSettings, "MGS", bodies ) );
+
+        // Set accelerations between bodies that are to be taken into account.
+        SelectedAccelerationMap accelerationMap;
+        std::map< std::string, std::vector< std::shared_ptr< AccelerationSettings > > > accelerationsOfSpacecraft;
+        accelerationsOfSpacecraft[ "Mars" ].push_back( std::make_shared< AccelerationSettings >( aerodynamic ) );
+        accelerationsOfSpacecraft[ "Mars" ].push_back( std::make_shared< AccelerationSettings >( point_mass_gravity ) );
+
+        accelerationMap[ "MGS" ] = accelerationsOfSpacecraft;
+
+        // Set bodies for which initial state is to be estimated and integrated.
+        std::vector< std::string > bodiesToEstimate = { "MGS" };
+        std::vector< std::string > centralBodies = { "Mars" };
+
+        AccelerationMap accelerationModelMap = createAccelerationModelsMap( bodies, accelerationMap, bodiesToEstimate, centralBodies );
+
+        std::vector< std::shared_ptr< estimatable_parameters::EstimatableParameterSettings > > additionalParameterNames;
+
+        if( i == 0 )
+        {
+            additionalParameterNames.push_back( estimatable_parameters::constantDragCoefficient( "MGS" ) );
+        }
+        else
+        {
+            additionalParameterNames.push_back( estimatable_parameters::dragComponentScaling( "MGS" ) );
+            //additionalParameterNames.push_back( estimatable_parameters::constantDragCoefficient( "MGS" ) );
+        }
+
+        Eigen::Matrix< double, Eigen::Dynamic, 1 > initialState =
+            getInitialStatesOfBodies( bodiesToEstimate, centralBodies, bodies, initialTime );
+
+        std::shared_ptr< TranslationalStatePropagatorSettings< double > > propagatorSettings =
+                std::make_shared< TranslationalStatePropagatorSettings< double > >(
+                        centralBodies,
+                        accelerationModelMap,
+                        bodiesToEstimate,
+                        initialState,
+                        initialTime,
+                        numerical_integrators::rungeKuttaFixedStepSettings( 120.0, numerical_integrators::rungeKuttaFehlberg78 ),
+                        std::make_shared< PropagationTimeTerminationSettings >( finalTime ) );
+
+        std::vector< std::shared_ptr< EstimatableParameterSettings > > parameterNames =
+                getInitialStateParameterSettings( 
+                    std::dynamic_pointer_cast< PropagatorSettings< double > >( propagatorSettings ),
+                    bodies );
+        parameterNames.insert( parameterNames.end( ), additionalParameterNames.begin( ), additionalParameterNames.end( ) );
+
+        std::shared_ptr< estimatable_parameters::EstimatableParameterSet< double > > parametersToEstimate =
+                createParametersToEstimate( parameterNames, bodies, std::dynamic_pointer_cast< PropagatorSettings< double > >( propagatorSettings ) );
+        printEstimatableParameterEntries( parametersToEstimate );
+
+        std::pair< std::vector< std::shared_ptr< observation_models::ObservationModelSettings > >,
+                   std::shared_ptr< observation_models::ObservationCollection< double > > >
+                observationCollectionAndModelSettings = simulatePseudoObservations(
+                        bodies, bodiesToEstimate, centralBodies, initialTime, finalTime, 120.0 );
+        std::shared_ptr< observation_models::ObservationCollection< double > > observationCollection =
+                observationCollectionAndModelSettings.second;
+
+        std::vector< std::shared_ptr< observation_models::ObservationModelSettings > > observationModelSettingsList =
+                observationCollectionAndModelSettings.first;
+
+        OrbitDeterminationManager< double > orbitDeterminationManager =
+                OrbitDeterminationManager< double >(
+                        bodies, parametersToEstimate, observationModelSettingsList, std::dynamic_pointer_cast< PropagatorSettings< double > >( propagatorSettings ) );
+
+        std::shared_ptr< EstimationInput< double > > estimationInput =
+                std::make_shared< EstimationInput< double > >( observationCollection );
+        //estimationInput->setConvergenceChecker( std::make_shared< EstimationConvergenceChecker >( 1 ) );
+        estimationInput->defineEstimationSettings( 0, 1, 0, 1, 1, 1 );
+
+        std::shared_ptr< EstimationOutput<> > estimationOutput = orbitDeterminationManager.estimateParameters( estimationInput );
+
+        residuals.push_back( estimationOutput->residualStandardDeviation_ );
+
+    }
+    std::cout<<residuals.at( 0 )<<std::endl;
+    std::cout<<residuals.at( 1 )<<std::endl;
+    BOOST_CHECK( std::abs( residuals.at( 0 ) - residuals.at( 1 ) ) < 1e-10 );
+
+}
+BOOST_AUTO_TEST_SUITE_END( )
+
+}  // namespace unit_tests
+
+}  // namespace tudat

--- a/tests/src/astro/propulsion/unitTestThrustAcceleration.cpp
+++ b/tests/src/astro/propulsion/unitTestThrustAcceleration.cpp
@@ -1082,7 +1082,7 @@ BOOST_AUTO_TEST_CASE( testConcurrentThrustAndAerodynamicAcceleration )
 
                 BOOST_CHECK_SMALL(
                         std::fabs( expectedAerodynamicAcceleration( i ) - currentAerodynamicAcceleration( i ) ),
-                        std::max( 10.0 * currentAerodynamicAcceleration.norm( ), 1.0 ) * std::numeric_limits< double >::epsilon( ) );
+                        std::max( 20.0 * currentAerodynamicAcceleration.norm( ), 1.0 ) * std::numeric_limits< double >::epsilon( ) );
             }
         }
     }

--- a/tests/src/astro/system_models/unitTestSelfShadowing.cpp
+++ b/tests/src/astro/system_models/unitTestSelfShadowing.cpp
@@ -1,4 +1,13 @@
-
+/*    Copyright (c) 2010-2019, Delft University of Technology
+ *    All rigths reserved
+ *
+ *    This file is part of the Tudat. Redistribution and use in source and
+ *    binary forms, with or without modification, are permitted exclusively
+ *    under the terms of the Modified BSD license. You should have received
+ *    a copy of the license with this file. If not, please or visit:
+ *    http://tudat.tudelft.nl/LICENSE.
+ */
+ 
 #define BOOST_TEST_DYN_LINK
 #define BOOST_TEST_MAIN
 


### PR DESCRIPTION
This PR introduces aerodynamic scaling coefficients to be used in the estimation process.

It is based on the yet-to-be-merged PR #335, as it requires the new implementation of the `AerodynamicAcceleration` class. 

The structure is similar to the scaling on `RadiationPressureAcceleration` (source direction and perpendicular direction).

This implementation has been tested, and the former `constant_drag_coefficient` yields the same results as `drag_component_scaling`, suggesting the correctness of the implementation. 

### TODO

- [x] Expand unit test for partials.