### PR TITLE
Enable unity build for all targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -483,6 +483,22 @@ install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME_LOWER}-config-version.
 # ========
 message(STATUS "TUDAT_DATA_DIR_RELATIVE_TO_INSTALL_PREFIX: ${TUDAT_DATA_DIR_RELATIVE_TO_INSTALL_PREFIX}")
 
+# ===========
+# Unity Build
+# ===========
+
+# Function to enable Unity Builds for a target
+function(enable_unity_builds target)
+    set_property(TARGET ${target} PROPERTY UNITY_BUILD ON)
+    set_property(TARGET ${target} PROPERTY UNITY_BUILD_BATCH_SIZE 8)
+endfunction()
+
+# Enable Unity Builds for all targets
+get_property(targets GLOBAL PROPERTY TARGETS)
+foreach(target IN LISTS targets)
+    enable_unity_builds(${target})
+endforeach()
+
 # +============================================================================
 # CLEAN UP (Project name independent)
 #  Cleanup in case project is not top level.


### PR DESCRIPTION
I got about 5% speedup[^1] with the build.

I think this could be done more methodically to get a more significant speedup.  We could look at the notes on CMake's docs page for unity builds for guidance (comments under ODR errors):
https://cmake.org/cmake/help/latest/prop_tgt/UNITY_BUILD.html

Thoughts?

**PS:** I noticed build steps around 500-650 remain the slowest, I think that was mostly targets in `astro`.

[^1]: my measurement was very approximate, built with `-j4` on a 6-core 12-thread system, while I was doing other things.